### PR TITLE
Feature/h5store attrs

### DIFF
--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -230,6 +230,10 @@ class H5Group(MutableMapping):
             else:
                 return super(H5Group, self).__eq__(other)
 
+    @property
+    def attrs(self):
+        return self._group.attrs
+
 
 class H5Store(MutableMapping):
     """An HDF5-backed container for storing array-like and dictionary-like data.
@@ -376,6 +380,10 @@ class H5Store(MutableMapping):
             raise H5StoreClosedError(self._filename)
         else:
             return self._file
+
+    @property
+    def attrs(self):
+        return self.file.attrs
 
     @property
     def mode(self):

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -527,6 +527,18 @@ class H5StoreTest(BaseH5StoreTest):
                 self.assertEqual(b, B)
                 self.assertEqual(h5s.a.b, A)
 
+    def test_attrs(self):
+        with self.get_h5store() as h5s:
+            self.assertNotIn('foo', h5s.attrs)
+            h5s.attrs['foo'] = 'bar'
+            self.assertIn('foo', h5s.attrs)
+            self.assertEqual(h5s.attrs['foo'], 'bar')
+            h5s.attrs.update(dict(foo='baz'))
+            self.assertIn('foo', h5s.attrs)
+            self.assertEqual(h5s.attrs['foo'], 'baz')
+            del h5s.attrs['foo']
+            self.assertNotIn('foo', h5s.attrs)
+
 
 class H5StoreNestedDataTest(H5StoreTest):
 


### PR DESCRIPTION
Expose the `attrs` property of `h5py.File` for `H5Store` and `H5Group`.

For example:
```
h5s.foo.attrs['parameter'] = 0
```