### PR TITLE
Documentation for JSONDict constructor.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -59,8 +59,8 @@ Fixed
 Added
 +++++
 
- - Adds the ``$ signac import`` command and the ``Project.import_from()`` method for the import of data spaces into a project workspace, such as a directory, a tarball, or a zip-file.
- - Adds the ``$ signac export`` command and the ``Project.export_to()`` method for the export of project workspaces to an external location, such as a directory, a tarball, or a zip-file.
+ - Adds the ``$ signac import`` command and the ``Project.import_from()`` method for the import of data spaces into a project workspace, such as a directory, a tarball, or a zip file.
+ - Adds the ``$ signac export`` command and the ``Project.export_to()`` method for the export of project workspaces to an external location, such as a directory, a tarball, or a zip file.
  - Adds functionality for the rapid initialization of temporary projects with the ``signac.TemporaryProject`` context manager.
  - Adds the ``signac.Project.temporary_project()`` context manager which creates a temporary project within the root project workspace.
  - Add ``signac`` to the default namespace when invoking ``signac shell``.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -113,6 +113,7 @@ The Job class
     :undoc-members:
     :show-inheritance:
 
+.. currentmodule:: signac
 
 The Collection
 ==============
@@ -121,6 +122,16 @@ The Collection
 
 .. autoclass:: Collection
    :members:
+
+
+The JSONDict
+============
+
+This class implements the interface for the job's :attr:`~signac.contrib.job.Job.statepoint` and :attr:`~signac.contrib.job.Job.document` attributes, but can also be used stand-alone:
+
+.. autoclass:: JSONDict
+   :members:
+
 
 Top-level functions
 ===================

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -264,10 +264,10 @@ class Job(object):
     def stores(self):
         """Access HDF5-stores associated wit this job.
 
-        Use this property to access an HDF5-file within the job's workspace
+        Use this property to access an HDF5 file within the job's workspace
         directory using the H5Store dict-like interface.
 
-        This is an example for accessing an HDF5-file called 'my_data.h5' within
+        This is an example for accessing an HDF5 file called 'my_data.h5' within
         the job's workspace:
 
             job.stores['my_data']['array'] = np.random((32, 4))

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -305,10 +305,10 @@ class Project(object):
     def stores(self):
         """Access HDF5-stores associated wit this project.
 
-        Use this property to access an HDF5-file within the project's root
+        Use this property to access an HDF5 file within the project's root
         directory using the H5Store dict-like interface.
 
-        This is an example for accessing an HDF5-file called 'my_data.h5' within
+        This is an example for accessing an HDF5 file called 'my_data.h5' within
         the project's root directory:
 
             project.stores['my_data']['array'] = np.random((32, 4))
@@ -1005,8 +1005,8 @@ class Project(object):
 
         :param target:
             A path to a directory to export to. The target can not already exist.
-            Besides directories, possible targets are tar-files (`.tar`), gzipped tar-files
-            (`.tar.gz`), zip-files (`.zip`), bzip2-compressed files (`.bz2`),
+            Besides directories, possible targets are tar files (`.tar`), gzipped tar files
+            (`.tar.gz`), zip files (`.zip`), bzip2-compressed files (`.bz2`),
             and xz-compressed files (`.xz`).
         :param path:
             The path (function) used to structure the exported data space.
@@ -1053,7 +1053,7 @@ class Project(object):
 
         :param origin:
             The path to the data space origin, which is to be imported. This may be a path to
-            a directory, a zip-file, or a tarball archive.
+            a directory, a zip file, or a tarball archive.
         :param schema:
             An optional schema function, which is either a string or a function that accepts a
             path as its first and only argument and returns the corresponding state point as dict.

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -63,7 +63,7 @@ class H5StoreClosedError(RuntimeError):
 
 
 class H5StoreAlreadyOpenError(OSError):
-    """Indicates that the underlying HDF5-file is already openend."""
+    """Indicates that the underlying HDF5 file is already openend."""
 
 
 def _h5set(store, grp, key, value, path=None):
@@ -236,7 +236,7 @@ class H5Store(MutableMapping):
 
     The H5Store API is a :class:`collections.abc.MutableMapping` and therefore
     behaves similar to a :class:`dict`, but all data is stored persistently in
-    the associated HDF5-file on disk.
+    the associated HDF5 file on disk.
 
     Supported types include:
 
@@ -258,7 +258,7 @@ class H5Store(MutableMapping):
             assert h5s['foo'] == 'bar'
 
     :param filename:
-        The filename of the underlying HDF5-file.
+        The filename of the underlying HDF5 file.
     :param kwargs:
         Additional keyword arguments to be forward to the h5py.File constructor
         See documentation for :class:`h5py.File` for more information.
@@ -317,7 +317,7 @@ class H5Store(MutableMapping):
         return self
 
     def open(self, mode=None):
-        """Open the underlying HDF5-file.
+        """Open the underlying HDF5 file.
 
         :param mode:
             The file open mode to use. Defaults to 'a' (append).
@@ -329,7 +329,7 @@ class H5Store(MutableMapping):
         return self._open(mode=mode)
 
     def close(self):
-        """Close the underlying HDF5-file."""
+        """Close the underlying HDF5 file."""
         locked = True
         try:
             self._file.close()
