### PR TITLE
Implement the H5StoreManager class.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ Highlights
 Added
 +++++
 
- - Adds an ``H5Store`` class, useful for storing array-like data with an HDF5 backend. Accessible via ``with job.data:`` or ``with project.data:``.
+ - Adds an ``H5Store`` and a ``H5StoreManager`` class, useful for storing array-like data with an HDF5 backend. Accessible via ``with job.data:`` or ``with project.data:``.
  - Adds the ``signac.get_job()`` and the ``signac.Project.get_job()`` functions which allow users to get a job handle by switching into or providing the job's workspace directory.
  - Add automatic cast of numpy arrays to lists when storing them within a `JSONDict`, e.g., a `job.statepoint` or `job.document`.
  - Enable `Collection` class to manage collections stored in gzip files.

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ Highlights
 Added
 +++++
 
- - Adds an ``H5Store`` and a ``H5StoreManager`` class, useful for storing array-like data with an HDF5 backend. Accessible via ``with job.data:`` or ``with project.data:``.
+ - Adds an ``H5Store`` and a ``H5StoreManager`` class, useful for storing array-like data with an HDF5-backend. Those classes are exposed as part of the ``job.data``, ``job.stores``, ``project.data``, and ``project.stores``, properties.
  - Adds the ``signac.get_job()`` and the ``signac.Project.get_job()`` functions which allow users to get a job handle by switching into or providing the job's workspace directory.
  - Add automatic cast of numpy arrays to lists when storing them within a `JSONDict`, e.g., a `job.statepoint` or `job.document`.
  - Enable `Collection` class to manage collections stored in gzip files.

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -11,7 +11,7 @@ from ..common import six
 from ..core.json import json, CustomJSONEncoder
 from ..core.attrdict import SyncedAttrDict
 from ..core.jsondict import JSONDict
-from ..core.h5store import H5Store
+from ..core.h5store import H5StoreManager
 from .hashing import calc_id
 from .utility import _mkdir_p
 from .errors import DestinationExistsError, JobsCorruptedError
@@ -53,8 +53,7 @@ class Job(object):
     FN_DOCUMENT = 'signac_job_document.json'
     "The job's document filename."
 
-    FN_DATA = 'signac_data.h5'
-    "The job's datastore filename."
+    KEY_DATA = 'signac_data'
 
     def __init__(self, project, statepoint, _id=None):
         self._project = project
@@ -76,10 +75,6 @@ class Job(object):
         # Prepare job document
         self._fn_doc = os.path.join(self._wd, self.FN_DOCUMENT)
         self._document = None
-
-        # Prepare job datastore
-        self._fn_data = os.path.join(self._wd, self.FN_DATA)
-        self._data = None
 
         # Prepare current working directory for context management
         self._cwd = list()
@@ -163,7 +158,6 @@ class Job(object):
         self._wd = dst._wd
         self._fn_doc = dst._fn_doc
         self._document = None
-        self._fn_data = dst._fn_data
         self._data = None
         self._cwd = list()
         logger.info("Moved '{}' -> '{}'.".format(self, dst))
@@ -264,20 +258,24 @@ class Job(object):
         self.document = new_doc
 
     @property
+    def stores(self):
+        return H5StoreManager(self._wd)
+
+    @property
     def data(self):
         """The data associated with this job.
 
+        Equivalent to:
+
+            return job.store['signac_data']
+
         :return: An HDF5-backed datastore.
         :rtype: :class:`~signac.core.h5store.H5Store`"""
-        if self._data is None:
-            self.init()
-            self._data = H5Store(filename=self._fn_data)
-        return self._data
+        return self.init().stores[self.KEY_DATA]
 
     @data.setter
     def data(self, new_data):
-        self._data.clear()
-        self._data.update(new_data)
+        self.stores[self.KEY_DATA] = new_data
 
     def _init(self, force=False):
         fn_manifest = os.path.join(self._wd, self.FN_MANIFEST)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -76,6 +76,9 @@ class Job(object):
         self._fn_doc = os.path.join(self._wd, self.FN_DOCUMENT)
         self._document = None
 
+        # Prepare job h5-stores
+        self._stores = H5StoreManager(self._wd)
+
         # Prepare current working directory for context management
         self._cwd = list()
 
