### PR TITLE
Fix/circle ci pypy3 issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
+    environment:
+      PYTHON: python
+
     working_directory: ~/repo
 
     steps:
@@ -42,7 +45,7 @@ jobs:
           name: install dependencies
           command: |
             export PATH=$PATH:$HOME/.local/bin
-            pip install -U virtualenv --user
+            ${PYTHON} -m pip install -U virtualenv --user
             mkdir -p ./venv
             virtualenv ./venv
             . venv/bin/activate
@@ -51,9 +54,9 @@ jobs:
             else
               sudo apt update -qq && sudo apt install -y -qq libhdf5-dev
             fi
-            pip install -U pip==18
-            pip install -U codecov
-            pip install -U -e . -r requirements-dev.txt
+            ${PYTHON} -m pip install -U pip==18
+            ${PYTHON} -m pip install -U codecov
+            ${PYTHON} -m pip install -U -e . -r requirements-dev.txt
 
       - save_cache:
           key: python-env-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}
@@ -64,9 +67,9 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            coverage run -m unittest discover tests/ -v
-            pip install python-rapidjson==0.7.1 && coverage run -m unittest discover tests/ -v
-            coverage report -i
+            ${PYTHON} -m coverage run -m unittest discover tests/ -v
+            ${PYTHON} -m pip install python-rapidjson==0.7.1 && coverage run -m unittest discover tests/ -v
+            ${PYTHON} -m coverage report -i
             codecov
 
       - store_artifacts:
@@ -77,14 +80,14 @@ jobs:
           name: benchmark
           command: |
             . venv/bin/activate
-            pip install -r requirements-benchmark.txt
-            pip freeze
-            python benchmark.py run -N 100 1000  # this revision
-            python benchmark.py report
+            ${PYTHON} -m pip install -r requirements-benchmark.txt
+            ${PYTHON} -m pip freeze
+            ${PYTHON} benchmark.py run -N 100 1000  # this revision
+            ${PYTHON} benchmark.py report
             git reset --hard origin/master
             git checkout "${CIRCLE_SHA1}" -- benchmark.py  # ensure that we use the same benchmark script
-            python benchmark.py run -N 100 1000 --force
-            python benchmark.py compare origin/master "${CIRCLE_SHA1}"
+            ${PYTHON} benchmark.py run -N 100 1000 --force
+            ${PYTHON} benchmark.py compare origin/master "${CIRCLE_SHA1}"
   test-3.6:
     <<: *test-template
     docker:
@@ -97,6 +100,9 @@ jobs:
     <<: *test-template
     docker:
       - image: pypy:3
+    environment:
+      PYTHON: pypy3
+
 
   check-metadata:
     docker:

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,6 +1,7 @@
 numpy==1.15
 GitPython==2.1.11
-pandas==0.23; implementation_name=='cpython'
+pandas==0.25; implementation_name!='cpython' --no-binary pandas
+pandas==0.25; implementation_name=='cpython'
 psutil==5.5
 tqdm==4.30
 backports.tempfile==1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 coverage==4
 mock==2
 numpy==1.15
-pandas==0.23; implementation_name=='cpython'
+pandas==0.25; implementation_name!='cpython' --no-binary pandas
+pandas==0.25; implementation_name=='cpython'
 h5py==2.9; implementation_name!='cpython' --no-binary h5py
 h5py==2.9; implementation_name=='cpython'
 tables==3.4.4

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -129,14 +129,18 @@ class H5StoreTest(BaseH5StoreTest):
         'double_array': array('d', [-1.5, 0, 1.5]),
         'int_array': array('i', [-1, 0, 1]),
         'uint_array': array('I', [0, 1, 2]),
-        'numpy_float_array': numpy.array([-1.5, 0, 1.5], dtype=float),
-        'numpy_int_array': numpy.array([-1, 0, 1], dtype=int),
         'dict': {
             'a': 1,
             'b': None,
             'c': 'test',
         },
     }
+
+    if NUMPY:
+        valid_types.update({
+            'numpy_float_array': numpy.array([-1.5, 0, 1.5], dtype=float),
+            'numpy_int_array': numpy.array([-1, 0, 1], dtype=int),
+        })
 
     def test_init(self):
         self.get_h5store()


### PR DESCRIPTION
I have updated the circle-ci configuration to fix an issue with the pypy3 dependency installation, an issue with the implementation of the `H5StoreTest` test class, and am no longer executing benchmarks for pypy.

The latter is mostly because we are using the following command to execute the benchmark: `python benchmark.py ...`, however that should probably say `pypy3 benchmark.py ...`. I'm not sure if there is a good way to easily execute the benchmark with both platforms without too much duplication of the CI-configuration, I'm all for it.

Usually, I'd have just merged these commits without review, but because I am making a bunch of more intrusive changes, I'd appreciate some feedback.

**I'd prefer if this PR was not squashed prior to merge.**