### PR TITLE
Change deprecated numpy.asscalar to o.item()

### DIFF
--- a/signac/core/json.py
+++ b/signac/core/json.py
@@ -41,7 +41,7 @@ class CustomJSONEncoder(JSONEncoder):
     def default(self, o):
         if NUMPY:
             if isinstance(o, numpy.number):
-                return numpy.ndarray.item(o)
+                return o.item()
             elif isinstance(o, numpy.ndarray):
                 return o.tolist()
         try:

--- a/signac/core/json.py
+++ b/signac/core/json.py
@@ -41,7 +41,7 @@ class CustomJSONEncoder(JSONEncoder):
     def default(self, o):
         if NUMPY:
             if isinstance(o, numpy.number):
-                return numpy.asscalar(o)
+                return numpy.ndarray.item(o)
             elif isinstance(o, numpy.ndarray):
                 return o.tolist()
         try:


### PR DESCRIPTION
## Motivation and Context
The function `numpy.asscalar` has been deprecated in NumPy 1.16. The [recommended replacement is `numpy.ndarray.item`](https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.asscalar.html#numpy.asscalar
), but this only applies to one-element arrays. Since we have a class of type `numpy.number`, just call `o.item()` directly, which is [exactly what the implementation of `asscalar()` does](https://github.com/numpy/numpy/blob/v1.16.1/numpy/lib/type_check.py#L517-L547). 

## Types of Changes
- [x] New feature

This pull request is based on
- [x] *develop*, because it introduces a new feature.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).