### PR TITLE
Elevate all dots-in-keys deprecation warnings to errors.

### DIFF
--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -16,7 +16,6 @@ import sys
 import io
 import re
 import logging
-import warnings
 import argparse
 import operator
 from itertools import islice
@@ -201,9 +200,11 @@ def _build_index(docs, key, primary_key):
             except KeyError:
                 pass
             else:
-                warnings.warn(
-                    "Using keys with dots ('.') is pending deprecation in the future!",
-                    PendingDeprecationWarning)
+                from ..errors import InvalidKeyError
+                raise InvalidKeyError(
+                    "\nThe use of '.' (dots) in keys is invalid.\n\n"
+                    "See http://www.signac.io/document-wide-migration/ "
+                    "for a recipe on how to replace dots in all keys.")
                 # inlined for performance
                 if type(v) is list:     # performance
                     index[_to_tuples(v)].add(doc[primary_key])

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -41,7 +41,13 @@ class DictManager(object):
             self._dict_registry[key] = self.cls(os.path.join(self.prefix, key) + self.suffix)
         return self._dict_registry[key]
 
+    @staticmethod
+    def _validate_key(key):
+        "Emit a warning or raise an exception if key is invalid. Returns key."
+        return key
+
     def __setitem__(self, key, value):
+        self._validate_key(key)
         tmp_key = str(uuid.uuid4())
         try:
             self[tmp_key].update(value)

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -10,6 +10,7 @@ import array
 from threading import RLock
 
 from ..common import six
+from ..errors import InvalidKeyError
 from .dict_manager import DictManager
 
 if six.PY2:
@@ -153,12 +154,7 @@ def _h5get(file, grp, key, path=None):
 def _validate_key(key):
     "Emit a warning or raise an exception if key is invalid. Returns key."
     if '.' in key:
-        from ..warnings import SignacDeprecationWarning
-        warnings.warn(
-            "\nThe use of '.' (dots) in keys is deprecated and may lead to "
-            "unexpected behavior!\nSee http://www.signac.io/document-wide-migration/ "
-            "for a recipe on how to replace dots in all keys.",
-            SignacDeprecationWarning)
+        raise InvalidKeyError("Keys for the H5Store may not contain dots ('.').")
     return key
 
 

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -3,7 +3,6 @@
 # This software is licensed under the BSD 3-Clause License.
 "Synchronized dictionary."
 import logging
-import warnings
 from contextlib import contextmanager
 from functools import wraps
 from copy import deepcopy
@@ -89,12 +88,11 @@ class _SyncedDict(MutableMapping):
     def _validate_key(key):
         "Emit a warning or raise an exception if key is invalid. Returns key."
         if '.' in key:
-            from ..warnings import SignacDeprecationWarning
-            warnings.warn(
+            from ..errors import InvalidKeyError
+            raise InvalidKeyError(
                 "\nThe use of '.' (dots) in keys is deprecated and may lead to "
                 "unexpected behavior!\nSee http://www.signac.io/document-wide-migration/ "
-                "for a recipe on how to replace dots in all keys.",
-                SignacDeprecationWarning)
+                "for a recipe on how to replace dots in all keys.")
         return key
 
     def _dfs_convert(self, root):

--- a/signac/errors.py
+++ b/signac/errors.py
@@ -52,6 +52,10 @@ class SchemaSyncConflict(SyncConflict):
         return "The synchronization failed, because of a schema conflict."
 
 
