### PR TITLE
Feature/h5store multiprocessing

### DIFF
--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -400,7 +400,7 @@ class H5Store(MutableMapping):
         try:
             with _ensure_open(self, mode='r'):
                 return len(self._file)
-        except OSError as error:
+        except (OSError, IOError) as error:
             if 'errno = 2' in str(error):
                 return 0
             else:
@@ -410,7 +410,7 @@ class H5Store(MutableMapping):
         try:
             with _ensure_open(self, mode='r'):
                 return key in self._file
-        except OSError as error:
+        except (OSError, IOError) as error:
             if 'errno = 2' in str(error):
                 return False
             else:

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -4,6 +4,7 @@
 "Data store implementation with backend HDF5 file."
 import logging
 import os
+import errno
 import warnings
 import array
 from threading import RLock
@@ -401,8 +402,8 @@ class H5Store(MutableMapping):
             with _ensure_open(self, mode='r'):
                 return len(self._file)
         except (OSError, IOError) as error:
-            if 'errno = 2' in str(error):
-                return 0
+            if 'errno = {}'.format(errno.ENOENT) in str(error):
+                return 0     # file does not exist
             else:
                 raise
 
@@ -411,8 +412,8 @@ class H5Store(MutableMapping):
             with _ensure_open(self, mode='r'):
                 return key in self._file
         except (OSError, IOError) as error:
-            if 'errno = 2' in str(error):
-                return False
+            if 'errno = {}'.format(errno.ENOENT) in str(error):
+                return False     # file does not exist
             else:
                 raise
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -162,15 +162,16 @@ def _validate_key(key):
 
 class _ensure_open(object):
 
-    __slots__ = ['file', 'open']
+    __slots__ = ['file', 'open', 'kwargs']
 
-    def __init__(self, file):
+    def __init__(self, file, **kwargs):
         self.file = file
         self.open = False
+        self.kwargs = kwargs
 
     def __enter__(self):
         if self.file._file is None:
-            self.file.open()
+            self.file._open(** self.kwargs)
             self.open = True
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
@@ -306,18 +307,29 @@ class H5Store(MutableMapping):
     def __exit__(self, exception_type, exception_value, exception_traceback):
         self.close()
 
-    def open(self):
-        """Open the underlying HDF5-file."""
+    def _open(self, **kwargs):
         if self._file is not None:
             raise H5StoreAlreadyOpenError(self)
         import h5py
+
+        # We use the default file parameters, which can optionally be overriden
+        # by additional keyword arguments (kwargs). This option is intentionally
+        # not exposed to the public API.
+        parameters = dict(self._kwargs)
+        parameters['mode'] = self.mode
+        parameters.update(kwargs)
+
         self._thread_lock.acquire()
         try:
-            self._file = h5py.File(self._filename, mode=self._mode, **self._kwargs)
+            self._file = h5py.File(self._filename, **parameters)
         except:  # noqa We need to release under **all** circumstances upon error!
             self._thread_lock.release()
             raise
         return self
+
+    def open(self):
+        """Open the underlying HDF5-file."""
+        return self._open()
 
     def close(self):
         """Close the underlying HDF5-file."""
@@ -385,11 +397,11 @@ class H5Store(MutableMapping):
                 yield key
 
     def __len__(self):
-        with _ensure_open(self):
+        with _ensure_open(self, mode='r'):
             return len(self._file)
 
     def __contains__(self, key):
-        with _ensure_open(self):
+        with _ensure_open(self, mode='r'):
             return key in self._file
 
     def clear(self):

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -397,12 +397,24 @@ class H5Store(MutableMapping):
                 yield key
 
     def __len__(self):
-        with _ensure_open(self, mode='r'):
-            return len(self._file)
+        try:
+            with _ensure_open(self, mode='r'):
+                return len(self._file)
+        except OSError as error:
+            if 'errno = 2' in str(error):
+                return 0
+            else:
+                raise
 
     def __contains__(self, key):
