### PR TITLE
Fix/schema subset

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ Fixed
  - Fix ``Collection.update()`` behavior such that existing documents with identical primary key are updated. Previously, a ``KeyError`` would be raised.
  - Fix issue where the ``Job.move()`` would trigger a confusing ``DestinationExists`` exception when trying to move jobs across devices / file systems.
  - Fix issue that caused failures when the ``python-rapidjson`` package is installed. The ``python-rapidjson`` package is used as the primary JSON-backend when installed.
+ - Fix issue where schema with multiple keys would subset incorrectly if the list of jobs or statepoints was provided as an iterator rather than an iterable.
 
 Removed
 +++++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -50,7 +50,7 @@ Fixed
  - Fix ``Collection.update()`` behavior such that existing documents with identical primary key are updated. Previously, a ``KeyError`` would be raised.
  - Fix issue where the ``Job.move()`` would trigger a confusing ``DestinationExists`` exception when trying to move jobs across devices / file systems.
  - Fix issue that caused failures when the ``python-rapidjson`` package is installed. The ``python-rapidjson`` package is used as the primary JSON-backend when installed.
- - Fix issue where schema with multiple keys would subset incorrectly if the list of jobs or statepoints was provided as an iterator rather than an iterable.
+ - Fix issue where schema with multiple keys would subset incorrectly if the list of jobs or statepoints was provided as an iterator rather than a sequence.
 
 Removed
 +++++++

--- a/signac/contrib/schema.py
+++ b/signac/contrib/schema.py
@@ -4,6 +4,7 @@
 from pprint import pformat
 from collections import defaultdict as ddict
 from numbers import Number
+import itertools
 
 from ..common import six
 if six.PY2:
@@ -179,9 +180,10 @@ class ProjectSchema(object):
     def __call__(self, jobs_or_statepoints):
         "Evaluate the schema for the given state points."
         s = dict()
-        for key in self:
+        iterators = itertools.tee(jobs_or_statepoints, len(self))
+        for key, it in zip(self, iterators):
             values = []
-            for sp in jobs_or_statepoints:
+            for sp in it:
                 if not isinstance(sp, Mapping):
                     sp = sp.statepoint
                 v = sp[key[0]]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -690,10 +690,13 @@ class ProjectTest(BaseProjectTest):
 
     def test_schema_eval(self):
         for i in range(10):
-            self.project.open_job(dict(a=i)).init()
+            for j in range(10):
+                self.project.open_job(dict(a=i, b=j)).init()
         s = self.project.detect_schema()
         self.assertEqual(s, s(self.project))
         self.assertEqual(s, s([job.sp for job in self.project]))
+        # Check that it works with iterables that can only be consumed once
+        self.assertEqual(s, s((job.sp for job in self.project)))
 
     def test_schema_difference(self):
         def get_sp(i):


### PR DESCRIPTION
The schema subsetting needs to be able to loop over the provided `jobs_or_statepoints` once per key.