@@ -259,7 +262,7 @@ class Job(object):
 
     @property
     def stores(self):
-        return H5StoreManager(self._wd)
+        return self.init()._stores
 
     @property
     def data(self):
@@ -271,7 +274,7 @@ class Job(object):
 
         :return: An HDF5-backed datastore.
         :rtype: :class:`~signac.core.h5store.H5Store`"""
-        return self.init().stores[self.KEY_DATA]
+        return self.stores[self.KEY_DATA]
 
     @data.setter
     def data(self, new_data):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -262,6 +262,28 @@ class Job(object):
 
     @property
     def stores(self):
+        """Access HDF5-stores associated wit this job.
+
+        Use this property to access an HDF5-file within the job's workspace
+        directory using the H5Store dict-like interface.
+
+        This is an example for accessing an HDF5-file called 'my_data.h5' within
+        the job's workspace:
+
+            job.stores['my_data']['array'] = np.random((32, 4))
+
+        This is equivalent to:
+
+            H5Store(job.fn('my_data.h5'))['array'] = np.random((32, 4))
+
+        Both the `job.stores` and the `H5Store` itself support attribute
+        access. The above example could therefore also be expressed as
+
+            job.stores.my_data.array = np.random((32, 4))
+
+        :return: The HDF5-Store manager for this job.
+        :rtype: :class:`~..core.h5store.H5StoreManager
+        """
         return self.init()._stores
 
     @property
@@ -270,10 +292,10 @@ class Job(object):
 
         Equivalent to:
 
-            return job.store['signac_data']
+            return job.stores['signac_data']
 
         :return: An HDF5-backed datastore.
-        :rtype: :class:`~signac.core.h5store.H5Store`"""
+        :rtype: :class:`~..core.h5store.H5Store`"""
         return self.stores[self.KEY_DATA]
 
     @data.setter

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -303,6 +303,28 @@ class Project(object):
 
     @property
     def stores(self):
+        """Access HDF5-stores associated wit this project.
+
+        Use this property to access an HDF5-file within the project's root
+        directory using the H5Store dict-like interface.
+
+        This is an example for accessing an HDF5-file called 'my_data.h5' within
+        the project's root directory:
+
+            project.stores['my_data']['array'] = np.random((32, 4))
+
+        This is equivalent to:
+
+            H5Store(project.fn('my_data.h5'))['array'] = np.random((32, 4))
+
+        Both the `project.stores` and the `H5Store` itself support attribute
+        access. The above example could therefore also be expressed as
+
+            project.stores.my_data.array = np.random((32, 4))
+
+        :return: The HDF5-Store manager for this project.
+        :rtype: :class:`~..core.h5store.H5StoreManager
+        """
         return H5StoreManager(self._rd)
 
     @property
@@ -314,7 +336,7 @@ class Project(object):
             return project.store['signac_data']
 
         :return: An HDF5-backed datastore.
-        :rtype: :class:`~signac.core.h5store.H5DictManager`
+        :rtype: :class:`~..core.h5store.H5Store`
         """
         return self.stores[self.KEY_DATA]
 

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -106,3 +106,10 @@ class DictManager(object):
 
     def __len__(self):
         return len(list(self.keys()))
+
+    def __getstate__(self):
+        return dict(_prefix=self._prefix, _dict_registry=self._dict_registry)
+
+    def __setstate__(self, d):
+        self._prefix = d['_prefix']
+        self._dict_registry = d['_dict_registry']

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -89,11 +89,11 @@ class DictManager(object):
         else:
             self.__setitem__(name, value)
 
-    def __delattr__(self, name, value):
+    def __delattr__(self, name):
         if name.startswith('__') or name in self.__slots__:
-            super(DictManager, self).__delattr__(name, value)
+            super(DictManager, self).__delattr__(name)
         else:
