### PR TITLE
Improve the reporting of benchmark results.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -383,7 +383,7 @@ def main_compare(args):
         s_speedup = "a maximal speedup of " + \
             click.style("{:0.1f}x".format(speedup[idx_max_speedup]), fg='green')
     else:
-        s_speedup = "no speedup"
+        s_speedup = "a maximal speedup of <10%"
 
     if round(difference[idx_max_slowdown], 1) < 0:
         max_slowdown = slowdown[idx_max_slowdown]
@@ -391,7 +391,7 @@ def main_compare(args):
             click.style("{:0.1f}x".format(slowdown[idx_max_slowdown]), fg='red')
     else:
         max_slowdown = 0
-        s_slowdown = "no slowdown"
+        s_slowdown = "a maximal slowdown of <10%"
 
     print("Revision '{this}' is {average_change} '{other}' on average "
           "with {speedup} and {slowdown}.".format(

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,3 +1,4 @@
+click>=7.0
 numpy==1.15
 GitPython==2.1.11
 pandas==0.25; implementation_name!='cpython' --no-binary pandas

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -53,6 +53,7 @@ class Job(object):
     KEY_DATA = 'signac_data'
 
     def __init__(self, project, statepoint, _id=None):
+        from time import sleep; sleep(0.0001)
         self._project = project
 
         # Set statepoint and id

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -53,7 +53,6 @@ class Job(object):
     KEY_DATA = 'signac_data'
 
     def __init__(self, project, statepoint, _id=None):
-        from time import sleep; sleep(0.0001)
         self._project = project
 
         # Set statepoint and id


### PR DESCRIPTION
The result message now better represents results when there is both
a speedup and a slowdown independent of the average speedup/slowdown.