### PR TITLE
Throw descriptive error message for linked views on Windows.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,11 @@ Changed
 
  - Implemented ``Project.__contains__`` check in constant time.
 
+Fixed
++++++
+
+ - Attempting to create a linked view for a Project on Windows now raises an informative error message.
+
 Removed
 +++++++
 

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -4,6 +4,7 @@
 import os
 import errno
 import logging
+import sys
 from itertools import chain
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,12 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     """Create or update a persistent linked view of the selected data space."""
     from .import_export import _make_path_function
     from .import_export import _check_directory_structure_validity
+
+    # Windows does not support the creation of symbolic links.
+    if sys.platform == 'win32':
+        raise OSError("signac cannot create linked views on Windows, because "
+                      "symbolic links are not supported by the platform.")
+
     if prefix is None:
         prefix = 'view'
 


### PR DESCRIPTION
## Description
Added an error message that is raised on Windows when attempting to create a linked view.

## Motivation and Context
Resolves #214.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