-            self.__delitem__(name, value)
+            self.__delitem__(name)
 
     def __iter__(self):
         for fn in os.listdir(self.prefix):

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"Basic wrapper to access multiple different data stores."
+import os
+import re
+import errno
+import uuid
+
+from ..common import six
+
+
+class DictManager(object):
+
+    cls = None
+    suffix = None
+
+    __slots__ = ['prefix']
+
+    def __init__(self, prefix):
+        assert self.cls is not None
+        assert self.suffix is not None
+        self.prefix = os.path.abspath(prefix)
+
+    def __eq__(self, other):
+        return os.path.realpath(self.prefix) == os.path.realpath(other.prefix) and \
+            self.suffix == other.suffix
+
+    def __repr__(self):
+        return "{}(prefix='{}')".format(type(self).__name__, os.path.relpath(self.prefix))
+
+    __str__ = __repr__
+
+    def __getitem__(self, key):
+        return self.cls(os.path.join(self.prefix, key) + self.suffix)
+
+    def __setitem__(self, key, value):
+        tmp_key = str(uuid.uuid4())
+        try:
+            self[tmp_key].update(value)
+            if six.PY2:
+                os.rename(self[tmp_key].filename, self[key].filename)
+            else:
+                os.replace(self[tmp_key].filename, self[key].filename)
+        except (IOError, OSError) as error:
+            if error.errno == errno.ENOENT and not len(value):
+                raise ValueError("Cannot asssign empty value!")
+            else:
+                raise error
+        except Exception:
+            try:
+                del self[tmp_key]
+            except KeyError:
+                pass
+            raise
+
+    def __delitem__(self, key):
+        try:
+            os.unlink(self[key].filename)
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                raise KeyError(key)
+            else:
+                raise error
+
+    def __getattr__(self, name):
+        try:
+            return super(DictManager, self).__getattribute__(name)
+        except AttributeError:
+            if name.startswith('__') or name in self.__slots__:
+                raise
+            try:
+                return self.__getitem__(name)
+            except KeyError:
+                raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if name.startswith('__') or name in self.__slots__:
+            super(DictManager, self).__setattr__(name, value)
+        else:
+            self.__setitem__(name, value)
+
+    def __delattr__(self, name, value):
+        if name.startswith('__') or name in self.__slots__:
+            super(DictManager, self).__delattr__(name, value)
+        else:
+            self.__delitem__(name, value)
+
+    def __iter__(self):
+        for fn in os.listdir(self.prefix):
+            m = re.match('(.*){}'.format(self.suffix), fn)
+            if m:
+                yield m.groups()[0]
+
+    def keys(self):
+        return iter(self)
+
+    def __len__(self):
+        return len(list(self.keys()))

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -15,12 +15,17 @@ class DictManager(object):
     cls = None
     suffix = None
 
-    __slots__ = ['prefix']
+    __slots__ = ['_prefix', '_dict_registry']
 
     def __init__(self, prefix):
         assert self.cls is not None
         assert self.suffix is not None
-        self.prefix = os.path.abspath(prefix)
+        self._prefix = os.path.abspath(prefix)
+        self._dict_registry = dict()
+
+    @property
+    def prefix(self):
+        return self._prefix
 
     def __eq__(self, other):
         return os.path.realpath(self.prefix) == os.path.realpath(other.prefix) and \
@@ -32,7 +37,9 @@ class DictManager(object):
     __str__ = __repr__
 
     def __getitem__(self, key):
-        return self.cls(os.path.join(self.prefix, key) + self.suffix)
+        if key not in self._dict_registry:
+            self._dict_registry[key] = self.cls(os.path.join(self.prefix, key) + self.suffix)
+        return self._dict_registry[key]
 
     def __setitem__(self, key, value):
         tmp_key = str(uuid.uuid4())
@@ -53,6 +60,8 @@ class DictManager(object):
             except KeyError:
                 pass
             raise error
+        else:
+            del self._dict_registry[key]
 
     def __delitem__(self, key):
         try:

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -47,12 +47,12 @@ class DictManager(object):
                 raise ValueError("Cannot asssign empty value!")
             else:
                 raise error
-        except Exception:
+        except Exception as error:
             try:
                 del self[tmp_key]
             except KeyError:
                 pass
-            raise
+            raise error
 
     def __delitem__(self, key):
         try:

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -57,7 +57,7 @@ class DictManager(object):
     def __delitem__(self, key):
         try:
             os.unlink(self[key].filename)
-        except IOError as error:
+        except (IOError, OSError) as error:
             if error.errno == errno.ENOENT:
                 raise KeyError(key)
             else:

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -18,8 +18,8 @@ class DictManager(object):
     __slots__ = ['_prefix', '_dict_registry']
 
     def __init__(self, prefix):
