### PR TITLE
Move repr from JSONDict to _SyncedDict.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ next
  - Fix: Searches for whole numbers will match all numerically matching integers regardless of whether they are stored as decimals or whole numbers (#169).
  - Fix: Passing an instance of dict to `H5Store.setdefault()` will return an instance of `H5Group` instead of a dict (#180).
  - Improve the representation (return value of `repr()`) of instances of `H5Group`.
+ - Improve the representation (return value of `repr()`) of instances of `SyncedAttrDict`.
 
 
 [1.0.0] -- 2019-02-28

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -297,9 +297,6 @@ class JSONDict(SyncedAttrDict):
                 with open(self._filename, 'wb') as file:
                     file.write(blob)
 
-    def __repr__(self):
-        return repr(self())
-
     @contextmanager
     def buffered(self):
         buffered_dict = BufferedSyncedAttrDict(self, parent=self)

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -257,6 +257,9 @@ class _SyncedDict(MutableMapping):
         self._synced_load()
         return self._convert_to_dict(self._data).items()
 
+    def __repr__(self):
+        return repr(self())
+
     def __str__(self):
         return str(self())
 

--- a/tests/test_synced_attrdict.py
+++ b/tests/test_synced_attrdict.py
@@ -90,7 +90,11 @@ class SyncedAttrDictTest(unittest.TestCase):
 
     def test_repr(self):
         sad = self.get_sad()
-        repr(sad)
+        self.assertEqual(repr(sad), repr(dict(sad())))
+        sad['a'] = 0
+        self.assertEqual(repr(sad), repr(dict(sad())))
+        sad['a'] = {'b': 0}
+        self.assertEqual(repr(sad), repr(dict(sad())))
 
     def test_call(self):
         sad = self.get_sad()


### PR DESCRIPTION
## Description
We define `__repr__` for `JSONDict` but not its parent `SyncedAttrDict` or its parent `_SyncedDict`:
```python
def __repr__(self):
    return repr(self())
```

## Motivation and Context
When I am in the REPL, the statepoint representation is currently not helpful but the document representation is helpful:
```python
>>> job.sp  # is a SyncedAttrDict
<signac.core.attrdict.SyncedAttrDict object at 0x10b858cc0>
>>> job.doc  # is a JSONDict
{'IBZ_sphericity': 0.5235987755982993, ...}
```

## Types of Changes
- [x] Bug fix
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
