### PR TITLE
Resolve issue #120 by allowing job methods to be chained.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Added
  - Add automatic cast of numpy arrays to lists when storing them within a `JSONDict`, e.g., a `job.statepoint` or `job.document`.
  - Enable `Collection` class to manage collections stored in gzip files.
  - Enable deleting of `JSONDict` keys through the attribute interface, e.g., `del job.doc.foo`.
+ - The `Job.init()` method returns the job to allow one-line job creation and initialization.
 
 Fixed
 +++++

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -347,12 +347,14 @@ class Job(object):
         Returns the calling job.
 
         :param force:
-                Overwrite any existing state point's manifest
-                files, e.g., to repair them when they got corrupted.
+            Overwrite any existing state point's manifest
+            files, e.g., to repair them when they got corrupted.
         :type force:
-                bool
-        :return: The job handle.
-        :rtype: :class:`~.Job`
+            bool
+        :return:
+            The job handle.
+        :rtype:
+            :class:`~.Job`
         """
         try:
             self._init(force=force)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -136,7 +136,7 @@ class Job(object):
         """
         dst = self._project.open_job(new_statepoint)
         if dst == self:
-            return self
+            return
         fn_manifest = os.path.join(self._wd, self.FN_MANIFEST)
         fn_manifest_backup = fn_manifest + '~'
         try:
@@ -167,7 +167,6 @@ class Job(object):
         self._data = None
         self._cwd = list()
         logger.info("Moved '{}' -> '{}'.".format(self, dst))
-        return self
 
     def _reset_sp(self, new_sp=None):
         if new_sp is None:
@@ -202,7 +201,7 @@ class Job(object):
                 if statepoint.get(key, value) != value:
                     raise KeyError(key)
         statepoint.update(update)
-        return self.reset_statepoint(statepoint)
+        self.reset_statepoint(statepoint)
 
     @property
     def statepoint(self):
@@ -345,11 +344,15 @@ class Job(object):
         This function will do nothing if the directory and
         the job manifest already exist.
 
+        Returns the calling job.
+
         :param force:
                 Overwrite any existing state point's manifest
                 files, e.g., to repair them when they got corrupted.
         :type force:
                 bool
+        :return: The job handle.
+        :rtype: :class:`~.Job`
         """
         try:
             self._init(force=force)
@@ -378,7 +381,6 @@ class Job(object):
         except (OSError, IOError) as error:
             if error.errno != errno.ENOENT:
                 raise error
-        return self
 
     def reset(self):
         """Remove all job data, but not the job itself.
@@ -387,7 +389,6 @@ class Job(object):
         initialized."""
         self.clear()
         self.init()
-        return self
 
     def remove(self):
         """Remove the job's workspace including the job document.
@@ -426,7 +427,6 @@ class Job(object):
         except OSError:
             raise DestinationExistsError(dst)
         self.__dict__.update(dst.__dict__)
-        return self
 
     def sync(self, other, strategy=None, exclude=None, doc_sync=None, **kwargs):
         """Perform a one-way synchronization of this job with the other job.
@@ -476,7 +476,6 @@ class Job(object):
             exclude=exclude,
             doc_sync=doc_sync,
             **kwargs)
-        return self
 
     def fn(self, filename):
         """Prepend a filename with the job's workspace directory path.

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -123,7 +123,7 @@ class Job(object):
 
         .. danger::
 
-            Use this function with caution! Resetting a job's state point,
+            Use this function with caution! Resetting a job's state point
             may sometimes be necessary, but can possibly lead to incoherent
             data spaces.
 
@@ -136,7 +136,7 @@ class Job(object):
         """
         dst = self._project.open_job(new_statepoint)
         if dst == self:
-            return
+            return self
         fn_manifest = os.path.join(self._wd, self.FN_MANIFEST)
         fn_manifest_backup = fn_manifest + '~'
         try:
@@ -167,6 +167,7 @@ class Job(object):
         self._data = None
         self._cwd = list()
         logger.info("Moved '{}' -> '{}'.".format(self, dst))
+        return self
 
     def _reset_sp(self, new_sp=None):
         if new_sp is None:
@@ -201,7 +202,7 @@ class Job(object):
                 if statepoint.get(key, value) != value:
                     raise KeyError(key)
         statepoint.update(update)
-        self.reset_statepoint(statepoint)
+        return self.reset_statepoint(statepoint)
 
     @property
     def statepoint(self):
@@ -356,6 +357,7 @@ class Job(object):
             logger.error(
                 "State point manifest file of job '{}' appears to be corrupted.".format(self._id))
             raise
+        return self
 
     def clear(self):
         """Remove all job data, but not the job itself.
@@ -376,6 +378,7 @@ class Job(object):
         except (OSError, IOError) as error:
             if error.errno != errno.ENOENT:
                 raise error
+        return self
 
     def reset(self):
         """Remove all job data, but not the job itself.
@@ -384,6 +387,7 @@ class Job(object):
         initialized."""
         self.clear()
         self.init()
+        return self
 
     def remove(self):
         """Remove the job's workspace including the job document.
@@ -422,6 +426,7 @@ class Job(object):
         except OSError:
             raise DestinationExistsError(dst)
         self.__dict__.update(dst.__dict__)
+        return self
 
     def sync(self, other, strategy=None, exclude=None, doc_sync=None, **kwargs):
         """Perform a one-way synchronization of this job with the other job.
@@ -471,6 +476,7 @@ class Job(object):
             exclude=exclude,
             doc_sync=doc_sync,
             **kwargs)
+        return self
 
     def fn(self, filename):
         """Prepend a filename with the job's workspace directory path.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -377,6 +377,15 @@ class JobOpenAndClosingTest(BaseJobTest):
         self.assertTrue(os.path.isdir(job.ws))
         self.assertTrue(os.path.exists(os.path.join(job.workspace(), job.FN_MANIFEST)))
 
+    def test_chained_init(self):
+        job = self.open_job(test_token)
+        self.assertFalse(os.path.isdir(job.workspace()))
+        job = self.open_job(test_token).init()
+        self.assertEqual(job.workspace(), job.ws)
+        self.assertTrue(os.path.isdir(job.workspace()))
+        self.assertTrue(os.path.isdir(job.ws))
+        self.assertTrue(os.path.exists(os.path.join(job.workspace(), job.FN_MANIFEST)))
+
     def test_construction(self):
         job = self.open_job(test_token)
         job2 = eval(repr(job))


### PR DESCRIPTION
See issue #120 for description.

I also looked at the possibility of chaining calls to `Project`, but there were no candidate methods that I thought would be good to chain.