-        assert self.cls is not None
-        assert self.suffix is not None
+        assert self.cls is not None, "Subclasses of DictManager must define the cls variable."
+        assert self.suffix is not None, "Subclasses of DictManager must define the suffix variable."
         self._prefix = os.path.abspath(prefix)
         self._dict_registry = dict()
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -364,7 +364,10 @@ class H5Store(MutableMapping):
 
     def flush(self):
         """Flush the underlying HDF5-file."""
-        self._file.flush()
+        if self._file is None:
+            raise H5StoreClosedError(self._filename)
+        else:
+            self._file.flush()
 
     def __getitem__(self, key):
         key = key if key.startswith('/') else '/' + key

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -400,6 +400,12 @@ class H5Store(MutableMapping):
         else:
             self.__setitem__(key, value)
 
+    def __delattr__(self, key):
+        if key.startswith('__') or key in self.__slots__:
+            super(H5Store, self).__delattr__(key)
+        else:
+            self.__delitem__(key)
+
     def __iter__(self):
         with _ensure_open(self):
             # The generator below should be refactored to use 'yield from'

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -10,6 +10,7 @@ import array
 from threading import RLock
 
 from ..common import six
+from .dict_manager import DictManager
 
 if six.PY2:
     from collections import Mapping
@@ -284,6 +285,10 @@ class H5Store(MutableMapping):
         self._file = None
         self._kwargs = kwargs
 
+    @property
+    def filename(self):
+        return self._filename
+
     def __repr__(self):
         return "<{}(filename={})>".format(type(self).__name__, os.path.relpath(self._filename))
 
