### PR TITLE
Run tests for Python 3.8 release candidate.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,10 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.5
+  test-3.8-rc:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.8-rc
   test-2.7:
     <<: *test-template
     docker:
@@ -164,6 +168,10 @@ workflows:
       - test-3.7:
           requires:
             - style-check
+      - test-3.8-rc:
+          requires:
+            - test-3.7
+            - style-check
       - test-pypy-2:
           requires:
             - test-2.7
@@ -183,6 +191,7 @@ workflows:
             - test-3.5
             - test-3.6
             - test-3.7
+            - test-3.8-rc
             - test-pypy-2
             - test-pypy-3
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,6 @@ jobs:
             - python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}
             - python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
             - python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-            - python-env-v4-{{ arch }}
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
             - python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
             - python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
             - python-env-v4-{{ arch }}
-            - python-env-v4
 
       - run:
           name: install dependencies


### PR DESCRIPTION
Run tests for the Python 3.8 release-candidate in preparation for the release of Python 3.8.