### PR TITLE
Remove dead code paths identified by vulture.

### DIFF
--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -213,11 +213,6 @@ def _build_index(docs, key, primary_key):
                     "Specifically keys with dots ('.').\n\n"
                     "See https://signac.io/document-wide-migration/ "
                     "for a recipe on how to replace dots in existing keys.")
-                # inlined for performance
-                if type(v) is list:     # performance
-                    index[_to_hashable(v)].add(doc[primary_key])
-                else:
-                    index[v].add(doc[primary_key])
     return index
 
 

--- a/signac/syncutil.py
+++ b/signac/syncutil.py
@@ -38,12 +38,10 @@ def copytree(src, dst, copy_function=shutil.copy2, symlinks=False):
             else:
                 copy_function(srcname, dstname)
         except OSError as why:
-            raise
             errors.append((srcname, dstname, str(why)))
         # catch the Error from the recursive copytree so that we can
         # continue with other files
         except shutil.Error as err:
-            raise
             errors.extend(err.args[0])
     if errors:
         raise shutil.Error(errors)


### PR DESCRIPTION
## Description
I used [vulture](https://github.com/jendrikseipp/vulture) to identify dead code paths in signac. This PR removes code paths that could never be reached (after a `raise`).

## Motivation and Context
Removes dead code.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
