### PR TITLE
Fix/issue 168

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,9 @@ next
  - Reduce the logging verbosity about a missing default host key in the configuration (#201).
  - Add ``read_json()`` and ``to_json()`` methods to Collection class (#104).
  - Fix issue with incorrect detection of dict-like files managed with the ``DictManager`` class (e.g. ``job.stores``) (#203).
+ - Fix issue causing a failure of the automatic conversion of valid key types (#168, #205).
+ - Improve the 'dots in keys' error message to make it easier to fix related issues (#170, #205).
+
 
 [1.1.0] -- 2019-05-19
 ---------------------

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -152,7 +152,7 @@ class Job(object):
             else:
                 raise
         # Update this instance
-        self._statepoint = SyncedAttrDict(dst._statepoint(), parent=_sp_save_hook(self))
+        self._statepoint = SyncedAttrDict(dst._statepoint._as_dict(), parent=_sp_save_hook(self))
         self._id = dst._id
         self._wd = dst._wd
         self._fn_doc = dst._fn_doc

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -24,10 +24,6 @@ else:
 logger = logging.getLogger(__name__)
 
 
-class SPDict(SyncedAttrDict):
-    pass
-
-
 class _sp_save_hook(object):
 
     def __init__(self, job):
@@ -64,10 +60,10 @@ class Job(object):
 
         # Ensure that the job id is configured
         if _id is None:
-            self._statepoint = SPDict(statepoint, parent=_sp_save_hook(self))
+            self._statepoint = SyncedAttrDict(statepoint, parent=_sp_save_hook(self))
             self._id = calc_id(self._statepoint())
         else:
-            self._statepoint = SPDict(statepoint, parent=_sp_save_hook(self))
+            self._statepoint = SyncedAttrDict(statepoint, parent=_sp_save_hook(self))
             self._id = _id
 
         # Prepare job working directory
@@ -156,7 +152,7 @@ class Job(object):
             else:
                 raise
         # Update this instance
-        self._statepoint = SPDict(dst._statepoint(), parent=_sp_save_hook(self))
+        self._statepoint = SyncedAttrDict(dst._statepoint(), parent=_sp_save_hook(self))
         self._id = dst._id
         self._wd = dst._wd
         self._fn_doc = dst._fn_doc

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -54,13 +54,9 @@ class Job(object):
     def __init__(self, project, statepoint, _id=None):
         self._project = project
 
-        # Ensure that the job id is configured
-        if _id is None:
-            self._statepoint = SyncedAttrDict(statepoint, parent=_sp_save_hook(self))
-            self._id = calc_id(self._statepoint())
-        else:
-            self._statepoint = SyncedAttrDict(statepoint, parent=_sp_save_hook(self))
-            self._id = _id
+        # Set statepoint and id
+        self._statepoint = SyncedAttrDict(statepoint, parent=_sp_save_hook(self))
+        self._id = calc_id(self._statepoint()) if _id is None else _id
 
         # Prepare job working directory
         self._wd = os.path.join(project.workspace(), self._id)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -216,13 +216,7 @@ class Job(object):
     def statepoint(self, new_sp):
         self._reset_sp(new_sp)
 
-    @property
-    def sp(self):
-        return self.statepoint
-
-    @sp.setter
-    def sp(self, value):
-        self.statepoint = value
+    sp = statepoint  # alias
 
     def _reset_document(self, new_doc):
         if not isinstance(new_doc, Mapping):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -228,16 +228,18 @@ class Job(object):
         if not isinstance(new_doc, Mapping):
             raise ValueError("The document must be a mapping.")
         else:
-            tmp = SyncedAttrDict(new_doc)
-        dirname, filename = os.path.split(self._fn_doc)
-        fn_tmp = os.path.join(dirname, '._{uid}_{fn}'.format(
-            uid=uuid.uuid4(), fn=filename))
-        with open(fn_tmp, 'wb') as tmpfile:
-            tmpfile.write(json.dumps(tmp).encode())
-        if six.PY2:
-            os.rename(fn_tmp, self._fn_doc)
-        else:
-            os.replace(fn_tmp, self._fn_doc)
+            # Convert for key type check and implicit conversions:
+            new_doc = SyncedAttrDict(new_doc)
+
+            dirname, filename = os.path.split(self._fn_doc)
+            fn_tmp = os.path.join(dirname, '._{uid}_{fn}'.format(
+                uid=uuid.uuid4(), fn=filename))
+            with open(fn_tmp, 'wb') as tmpfile:
+                tmpfile.write(json.dumps(new_doc).encode())
+            if six.PY2:
+                os.rename(fn_tmp, self._fn_doc)
+            else:
+                os.replace(fn_tmp, self._fn_doc)
 
     @property
     def document(self):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -216,7 +216,14 @@ class Job(object):
     def statepoint(self, new_sp):
         self._reset_sp(new_sp)
 
-    sp = statepoint  # alias
+    @property
+    def sp(self):
+        "Alias for :attr:`Job.statepoint`."
+        return self.statepoint
+
+    @sp.setter
+    def sp(self, new_sp):
+        self.statepoint = new_sp
 
     def _reset_document(self, new_doc):
         if not isinstance(new_doc, Mapping):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -372,7 +372,7 @@ class Project(object):
             # second best case
             job = self.Job(project=self, statepoint=statepoint)
             if job._id not in self._sp_cache:
-                self._sp_cache[job._id] = job._statepoint._as_dict()
+                self._sp_cache[job._id] = job.statepoint._as_dict()
             return job
         elif id in self._sp_cache:
             # optimal case

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -34,9 +34,9 @@ from .errors import WorkspaceError
 from .errors import DestinationExistsError
 from .errors import JobsCorruptedError
 if six.PY2:
-    from collections import Mapping, Iterable
+    from collections import Iterable
 else:
-    from collections.abc import Mapping, Iterable
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -259,17 +259,7 @@ class Project(object):
         return os.path.isfile(self.fn(filename))
 
     def _reset_document(self, new_doc):
-        if not isinstance(new_doc, Mapping):
-            raise ValueError("The document must be a mapping.")
-        dirname, filename = os.path.split(self._fn_doc)
-        fn_tmp = os.path.join(dirname, '._{uid}_{fn}'.format(
-            uid=uuid.uuid4(), fn=filename))
-        with open(fn_tmp, 'wb') as tmpfile:
-            tmpfile.write(json.dumps(new_doc).encode())
-        if six.PY2:
-            os.rename(fn_tmp, self._fn_doc)
-        else:
-            os.replace(fn_tmp, self._fn_doc)
+        self.document.reset(new_doc)
 
     @property
     def document(self):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -372,7 +372,7 @@ class Project(object):
             # second best case
             job = self.Job(project=self, statepoint=statepoint)
             if job._id not in self._sp_cache:
-                self._sp_cache[job._id] = dict(job._statepoint)
+                self._sp_cache[job._id] = job._statepoint._as_dict()
             return job
         elif id in self._sp_cache:
             # optimal case
@@ -719,7 +719,7 @@ class Project(object):
 
     def _register(self, job):
         "Register the job within the local index."
-        self._sp_cache[job._id] = dict(job._statepoint)
+        self._sp_cache[job._id] = job._statepoint._as_dict()
 
     def _get_statepoint_from_workspace(self, jobid):
         "Attempt to read the statepoint from the workspace."

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -15,6 +15,10 @@ from .errors import Error
 from . import json
 from .attrdict import SyncedAttrDict
 from ..common import six
+if six.PY2:
+    from collections import Mapping
+else:
+    from collections.abc import Mapping
 
 
 logger = logging.getLogger(__name__)
@@ -296,6 +300,13 @@ class JSONDict(SyncedAttrDict):
             else:
                 with open(self._filename, 'wb') as file:
                     file.write(blob)
+
+    def reset(self, data):
+        """Replace the document contents with data."""
+        if isinstance(data, Mapping):
+            self._save(data=data)
+        else:
+            raise ValueError("The document must be a mapping.")
 
     @contextmanager
     def buffered(self):

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -98,16 +98,15 @@ class _SyncedDict(MutableMapping):
             if '.' in key:
                 from ..errors import InvalidKeyError
                 raise InvalidKeyError(
-                    "Key '{}' contains dots ('.').\n\n"
-                    "See https://signac.io/document-wide-migration/ "
-                    "for a recipe on how to replace dots in existing keys.".format(key))
+                    "keys may not contain dots ('.'): {}".format(key))
             else:
                 return key
         elif isinstance(key, cls.VALID_KEY_TYPES):
             return cls._validate_key(str(key))
         else:
-            from ..errors import InvalidKeyTypeError
-            raise InvalidKeyTypeError(key)
+            from ..errors import KeyTypeError
+            raise KeyTypeError(
+                "keys must be str, int, bool or None, not {}".format(type(key).__name__))
 
     def _dfs_convert(self, root):
         if type(root) is type(self):

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -76,6 +76,8 @@ class _SyncedList(list):
 
 class _SyncedDict(MutableMapping):
 
+    VALID_KEY_TYPES = six.string_types + (int, bool, type(None))
+
     def __init__(self, initialdata=None, parent=None):
         self._suspend_sync_ = 1
         self._parent = parent
@@ -89,16 +91,23 @@ class _SyncedDict(MutableMapping):
             }
         self._suspend_sync_ = 0
 
-    @staticmethod
-    def _validate_key(key):
+    @classmethod
+    def _validate_key(cls, key):
         "Emit a warning or raise an exception if key is invalid. Returns key."
-        if '.' in key:
-            from ..errors import InvalidKeyError
-            raise InvalidKeyError(
-                "\nThe use of '.' (dots) in keys is invalid.\n\n"
-                "See https://signac.io/document-wide-migration/ "
-                "for a recipe on how to replace dots in existing keys.")
-        return key
+        if isinstance(key, six.string_types):
+            if '.' in key:
+                from ..errors import InvalidKeyError
+                raise InvalidKeyError(
+                    "Key '{}' contains dots ('.').\n\n"
+                    "See https://signac.io/document-wide-migration/ "
+                    "for a recipe on how to replace dots in existing keys.".format(key))
+            else:
+                return key
+        elif isinstance(key, cls.VALID_KEY_TYPES):
+            return cls._validate_key(str(key))
+        else:
+            from ..errors import InvalidKeyTypeError
+            raise InvalidKeyTypeError(key)
 
     def _dfs_convert(self, root):
         if type(root) is type(self):
@@ -110,6 +119,8 @@ class _SyncedDict(MutableMapping):
                 for k in root:
                     ret[k] = root[k]
             return ret
+        elif type(root) is tuple:
+            return _SyncedList(root, self)
         elif type(root) is list:
             return _SyncedList(root, self)
         elif NUMPY:

--- a/signac/errors.py
+++ b/signac/errors.py
@@ -56,7 +56,7 @@ class InvalidKeyError(ValueError):
     """Raised when a user uses a non-conforming key."""
 
 
-class InvalidKeyTypeError(TypeError):
+class KeyTypeError(TypeError):
     """Raised when a user uses a key of invalid type."""
 
 

--- a/signac/errors.py
+++ b/signac/errors.py
@@ -56,6 +56,10 @@ class InvalidKeyError(ValueError):
     """Raised when a user uses a non-conforming key."""
 
 
+class InvalidKeyTypeError(TypeError):
+    """Raised when a user uses a key of invalid type."""
+
+
 __all__ = [
     'Error',
     'BufferException',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -192,13 +192,11 @@ class JobSPInterfaceTest(BaseJobTest):
             self.assertEqual(getattr(job.sp.g, x), sp['g'][x])
             self.assertEqual(job.sp[x], sp[x])
         a = [1, 1.0, '1.0', True, None]
-        b = list(a) + [a] + [tuple(a)]
-        for v in b:
-            for x in ('a', 'b', 'c', 'd', 'e'):
-                setattr(job.sp, x, v)
-                self.assertEqual(getattr(job.sp, x), v)
-                setattr(job.sp.g, x, v)
-                self.assertEqual(getattr(job.sp.g, x), v)
+        for x in ('a', 'b', 'c', 'd', 'e'):
+            setattr(job.sp, x, a)
+            self.assertEqual(getattr(job.sp, x), a)
+            setattr(job.sp.g, x, a)
+            self.assertEqual(getattr(job.sp.g, x), a)
 
     def test_interface_job_identity_change(self):
         job = self.open_job({'a': 0})
@@ -327,6 +325,46 @@ class JobSPInterfaceTest(BaseJobTest):
             job2 = self.project.open_job(id=id0)
             self.assertEqual(job.sp, job2.sp)
             self.assertEqual(job.get_id(), job2.get_id())
+
+    def test_valid_sp_key_types(self):
+        job = self.open_job(dict(invalid_key=True)).init()
+
+        class A:
+            pass
+        for key in ('0', 0, True, False, None):
+            job.sp[key] = 'test'
+            self.assertIn(str(key), job.sp)
+
+    def test_invalid_sp_key_types(self):
+        job = self.open_job(dict(invalid_key=True)).init()
+
+        class A:
+            pass
+        for key in (0.0, A(), [], {}, dict()):
+            with self.assertRaises(TypeError):
+                job.sp[key] = 'test'
+            with self.assertRaises(TypeError):
+                job.sp = {key: 'test'}
+
+    def test_valid_doc_key_types(self):
+        job = self.open_job(dict(invalid_key=True)).init()
+
+        class A:
+            pass
+        for key in ('0', 0, True, False, None):
+            job.doc[key] = 'test'
+            self.assertIn(str(key), job.doc)
+
+    def test_invalid_doc_key_types(self):
+        job = self.open_job(dict(invalid_key=True)).init()
+
+        class A:
+            pass
+        for key in (0.0, A(), [], {}, dict()):
+            with self.assertRaises(TypeError):
+                job.doc[key] = 'test'
+            with self.assertRaises(TypeError):
+                job.doc = {key: 'test'}
 
 
 class ConfigTest(BaseJobTest):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -198,6 +198,11 @@ class JobSPInterfaceTest(BaseJobTest):
             self.assertEqual(getattr(job.sp, x), a)
             setattr(job.sp.g, x, a)
             self.assertEqual(getattr(job.sp.g, x), a)
+        t = (1, 2, 3)  # tuple
+        job.sp.t = t
+        self.assertEqual(job.sp.t, list(t))  # implicit conversion
+        job.sp.g.t = t
+        self.assertEqual(job.sp.g.t, list(t))
 
     def test_interface_job_identity_change(self):
         job = self.open_job({'a': 0})

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -19,7 +19,7 @@ from signac.common import six
 from signac.errors import DestinationExistsError
 from signac.errors import JobsCorruptedError
 from signac.errors import InvalidKeyError
-from signac.errors import InvalidKeyTypeError
+from signac.errors import KeyTypeError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -342,9 +342,9 @@ class JobSPInterfaceTest(BaseJobTest):
         class A:
             pass
         for key in (0.0, A(), (1, 2, 3)):
-            with self.assertRaises(InvalidKeyTypeError):
+            with self.assertRaises(KeyTypeError):
                 job.sp[key] = 'test'
-            with self.assertRaises(InvalidKeyTypeError):
+            with self.assertRaises(KeyTypeError):
                 job.sp = {key: 'test'}
         for key in ([], {}, dict()):
             with self.assertRaises(TypeError):
@@ -367,9 +367,9 @@ class JobSPInterfaceTest(BaseJobTest):
         class A:
             pass
         for key in (0.0, A(), (1, 2, 3)):
-            with self.assertRaises(InvalidKeyTypeError):
+            with self.assertRaises(KeyTypeError):
                 job.doc[key] = 'test'
-            with self.assertRaises(InvalidKeyTypeError):
+            with self.assertRaises(KeyTypeError):
                 job.doc = {key: 'test'}
         for key in ([], {}, dict()):
             with self.assertRaises(TypeError):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -19,6 +19,7 @@ from signac.common import six
 from signac.errors import DestinationExistsError
 from signac.errors import JobsCorruptedError
 from signac.errors import InvalidKeyError
+from signac.errors import InvalidKeyTypeError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -340,7 +341,12 @@ class JobSPInterfaceTest(BaseJobTest):
 
         class A:
             pass
-        for key in (0.0, A(), [], {}, dict()):
+        for key in (0.0, A(), (1, 2, 3)):
+            with self.assertRaises(InvalidKeyTypeError):
+                job.sp[key] = 'test'
+            with self.assertRaises(InvalidKeyTypeError):
+                job.sp = {key: 'test'}
+        for key in ([], {}, dict()):
             with self.assertRaises(TypeError):
                 job.sp[key] = 'test'
             with self.assertRaises(TypeError):
@@ -360,7 +366,12 @@ class JobSPInterfaceTest(BaseJobTest):
 
         class A:
             pass
-        for key in (0.0, A(), [], {}, dict()):
+        for key in (0.0, A(), (1, 2, 3)):
+            with self.assertRaises(InvalidKeyTypeError):
+                job.doc[key] = 'test'
+            with self.assertRaises(InvalidKeyTypeError):
+                job.doc = {key: 'test'}
+        for key in ([], {}, dict()):
             with self.assertRaises(TypeError):
                 job.doc[key] = 'test'
             with self.assertRaises(TypeError):

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -231,6 +231,25 @@ class JSONDictTest(BaseJSONDictTest):
         with self.assertRaises(InvalidKeyError):
             jsd['a.b'] = None
 
+    def test_keys_valid_type(self):
+        jsd = self.get_json_dict()
+
+        class MyStr(str):
+            pass
+        for key in ('key', MyStr('key'), 0, None, True):
+            d = jsd[key] = self.get_testdata()
+            self.assertIn(str(key), jsd)
+            self.assertEqual(jsd[str(key)], d)
+
+    def test_keys_invalid_type(self):
+        jsd = self.get_json_dict()
+
+        class A:
+            pass
+        for key in (0.0, A(), [], {}, dict()):
+            with self.assertRaises(TypeError):
+                jsd[key] = self.get_testdata()
+
 
 class JSONDictWriteConcernTest(JSONDictTest):
 

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -8,7 +8,7 @@ import uuid
 from signac.core.jsondict import JSONDict
 from signac.common import six
 from signac.errors import InvalidKeyError
-from signac.errors import InvalidKeyTypeError
+from signac.errors import KeyTypeError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -248,7 +248,7 @@ class JSONDictTest(BaseJSONDictTest):
         class A:
             pass
         for key in (0.0, A(), (1, 2, 3)):
-            with self.assertRaises(InvalidKeyTypeError):
+            with self.assertRaises(KeyTypeError):
                 jsd[key] = self.get_testdata()
         for key in ([], {}, dict()):
             with self.assertRaises(TypeError):

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -8,6 +8,7 @@ import uuid
 from signac.core.jsondict import JSONDict
 from signac.common import six
 from signac.errors import InvalidKeyError
+from signac.errors import InvalidKeyTypeError
 
 if six.PY2:
     from tempdir import TemporaryDirectory
@@ -246,7 +247,10 @@ class JSONDictTest(BaseJSONDictTest):
 
         class A:
             pass
-        for key in (0.0, A(), [], {}, dict()):
+        for key in (0.0, A(), (1, 2, 3)):
+            with self.assertRaises(InvalidKeyTypeError):
+                jsd[key] = self.get_testdata()
+        for key in ([], {}, dict()):
             with self.assertRaises(TypeError):
                 jsd[key] = self.get_testdata()
 


### PR DESCRIPTION
## Description

Fixes issue #168 and #170 .

## Motivation and Context

This patch refactors the state point management with in the `Job` class and also adds a general key type check and conversion to the SyncedDict class. That means that the `Job.sp`, `Job.doc`, and `Project.doc` attributes and their aliases should now behave consistently with respect to their key conversion and validation behavior.

Valid key types are now explicitly listed in the source code, namely: `str`, `int`, `bool`, and `NoneType`.
Trying to use a key of different type should trigger a `KeyTypeError`.

There are two minor incompatibilities introduced with this patch:

1) I discovered a bug where a value of type `tuple` would not be immediately converted to a list when assigned to a state point key and remain a tuple. The value would be a list after reloading the job. The unit test actually expected this odd behavior, I therefore changed a unit test with respect to this bug.
2) Instead of raising an `InvalidKeyError`, which is a `ValueError`, trying to use a floating point number as a key will now raise an `KeyTypeError`, which is a `TypeError`. Using floats as keys was already illegal, since they must contain dots in their JSON representation. However, this would have triggered a `InvalidKeyError`, instead of a `KeyTypeError`.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
