### PR TITLE
Create a hard-link within files when assigning a dataset.

### DIFF
--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -73,12 +73,15 @@ def _h5set(file, grp, key, value, path=None):
     # Guard against assigning a group to itself, e.g., `h5s[key] = h5s[key]`,
     # where h5s[key] is a mapping. This is necessary, because the original
     # mapping would be deleted prior to assignment.
-    if isinstance(value, H5Group) and key in grp:
-        if grp[key] == value._group:
-            return  # Groups are identical, do nothing.
-
-    # Delete any existing data
     if key in grp:
+        if isinstance(value, H5Group):
+            if grp[key] == value._group:
+                return  # Groups are identical, do nothing.
+        elif isinstance(value, h5py._hl.dataset.Dataset):
+            if grp == value.parent:
+                return  # Dataset is identical, do nothing.
+
+        # Delete any existing data
         del grp[key]
 
     # Mapping-types
@@ -101,7 +104,7 @@ def _h5set(file, grp, key, value, path=None):
 
     # h5py native types
     elif isinstance(value, h5py._hl.dataset.Dataset):
-        grp[key] = value[()]    # Create a copy, not a hard link!
+        grp[key] = value  # Creates hard-link!
 
     # Other types
     else:

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -326,12 +326,34 @@ class H5StoreTest(BaseH5StoreTest):
         with self.open_h5store() as h5s:
             with self.open_h5store() as same_h5s:
                 for k, v in self.valid_types.items():
+                    # First, store v under k
                     h5s[k] = v
                     self.assertEqual(h5s[k], v)
+
+                    # Assign the same value under the same key.
                     try:
                         same_h5s[k] = h5s[k]
                     except H5StoreClosedError:
                         pass
+                    self.assertEqual(h5s[k], v)
+                    self.assertEqual(same_h5s[k], v)
+                    self.assertEqual(h5s[k], same_h5s[k])
+
+                    # Assign the same value, under a different key.
+                    other_key = k + '-other'
+                    try:
+                        same_h5s[other_key] = h5s[k]
+                    except H5StoreClosedError:
+                        pass
+                    self.assertEqual(h5s[other_key], v)
+                    self.assertEqual(same_h5s[other_key], v)
+                    self.assertEqual(h5s[k], same_h5s[other_key])
+
+                    # Deleting the value assigned to the alternative key should have
+                    # no effect on the value stored under the original key, regardless
+                    # whether it was copied by reference (hard-link) or copied by
+                    # value (true copy).
+                    del same_h5s[other_key]
                     self.assertEqual(h5s[k], v)
                     self.assertEqual(same_h5s[k], v)
                     self.assertEqual(h5s[k], same_h5s[k])

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -342,7 +342,14 @@ class H5StoreTest(BaseH5StoreTest):
                 for k, v in self.valid_types.items():
                     h5s[k] = v
                     self.assertEqual(h5s[k], v)
-                    other_h5s[k] = h5s[k]
+                    try:
+                        other_h5s[k] = h5s[k]
+                    except RuntimeError as error:
+                        self.assertEqual(
+                            str(error),
+                            "Unable to create link (interfile hard links are not allowed)")
+                        self.assertTrue(isinstance(v, (array, numpy.ndarray)))
+                        other_h5s[k] = h5s[k][()]
                     self.assertEqual(h5s[k], v)
                     self.assertEqual(other_h5s[k], v)
                     self.assertEqual(h5s[k], other_h5s[k])


### PR DESCRIPTION
Instead of creating an automatic copy.

There are many good reasons for this change in behavior:

  1. Creating an automatic copy is the much more dangerous option,
  potentially leading to an unexpected copy of terra-bytes of data.
  2. Creating an automatic copy is not what a user familiar with h5py
  would expect to happen.
  3. Creating a hard-link is actually closer to the behavior of standard
  in-memory dicts, which would also create a reference instead of a copy
  when assigning the same array to multiple keys.
  4. With this behavior, the user still has the option to create a copy
  if desired, the reverse would not be immediately possible.

The only viable alternative behavior that I see is to not allow assigning
arrays at all, which I find much less appealing.