### PR TITLE
Doc/document statepoint behavior

### DIFF
--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -203,6 +203,16 @@ class Job(object):
     @property
     def statepoint(self):
         """Access the job's state point as attribute dictionary.
+
+        .. warning::
+
+            The statepoint object behaves like a dictionary in most cases,
+            but because it persists changes to the filesystem, making a copy
+            requires explicitly converting it to a dict. If you need a
+            modifiable copy that will not modify the underlying JSON file,
+            you can access a dict copy of the statepoint by calling it, e.g.
+            `sp_dict = job.statepoint()` instead of `sp = job.statepoint`.
+            For more information, see :class:`~signac.JSONDict`.
         """
         if self._sp is None:
             self._sp = SyncedAttrDict(self._statepoint, parent=_sp_save_hook(self))
@@ -215,6 +225,12 @@ class Job(object):
     @property
     def sp(self):
         """ Alias for :attr:`Job.statepoint`.
+
+        .. warning::
+
+            As with :attr:`Job.statepoint`, use `job.sp()` instead of
+            `job.sp` if you need to deep copy that will not modify the
+            underlying persisted JSON file.
         """
         return self.statepoint
 
@@ -239,6 +255,13 @@ class Job(object):
     def document(self):
         """The document associated with this job.
 
+        .. warning::
+
+            If you need to deep copy that will not modify the underlying
+            persisted JSON file, use `job.document()` instead of `job.doc`.
+            For more information, see :attr:`Job.statepoint` or
+            :class:`~signac.JSONDict`.
+
         :return:
             The job document handle.
         :rtype:
@@ -256,6 +279,13 @@ class Job(object):
     @property
     def doc(self):
         """Alias for :attr:`Job.document`.
+
+        .. warning::
+
+            If you need to deep copy that will not modify the underlying
+            persisted JSON file, use `job.document()` instead of `job.doc`.
+            For more information, see :attr:`Job.statepoint` or
+            :class:`~signac.JSONDict`.
         """
         return self.document
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -229,8 +229,8 @@ class Job(object):
         .. warning::
 
             As with :attr:`Job.statepoint`, use `job.sp()` instead of
-            `job.sp` if you need to deep copy that will not modify the
-            underlying persisted JSON file.
+            `job.sp` if you need a deep copy that will not modify the
+            underlying persistent JSON file.
         """
         return self.statepoint
 
@@ -257,8 +257,8 @@ class Job(object):
 
         .. warning::
 
-            If you need to deep copy that will not modify the underlying
-            persisted JSON file, use `job.document()` instead of `job.doc`.
+            If you need a deep copy that will not modify the underlying
+            persistent JSON file, use `job.document()` instead of `job.doc`.
             For more information, see :attr:`Job.statepoint` or
             :class:`~signac.JSONDict`.
 
@@ -282,8 +282,8 @@ class Job(object):
 
         .. warning::
 
-            If you need to deep copy that will not modify the underlying
-            persisted JSON file, use `job.document()` instead of `job.doc`.
+            If you need a deep copy that will not modify the underlying
+            persistent JSON file, use `job.document()` instead of `job.doc`.
             For more information, see :attr:`Job.statepoint` or
             :class:`~signac.JSONDict`.
         """

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -219,6 +219,16 @@ class JSONDict(SyncedAttrDict):
         >>> doc.foo.bar = False
         {'foo': {'bar': False}}
 
+    .. warning::
+
+        While the JSONDict object behaves like a dictionary, there are
+        important distinctions to remember. In particular, because operations
+        are reflected as changes to an underlying file, copying (even deep
+        copying) a JSONDict instance may exhibit unexpected behavior. If a
+        true copy is required, you should use the `_as_dict` method to get a
+        dictionary representation, and if necessary construct a new JSONDict
+        instance: `new_dict = JSONDict(old_dict._as_dict())`.
+
     :param filename:
         The filename of the associated JSON file on disk.
     :param write_concern:


### PR DESCRIPTION
Document that JSONDict copies will modify underlying file. 