-        with _ensure_open(self, mode='r'):
-            return key in self._file
+        try:
+            with _ensure_open(self, mode='r'):
+                return key in self._file
+        except OSError as error:
+            if 'errno = 2' in str(error):
+                return False
+            else:
+                raise
 
     def clear(self):
         """Remove all data from this store.

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -207,6 +207,18 @@ class H5StoreTest(BaseH5StoreTest):
             str(h5s)    # open
         str(h5s)    # closed
 
+    def test_len(self):
+        h5s = self.get_h5store()
+        self.assertEqual(len(h5s), 0)
+        h5s['test_len'] = True
+        self.assertEqual(len(h5s), 1)
+
+    def test_contains(self):
+        h5s = self.get_h5store()
+        self.assertNotIn('test_contains', h5s)
+        h5s['test_contains'] = True
+        self.assertIn('test_contains', h5s)
+
     def test_copy_value(self):
         with self.open_h5store() as h5s:
             key = 'copy_value'

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -642,9 +642,6 @@ def _read_from_h5store(filename, **kwargs):
         list(h5s)
 
 
-@unittest.skipIf(
-    six.PY2 or (six.PY3 and sys.version_info.minor < 4),
-    'tests only implemented for Python > 3.4')
 class H5StoreMultiProcessingTest(BaseH5StoreTest):
 
     def test_single_writer_multiple_reader_same_process(self):

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 import os
+import sys
 import unittest
 import random
 import string
@@ -628,6 +629,9 @@ def _read_from_h5store(filename, **kwargs):
         list(h5s)
 
 
+@unittest.skipIf(
+    six.PY2 or six.PY3 and sys.version_info.minor < 4,
+    'tests only implemented for Python > 3.4')
 class H5StoreMultiProcessingTest(BaseH5StoreTest):
 
     def test_single_writer_multiple_reader_same_process(self):

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -683,6 +683,7 @@ class H5StoreMultiProcessingTest(BaseH5StoreTest):
             print('\n', error.output.decode(), file=sys.stderr)
             raise
 
+    @unittest.skipIf(six.PY2, 'requires Python 3')
     def test_single_writer_multiple_reader_different_process_no_swmr(self):
 
         read_cmd = "python -c 'from signac.core.h5store import H5Store; "
@@ -693,6 +694,7 @@ class H5StoreMultiProcessingTest(BaseH5StoreTest):
             with self.assertRaises(subprocess.CalledProcessError):
                 subprocess.check_output(read_cmd, shell=True, stderr=subprocess.DEVNULL)
 
+    @unittest.skipIf(six.PY2, 'requires Python 3')
     @unittest.skipUnless(python_implementation() == 'CPython', 'SWMR mode not available.')
     def test_single_writer_multiple_reader_different_process_swmr(self):
 

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -211,8 +211,6 @@ class H5StoreTest(BaseH5StoreTest):
             key = 'copy_value'
             key2 = 'copy_value2'
             d = self.get_testdata()
-            self.assertNotIn(key, h5s)
-            self.assertNotIn(key2, h5s)
             h5s[key] = d
             self.assertIn(key, h5s)
             self.assertEqual(h5s[key], d)

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -696,6 +696,7 @@ class H5StoreMultiProcessingTest(BaseH5StoreTest):
             with self.assertRaises(subprocess.CalledProcessError):
                 subprocess.check_output(read_cmd, shell=True, stderr=subprocess.DEVNULL)
 
+    @unittest.skipUnless(python_implementation() == 'CPython', 'SWMR mode not available.')
     def test_single_writer_multiple_reader_different_process_swmr(self):
 
         read_cmd = "python -c 'from signac.core.h5store import H5Store; "


### PR DESCRIPTION
This patch adds unit tests for multi-processing environments.

Specifically I test how we can interact with one store by opening multiple writers and readers under varying conditions, for example within the same instance, across multiple processes, but within the same instance, and across different instances.

I also added a simple test how one could enable the SWMR mode manually, however there are too many caveats with this mode to make this any more official in my opinion, at least at this stage.

Finally, I enabled the option to internally override certain file parameters, such as the opening-mode, which allows us to execute specific functions in read-only mode, such as the `len` or the `in` checks.