@@ -352,7 +352,7 @@ class H5Store(MutableMapping):
         return self._mode
 
     def flush(self):
-        """Flush the underlying HDF5-file."""
+        """Flush the underlying HDF5 file."""
         if self._file is None:
             raise H5StoreClosedError(self._filename)
         else:

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -194,11 +194,11 @@ def buffer_reads_writes(buffer_size=DEFAULT_BUFFER_SIZE, force_write=False):
 
 
 class JSONDict(SyncedAttrDict):
-    """A dict-like mapping interface to a persistent JSON-file.
+    """A dict-like mapping interface to a persistent JSON file.
 
     The JSONDict is a :class:`~collections.abc.MutableMapping` and therefore
     behaves similar to a :class:`dict`, but all data is stored persistently in
-    the associated JSON-file on disk.
+    the associated JSON file on disk.
 
     .. code-block:: python
 
@@ -220,7 +220,7 @@ class JSONDict(SyncedAttrDict):
         {'foo': {'bar': False}}
 
     :param filename:
-        The filename of the associated JSON-file on disk.
+        The filename of the associated JSON file on disk.
     :param write_concern:
         Ensure file consistency by writing changes back to a temporary file
         first, before replacing the original file. Default is False.

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -202,11 +202,11 @@ class JSONDict(SyncedAttrDict):
 
     .. code-block:: python
 
-            doc = JSONDict('data.json', write_concern=True)
-            doc['foo'] = "bar"
-            assert doc.foo == doc['foo'] == "bar"
-            assert 'foo' in doc
-            del doc['foo']
+        doc = JSONDict('data.json', write_concern=True)
+        doc['foo'] = "bar"
+        assert doc.foo == doc['foo'] == "bar"
+        assert 'foo' in doc
+        del doc['foo']
 
     This class allows access to keys both with the slicing and attributes.
     That means ``doc.foo`` and ``doc['foo']`` are equivalent.
@@ -214,11 +214,11 @@ class JSONDict(SyncedAttrDict):
 
     .. code-block:: python
 
-            >>> doc['foo'] = dict(bar=True)
-            >>> doc
-            {'foo': {'bar': True}}
-            >>> doc.foo.bar = False
-            {'foo': {'bar': False}}
+        >>> doc['foo'] = dict(bar=True)
+        >>> doc
+        {'foo': {'bar': True}}
+        >>> doc.foo.bar = False
+        {'foo': {'bar': False}}
 
     :param filename:
         The filename of the associated JSON-file on disk.

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -223,7 +223,7 @@ class JSONDict(SyncedAttrDict):
         The filename of the associated JSON-file on disk.
     :param write_concern:
         Ensure file consistency by writing changes back to a temporary file
-        first, before replacing the original file.
+        first, before replacing the original file. Default is False.
     :param parent:
         A parent instance of JSONDict or None.
     """

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -208,9 +208,8 @@ class JSONDict(SyncedAttrDict):
         assert 'foo' in doc
         del doc['foo']
 
-    This class allows access to keys both with the slicing and attributes.
-    That means ``doc.foo`` and ``doc['foo']`` are equivalent.
-    Nested keys can also be accessed like that:
+    This class allows access to values through key indexing or attributes
+    named by keys, including nested keys:
 
     .. code-block:: python
 

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -194,8 +194,41 @@ def buffer_reads_writes(buffer_size=DEFAULT_BUFFER_SIZE, force_write=False):
 
 
 class JSONDict(SyncedAttrDict):
+    """A dict-like mapping interface to a persistent JSON-file.
 
-    def __init__(self, parent=None, filename=None, write_concern=False):
+    The JSONDict is a :class:`~collections.abc.MutableMapping` and therefore
+    behaves similar to a :class:`dict`, but all data is stored persistently in
+    the associated JSON-file on disk.
+
+    .. code-block:: python
+
+            doc = JSONDict('data.json', write_concern=True)
+            doc['foo'] = "bar"
+            assert doc.foo == doc['foo'] == "bar"
+            assert 'foo' in doc
+            del doc['foo']
+
+    This class allows access to keys both with the slicing and attributes.
+    That means ``doc.foo`` and ``doc['foo']`` are equivalent.
+    Nested keys can also be accessed like that:
+
+    .. code-block:: python
+
+            >>> doc['foo'] = dict(bar=True)
+            >>> doc
+            {'foo': {'bar': True}}
+            >>> doc.foo.bar = False
+            {'foo': {'bar': False}}
+
+    :param filename:
+        The filename of the associated JSON-file on disk.
+    :param write_concern:
+        Ensure file consistency by writing changes back to a temporary file
+        first, before replacing the original file.
+    :param parent:
+        A parent instance of JSONDict or None.
+    """
+    def __init__(self, filename=None, write_concern=False, parent=None):
         if (filename is None) == (parent is None):
             raise ValueError(
                 "Illegal argument combination, one of the two arguments, "


### PR DESCRIPTION
I added a docstring to the root-namespace exposed JSONDict class and
moved the `parent` constructor argument to the end of the argument
order.

Having the filename be the first argument is much more natural to users
who would want to use this class stand-alone. All internal calls to this
constructor used `filename=...` syntax, so this change does not require
any other changes to the code base.