@@ -428,3 +433,8 @@ class H5Store(MutableMapping):
         """
         with _ensure_open(self):
             self._file.clear()
+
+
+class H5StoreManager(DictManager):
+    cls = H5Store
+    suffix = '.h5'

--- a/tests/test_h5store_manager.py
+++ b/tests/test_h5store_manager.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+import os
+import unittest
+
+from signac.core.h5store import H5StoreManager
+from signac.common import six
+if six.PY2:
+    from tempdir import TemporaryDirectory
+else:
+    from tempfile import TemporaryDirectory
+
+
+class TestH5StoreManager(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp_dir = TemporaryDirectory(prefix='h5store_')
+        self.addCleanup(self._tmp_dir.cleanup)
+        self.store = H5StoreManager(prefix=self._tmp_dir.name)
+        with open(os.path.join(self._tmp_dir.name, 'other_file.txt'), 'w') as file:
+            file.write(r'blank\n')
+
+    def test_repr(self):
+        self.assertEqual(eval(repr(self.store)), self.store)
+
+    def test_str(self):
+        self.assertEqual(eval(str(self.store)), self.store)
+
+    def test_set(self):
+        self.assertEqual(len(self.store), 0)
+        self.assertNotIn('test', self.store)
+        for value in ('', [], {}):
+            with self.assertRaises(ValueError):
+                self.store['test'] = value
+        for value in (True, 0, 0.0, 1, 1.0, None):
+            with self.assertRaises(TypeError):
+                self.store['test'] = value
+        for value in ('abc'):
+            with self.assertRaises(ValueError):
+                self.store['test'] = value
+
+        # Assigning a dictionary is the intended use case
+        self.store['test'] = dict(foo=True)
+        self.assertEqual(len(self.store), 1)
+        self.assertIn('test', self.store)
+
+    def test_set_iterable(self):
+        self.assertEqual(len(self.store), 0)
+        self.assertNotIn('test', self.store)
+        self.store['test'] = list(dict(foo=True).items())
+        self.assertEqual(len(self.store), 1)
+        self.assertIn('test', self.store)
+
+    def test_set_get(self):
+        self.assertEqual(len(self.store), 0)
+        self.assertNotIn('test', self.store)
+        self.store['test']['foo'] = 'bar'
+        self.assertIn('test', self.store)
+        self.assertEqual(len(self.store), 1)
+        self.assertIn('foo', self.store['test'])
+
+    def test_del(self):
+        self.assertEqual(len(self.store), 0)
+        self.assertNotIn('test', self.store)
+        self.store['test']['foo'] = 'bar'
+        self.assertIn('test', self.store)
+        self.assertEqual(len(self.store), 1)
+        self.assertIn('foo', self.store['test'])
+        with self.assertRaises(KeyError):
+            del self.store['invalid']
+        del self.store['test']
+        self.assertEqual(len(self.store), 0)
+        self.assertNotIn('test', self.store)
+
+    def test_iteration(self):
+        keys = ['foo', 'bar', 'baz']
+        for key in keys:
+            self.store[key] = dict(test=True)
+        self.assertEqual(list(sorted(keys)), list(sorted(self.store)))
+        self.assertEqual(list(sorted(keys)), list(sorted(self.store.keys())))
+
+    def test_contains(self):
+        keys = ['foo', 'bar', 'baz']
+        for key in keys:
+            self.assertNotIn(key, self.store)
+        for key in keys:
+            self.store[key] = dict(test=True)
+        for key in keys:
+            self.assertIn(key, self.store)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_h5store_manager.py
+++ b/tests/test_h5store_manager.py
@@ -3,6 +3,7 @@
 # This software is licensed under the BSD 3-Clause License.
 import os
 import unittest
+import pickle
 
 from signac.core.h5store import H5StoreManager
 from signac.common import six
@@ -88,6 +89,9 @@ class TestH5StoreManager(unittest.TestCase):
             self.store[key] = dict(test=True)
         for key in keys:
             self.assertIn(key, self.store)
+
+    def test_pickle(self):
+        self.assertEqual(pickle.loads(pickle.dumps(self.store)), self.store)
 
 
 if __name__ == '__main__':

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1634,7 +1634,7 @@ class JobOpenCustomDataTest(BaseJobTest):
             self.assertEqual(len(job.stores.test), 0)
 
     def test_reopen(self):
-        key = 'clear'
+        key = 'reopen'
         d = testdata()
         job = self.open_job(test_token)
         with self.open_data(job):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1383,6 +1383,19 @@ class JobClosedDataTest(JobOpenDataTest):
     def open_data(job):
         yield
 
+    def test_implicit_initialization(self):
+        job = self.open_job(test_token)
+        self.assertNotIn('test', job.stores)
+        self.assertNotIn('foo', job.stores.test)
+        self.assertEqual(list(job.stores.keys()), [])
+        self.assertEqual(list(job.stores), [])
+        self.assertNotIn('test', job.stores)
+        job.stores.test.foo = True
+        self.assertIn('test', job.stores)
+        self.assertIn('foo', job.stores.test)
+        self.assertEqual(list(job.stores.keys()), ['test'])
+        self.assertEqual(list(job.stores), ['test'])
+
 
 class JobOpenCustomDataTest(BaseJobTest):
 


### PR DESCRIPTION
## Description

Introduces the `DictManager` and the `H5StoreManager` classes that are exposed as `job.stores` and `project.stores`.

## Motivation and Context

It would be highly advantageous to enable users to easily manage multiple HDF5-files instead of just one. There are plenty of reasons why that is a good idea:

1. While the HDF5-format is generally mutable, it is fundamentally designed to be used as an immutable data container. In fact, even the latest version is internally restricted to append-only operations and a file will continue to grow with repeated addition and edits. The only way to reduce the file size is to create a new file (e.g. with `h5repack`).
2. A single large file is difficult to synchronize. Even if we only change a few MBs or even KBs of a multiple TBs-large file, there is a large chance that synchronization tools like `rsync` or GLOBUS will have to transfer the complete file. Furthermore, all data stored within one large file share one modification time stamp, making fine-grained synchronization even more difficult. Finally, synchronization of parts of a file are impossible.
3. A single large file, especially when it is repeatedly mutated poses a data corruption risk. The HDF5 library uses file locks to reduce the risk of data corruption, but there is no journaling as of yet and the corruption of parts of the file, e.g., through a crashed application (think job killed due to walltime stop etc.) might corrupt the whole file leading to complete data loss.
4. The HDF5-format does not play well with concurrent/parallel access. While the single-writer-multiple-reader (SWMR) mode is implemented for some libraries, it comes with severe limitations and requires a special access style that cannot be easily made transparent to the user. Existence checks etc would be much easier to execute concurrently if they are kept to the file system level without needing to open the file.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [ ] *master*, because it is a bug fix or an update to the documentation.
- [x] *develop*, because it introduces a new feature.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