+class InvalidKeyError(ValueError):
+    """Raised when a user uses a non-conforming key."""
+
+
 __all__ = [
     'Error',
     'BufferException',
@@ -67,4 +71,5 @@ __all__ = [
     'FileSyncConflict',
     'DocumentSyncConflict',
     'SchemaSyncConflict',
+    'InvalidKeyError',
 ]

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,13 +1,13 @@
 from __future__ import division
 import os
 import io
-import warnings
 import unittest
 from collections import OrderedDict
 from itertools import islice
 
 from signac import Collection
 from signac.common import six
+from signac.errors import InvalidKeyError
 if six.PY2:
     from tempdir import TemporaryDirectory
 else:
@@ -293,8 +293,7 @@ class CollectionTest(unittest.TestCase):
         self.assertEqual(self.c.find_one({'a': {'$type': 'float'}})['_id'], id_float)
 
     def test_find_with_dots(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('once')
+        with self.assertRaises(InvalidKeyError):
             self.assertEqual(len(self.c.find()), 0)
             self.assertEqual(list(self.c.find()), [])
             self.assertEqual(len(self.c.find({'a.b': 0})), 0)
@@ -309,10 +308,6 @@ class CollectionTest(unittest.TestCase):
             self.assertEqual(len(self.c.find()), 2 * len(docs))
             self.assertEqual(len(self.c.find({'a.b': 0})), 2)
             self.assertEqual(len(self.c.find({'a.b': -1})), 0)
-            if six.PY34:  # warning registry not cleared in earlier versions
-                assert len(w) == 1
-                assert issubclass(w[0].category, PendingDeprecationWarning)
-                assert 'deprecation' in str(w[0].message)
 
     def test_find_types(self):
         # Note: All of the iterables will be normalized to lists!

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -7,7 +7,6 @@ import sys
 import unittest
 import random
 import string
-import warnings
 import subprocess
 from itertools import chain
 from array import array
@@ -20,7 +19,7 @@ from contextlib import closing
 
 from signac.core.h5store import H5Store, H5StoreClosedError, H5StoreAlreadyOpenError
 from signac.common import six
-from signac.warnings import SignacDeprecationWarning
+from signac.errors import InvalidKeyError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -406,15 +405,12 @@ class H5StoreTest(BaseH5StoreTest):
             self.assertEqual(h5s[key], d)
 
     def test_keys_with_dots(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with self.assertRaises(InvalidKeyError):
             with self.open_h5store() as h5s:
                 key = 'a.b'
                 d = self.get_testdata()
                 h5s[key] = d
                 self.assertEqual(h5s[key], d)
-            assert len(w) >= 1
-            assert any(issubclass(w_.category, SignacDeprecationWarning) for w_ in w)
 
     def test_keys_with_slashes(self):
         # HDF5 uses slashes for nested keys internally

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -18,7 +18,7 @@ import signac.common.config
 from signac.common import six
 from signac.errors import DestinationExistsError
 from signac.errors import JobsCorruptedError
-from signac.warnings import SignacDeprecationWarning
+from signac.errors import InvalidKeyError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -202,24 +202,10 @@ class JobSPInterfaceTest(BaseJobTest):
         self.assertNotEqual(old_id, job.get_id())
 
     def test_interface_nested_kws(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('error')
-            with self.assertRaises(SignacDeprecationWarning):
-                job = self.open_job({'a.b.c': 0})
-        with warnings.catch_warnings(record=True) as warning_record:
-            warnings.simplefilter('always')
+        with self.assertRaises(InvalidKeyError):
             job = self.open_job({'a.b.c': 0})
-            self.assertEqual(job.sp['a.b.c'], 0)
-            with self.assertRaises(AttributeError):
-                job.sp.a.b.c
-            job.sp['a.b.c'] = 1
-            self.assertEqual(job.sp['a.b.c'], 1)
-            self.assertEqual(len(warning_record), 4)
-            for warning in warning_record:
-                self.assertTrue(issubclass(warning.category, SignacDeprecationWarning))
-                self.assertIn('dots', str(warning.message))
-        job.sp.clear()
-        job.sp.a = dict(b=dict(c=2))
+
+        job = self.open_job(dict(a=dict(b=dict(c=2))))
         self.assertEqual(job.sp.a.b.c, 2)
         self.assertEqual(job.sp['a']['b']['c'], 2)
 

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -3,12 +3,11 @@
 # This software is licensed under the BSD 3-Clause License.
 import os
 import unittest
-import warnings
 import uuid
 
 from signac.core.jsondict import JSONDict
 from signac.common import six
-from signac.warnings import SignacDeprecationWarning
+from signac.errors import InvalidKeyError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -229,10 +228,8 @@ class JSONDictTest(BaseJSONDictTest):
 
     def test_keys_with_dots(self):
         jsd = self.get_json_dict()
-        with warnings.catch_warnings():
-            warnings.simplefilter('error')
-            with self.assertRaises(SignacDeprecationWarning):
-                jsd['a.b'] = None
+        with self.assertRaises(InvalidKeyError):
+            jsd['a.b'] = None
 
 
 class JSONDictWriteConcernTest(JSONDictTest):


### PR DESCRIPTION
The use of an invalid key should lead to the raise of an
InvalidKeyError, which is newly defined in the errors module.