### PR TITLE
Update sync.py

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -57,4 +57,8 @@ contributors:
     given-names: "Thomas R."
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0001-6876-5956"
+  -
+    family-names: Malek
+    given-names: Ali
+    affiliation: "University of Goettingen"
 ...

--- a/signac/sync.py
+++ b/signac/sync.py
@@ -21,14 +21,14 @@ part of the :class:`~.FileSync` class. These are the default strategies:
 
     1. always -- Always overwrite on conflict.
     2. never -- Never overwrite on conflict.
-    3. time -- Overwrite when the modification time of the source file is newer.
+    3. update -- Overwrite when the modification time of the source file is newer.
     4. Ask -- Ask the user interactively about each conflicting filename.
 
 For example, to synchronize two projects resolving conflicts by modification time, use:
 
 .. code-block:: python
 
-    dest_project.sync(source_project, strategy=sync.FileSync.time)
+    dest_project.sync(source_project, strategy=sync.FileSync.update)
 
 Unlike files, which are always either overwritten as a whole or not, documents
 can be synchronized more fine-grained with a *sync function*. Such a function (or


### PR DESCRIPTION
`FileSync` has no attribute called `time`. The described functionality assigned to `time` in the documentation should be of `update`.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
