### PR TITLE
Fix issue in DictManager that would lead to incorrectly listed dicts.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,7 +21,7 @@ next
 ----
 
  - Keep signac shell command history on a per-project basis.
- - Fix issue with incorrect detection of dict-like files managed with the ``DictManager`` class (e.g. ``job.stores``).
+ - Fix issue with incorrect detection of dict-like files managed with the ``DictManager`` class (e.g. ``job.stores``) (#203).
 
 [1.1.0] -- 2019-05-19
 ---------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ next
 ----
 
  - Keep signac shell command history on a per-project basis.
+ - Fix issue with incorrect detection of dict-like files managed with the ``DictManager`` class (e.g. ``job.stores``).
 
 [1.1.0] -- 2019-05-19
 ---------------------

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -108,7 +108,7 @@ class DictManager(object):
 
     def __iter__(self):
         for fn in os.listdir(self.prefix):
-            m = re.fullmatch('(.*){}'.format(self.suffix), fn)
+            m = re.match('^(.*){}$'.format(self.suffix), fn)
             if m:
                 yield m.groups()[0]
 

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -108,7 +108,7 @@ class DictManager(object):
 
     def __iter__(self):
         for fn in os.listdir(self.prefix):
-            m = re.match('(.*){}'.format(self.suffix), fn)
+            m = re.fullmatch('(.*){}'.format(self.suffix), fn)
             if m:
                 yield m.groups()[0]
 


### PR DESCRIPTION
## Description

The regex was matching files that included the suffix, but did not
necessarily *end* with the given suffix.

## Motivation and Context

The `DictManager` would list dicts with filenames that do not actually end with the given suffix. For example, `mystore.h5` would be listed, but also `mystore.5h.lock`.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
