### PR TITLE
Default host is typically not present

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ next
 ----
 
  - Keep signac shell command history on a per-project basis.
+ - Reduce the logging verbosity about a missing default host key in the configuration (#201).
 
 [1.1.0] -- 2019-05-19
 ---------------------

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -50,12 +50,12 @@ def get_validator():
 
 
 cfg = """
-workspace_dir = string(default='workspace')
 project = string()
+workspace_dir = string(default='workspace')
 signac_version = version(default='0,1,0')
 
 [General]
-default_host = string()
+default_host = string(default=None)
 
 [hosts]
 [[__many__]]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
I added a default value of None to the `default_host` in the config object. I also reordered the workspace and project for clarity (since `workspace_dir`) is an optional key.

## Motivation and Context
When requesting high verbosity for any signac command (since essentially everything reads signac.rc), there are a lot of false positives indicating that something is wrong with the configuration because it's expecting a `default_host` key in the `[General]` section and it typically does not find one.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
