### PR TITLE
Add function to initialize a test workspace

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,15 @@ Highlights
  - Support for compressed Collection files.
 
 
+Next
+----
+
+Added
++++++
+
+ - Add function to initialize a sample data space for testing purposes
+
+
 [1.2.0] -- 2019-07-22
 ---------------------
 

--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -17,6 +17,7 @@ from . import cite
 from . import errors
 from . import warnings
 from . import sync
+from . import testing
 from .contrib import Project
 from .contrib import TemporaryProject
 from .contrib import get_project
@@ -61,4 +62,5 @@ __all__ = ['__version__', 'contrib', 'db', 'errors', 'warnings', 'sync',
            'buffered', 'is_buffered', 'flush', 'get_buffer_size', 'get_buffer_load',
            'JSONDict',
            'H5Store', 'H5StoreManager',
+           'testing',
            ]

--- a/signac/testing.py
+++ b/signac/testing.py
@@ -25,9 +25,9 @@ def init_jobs(project, nested=False, listed=False, heterogeneous=False):
     :type heterogeneous:
         bool
     :returns:
-        The project handle of the initialized project
+        A list containing the initialized jobs
     :rtype:
-        :py:class:`~.Project`
+        list of :py:class:`~.Job`
     """
     jobs_init = []
     vals = [1, 1.0, '1', False, True, None]

--- a/signac/testing.py
+++ b/signac/testing.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 """Functions for initializing workspaces for testing purposes."""
+from itertools import cycle
 
 
 def init_jobs(project, nested=False, listed=False, heterogeneous=False):
@@ -28,11 +29,16 @@ def init_jobs(project, nested=False, listed=False, heterogeneous=False):
     :rtype:
         :py:class:`~.Project`
     """
-    vals = [1, 1.0, '1', True, None]
+    jobs_init = []
+    vals = [1, 1.0, '1', False, True, None]
     if nested:
         vals += [{'b': v, 'c': 0} if heterogeneous else {'b': v} for v in vals]
     if listed:
         vals += [[v, 0] if heterogeneous else [v] for v in vals]
-    for v in vals:
-        project.open_job(dict(a=v)).init()
-    return project
+    if heterogeneous:
+        for k, v in zip(cycle('ab'), vals):
+            jobs_init.append(project.open_job({k: v}).init())
+    else:
+        for v in vals:
+            jobs_init.append(project.open_job(dict(a=v)).init())
+    return jobs_init

--- a/signac/testing.py
+++ b/signac/testing.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-from __future__ import print_function
+"""Functions for initializing workspaces for testing purposes."""
 
 
 def init_jobs(project, nested=False, listed=False, heterogeneous=False):
@@ -26,3 +26,4 @@ def init_jobs(project, nested=False, listed=False, heterogeneous=False):
         vals += [[v, 0] if heterogeneous else [v] for v in vals]
     for v in vals:
         project.open_job(dict(a=v)).init()
+    return project

--- a/signac/testing.py
+++ b/signac/testing.py
@@ -7,17 +7,26 @@
 def init_jobs(project, nested=False, listed=False, heterogeneous=False):
     """Initialize a dataspace for testing purposes
 
-    :param project: The project to add the jobs to
-    :type project: :py:class:`~.project.Project`
-    :param nested: If True, included nested state points
-    :type nested: bool
-    :param listed: If True, include lists as values of state point parameters
-    :type listed: bool
-    :param heterogeneous: If True, include heterogeneous state point parameters
-    :type heterogeneous: bool
-    :returns: The project handle of the initialized project
-    :rtype: :py:class:`~.Project`
-
+    :param project:
+        The project to add the jobs to
+    :type project:
+        :py:class:`~.project.Project`
+    :param nested:
+        If True, included nested state points
+    :type nested:
+        bool
+    :param listed:
+        If True, include lists as values of state point parameters
+    :type listed:
+        bool
+    :param heterogeneous:
+        If True, include heterogeneous state point parameters
+    :type heterogeneous:
+        bool
+    :returns:
+        The project handle of the initialized project
+    :rtype:
+        :py:class:`~.Project`
     """
     vals = [1, 1.0, '1', True, None]
     if nested:

--- a/signac/testing.py
+++ b/signac/testing.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+from __future__ import print_function
+
+
+def init_jobs(project, nested=False, listed=False, heterogeneous=False):
+    """Initialize a dataspace for testing purposes
+
+    :param project: The project to add the jobs to
+    :type project: :py:class:`~.project.Project`
+    :param nested: If True, included nested state points
+    :type nested: bool
+    :param listed: If True, include lists as values of state point parameters
+    :type listed: bool
+    :param heterogeneous: If True, include heterogeneous state point parameters
+    :type heterogeneous: bool
+    :returns: The project handle of the initialized project
+    :rtype: :py:class:`~.Project`
+
+    """
+    vals = [1, 1.0, '1', True, None]
+    if nested:
+        vals += [{'b': v, 'c': 0} if heterogeneous else {'b': v} for v in vals]
+    if listed:
+        vals += [[v, 0] if heterogeneous else [v] for v in vals]
+    for v in vals:
+        project.open_job(dict(a=v)).init()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,6 +6,7 @@ import os
 import uuid
 import warnings
 import logging
+import itertools
 import json
 import pickle
 from tarfile import TarFile
@@ -1980,6 +1981,18 @@ class ProjectPicklingTest(BaseProjectTest):
             self.project.open_job(dict(a=i, b=dict(c=i), d=list(range(i, i+3)))).init()
         for job in self.project:
             self.assertEqual(pickle.loads(pickle.dumps(job)), job)
+
+
+class TestTestingProjectInitialization(unittest.TestCase):
+
+    # Sanity check on all different combinations of inputs
+    def test_input_args(self):
+        for nested, listed, het in itertools.product([True, False], repeat=3):
+            with TemporaryDirectory(prefix='signac_') as _tmp_dir:
+                root = _tmp_dir
+                pr = signac.init_project(name='testproject', root=root)
+                pr = signac.testing.init_jobs(pr, nested=nested, listed=listed,
+                        heterogeneous=het)
 
 
 if __name__ == '__main__':

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1989,10 +1989,21 @@ class TestTestingProjectInitialization(unittest.TestCase):
     def test_input_args(self):
         for nested, listed, het in itertools.product([True, False], repeat=3):
             with TemporaryDirectory(prefix='signac_') as _tmp_dir:
+                print(nested, listed, het)
                 root = _tmp_dir
                 pr = signac.init_project(name='testproject', root=root)
+                s_sub = pr.detect_schema()
+                self.assertEqual(len(pr), 0)
+                pr_id_b4 = id(pr)
                 pr = signac.testing.init_jobs(pr, nested=nested, listed=listed,
                         heterogeneous=het)
+                self.assertGreater(len(pr), 0)
+                self.assertIsInstance(pr, signac.contrib.project.Project)
+                self.assertEqual(pr_id_b4, id(pr))
+                s = pr.detect_schema()
+                self.assertNotEqual(s_sub, s)
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,6 +20,7 @@ from signac.contrib.schema import ProjectSchema
 from signac.contrib.errors import JobsCorruptedError
 from signac.contrib.errors import WorkspaceError
 from signac.contrib.errors import StatepointParsingError
+from signac.contrib.project import JobsCursor, Project
 
 from test_job import BaseJobTest
 


### PR DESCRIPTION
This is related to signac-flow issue https://github.com/glotzerlab/signac-flow/pull/130 and https://github.com/glotzerlab/signac-flow/issues/129, where we decided it makes more sense to break up the data space initialization into signac core and the flow project initialization into flow.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- New feature

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [x] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
