### PR TITLE
Improve the representation of `H5Group`.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ next
  - Add command line options ``--sp`` and ``--doc`` for ``signac find`` that allow users to display key-value pairs of the state point and document in combination with the job id (#97, #146).
  - Fix: Searches for whole numbers will match all numerically matching integers regardless of whether they are stored as decimals or whole numbers (#169).
  - Fix: Passing an instance of dict to `H5Store.setdefault()` will return an instance of `H5Group` instead of a dict (#180).
+ - Improve the representation (return value of `repr()`) of instances of `H5Group`.
 
 
 [1.0.0] -- 2019-02-28

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -180,6 +180,10 @@ class H5Group(MutableMapping):
         self._store = store
         self._path = path
 
+    def __repr__(self):
+        return '{}(store={}, path={})'.format(
+            type(self).__name__, repr(self._store), repr(self._path))
+
     @property
     def _group(self):
         return self._store.file[self._path]

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -21,6 +21,12 @@ else:
     from collections.abc import MutableMapping
 
 
+__all__ = [
+    'H5Store', 'H5Group', 'H5StoreManager',
+    'H5StoreClosedError', 'H5StoreAlreadyOpenError',
+    ]
+
+
 def _group_is_pandas_type(group):
     return 'pandas_type' in group.attrs
 

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -200,10 +200,9 @@ class H5StoreTest(BaseH5StoreTest):
     def test_repr(self):
         with self.open_h5store() as h5s:
             key = 'test_repr'
+            self.assertEqual(repr(h5s), repr(eval(repr(h5s))))
             h5s[key] = self.get_testdata()
-            repr(h5s[key])
-            repr(h5s)    # open
-        repr(h5s)   # closed
+        self.assertEqual(repr(h5s), repr(eval(repr(h5s))))
 
     def test_str(self):
         with self.open_h5store() as h5s:
@@ -537,6 +536,15 @@ class H5StoreNestedDataTest(H5StoreTest):
 
     def get_testdata(self, size=None):
         return dict(a=super(H5StoreNestedDataTest, self).get_testdata(size))
+
+    def test_repr(self):
+        from signac.core.h5store import H5Store, H5Group  # noqa:F401
+        with self.open_h5store() as h5s:
+            key = 'test_repr'
+            self.assertEqual(repr(h5s), repr(eval(repr(h5s))))
+            h5s[key] = self.get_testdata()
+            self.assertEqual(repr(h5s[key]), repr(eval(repr(h5s[key]))))
+        self.assertEqual(repr(h5s), repr(eval(repr(h5s))))
 
 
 class H5StoreBytesDataTest(H5StoreTest):

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -201,6 +201,7 @@ class H5StoreTest(BaseH5StoreTest):
         with self.open_h5store() as h5s:
             key = 'test_repr'
             h5s[key] = self.get_testdata()
+            repr(h5s[key])
             repr(h5s)    # open
         repr(h5s)   # closed
 


### PR DESCRIPTION
Implements `H5Group.__repr__`.

For example:

```python\
>>> H5Store('data.h5')['foo']
H5Group(store=H5Store(filename='data.h5'), path='/foo')
```

Improves the REPL experience.