### PR TITLE
Fix/h5store setdefault

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ next
 
  - Add command line options ``--sp`` and ``--doc`` for ``signac find`` that allow users to display key-value pairs of the state point and document in combination with the job id (#97, #146).
  - Fix: Searches for whole numbers will match all numerically matching integers regardless of whether they are stored as decimals or whole numbers (#169).
+ - Fix: Passing an instance of dict to `H5Store.setdefault()` will return an instance of `H5Group` instead of a dict (#180).
 
 
 [1.0.0] -- 2019-02-28

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -210,6 +210,10 @@ class H5Group(MutableMapping):
         else:
             self.__setitem__(key, value)
 
+    def setdefault(self, key, value):
+        super(H5Group, self).setdefault(key, value)
+        return self.__getitem__(key)
+
     def __iter__(self):
         # The generator below should be refactored to use 'yield from'
         # once we drop Python 2.7 support.
@@ -432,6 +436,10 @@ class H5Store(MutableMapping):
             super(H5Store, self).__delattr__(key)
         else:
             self.__delitem__(key)
+
+    def setdefault(self, key, value):
+        super(H5Store, self).setdefault(key, value)
+        return self.__getitem__(key)
 
     def __iter__(self):
         with _ensure_open(self):

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -177,7 +177,11 @@ class H5StoreTest(BaseH5StoreTest):
         with self.open_h5store() as h5s:
             key = 'setgetexplicitnested'
             d = self.get_testdata()
-            h5s.setdefault('a', dict())
+            self.assertNotIn('a', h5s)
+            ret = h5s.setdefault('a', dict())
+            self.assertIn('a', h5s)
+            self.assertEqual(ret, h5s['a'])
+            self.assertTrue(hasattr(ret, '_store'))  # is an H5Group object
             child1 = h5s['a']
             child2 = h5s['a']
             self.assertEqual(child1, child2)


### PR DESCRIPTION
This pull request ensures that the return value of a call to `H5Store.setdefault` and `H5Group.setdefault` returns a reference to a `H5Group` object if the value is a dictionary.

For example:

```
foo = h5s.setdefault('foo', dict())
```
will return a dictionary before this patch.
Any further modifications of `foo` would not affect the file at all, but instead operate on a local instance of `dict`.