### PR TITLE
Ignore deprecation warnings when testing

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -33,11 +33,6 @@ except ImportError:
 # Make sure the jobs created for this test are unique.
 test_token = {'test_token': str(uuid.uuid4())}
 
-warnings.simplefilter('default')
-warnings.filterwarnings('error', category=DeprecationWarning, module='signac')
-warnings.filterwarnings(
-    'ignore', category=PendingDeprecationWarning, message=r'.*Cache API.*')
-
 BUILTINS = [
     ({'e': [1.0, '1.0', 1, True]}, '4d8058a305b940005be419b30e99bb53'),
     ({'d': True}, '33cf9999de25a715a56339c6c1b28b41'),
@@ -85,7 +80,8 @@ class BaseJobTest(unittest.TestCase):
             name='testing_test_project',
             root=self._tmp_pr,
             workspace=self._tmp_wd)
-        self.project.config['default_host'] = 'testing'
+
+        warnings.filterwarnings('ignore', category=DeprecationWarning, module='signac')
 
     def tearDown(self):
         pass
@@ -519,42 +515,34 @@ class JobOpenAndClosingTest(BaseJobTest):
         self.assertEqual(job, job2)
 
     def test_open_job_close(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            with self.open_job(test_token) as job:
-                pass
-            job.remove()
+        with self.open_job(test_token) as job:
+            pass
+        job.remove()
 
     def test_open_job_close_manual(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            job = self.open_job(test_token)
-            job.open()
-            job.close()
-            job.remove()
+        job = self.open_job(test_token)
+        job.open()
+        job.close()
+        job.remove()
 
     def test_open_job_close_with_error(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            job = self.open_job(test_token)
+        job = self.open_job(test_token)
 
-            class TestError(Exception):
-                pass
-            with self.assertRaises(TestError):
-                with job:
-                    raise TestError()
-            job.remove()
+        class TestError(Exception):
+            pass
+        with self.assertRaises(TestError):
+            with job:
+                raise TestError()
+        job.remove()
 
     def test_reopen_job(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            with self.open_job(test_token) as job:
-                job_id = job.get_id()
-                self.assertEqual(str(job_id), str(job))
+        with self.open_job(test_token) as job:
+            job_id = job.get_id()
+            self.assertEqual(str(job_id), str(job))
 
-            with self.open_job(test_token) as job:
-                self.assertEqual(job.get_id(), job_id)
-            job.remove()
+        with self.open_job(test_token) as job:
+            self.assertEqual(job.get_id(), job_id)
+        job.remove()
 
     def test_close_nonopen_job(self):
         job = self.open_job(test_token)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -42,9 +42,6 @@ except ImportError:
 # Make sure the jobs created for this test are unique.
 test_token = {'test_token': str(uuid.uuid4())}
 
-warnings.simplefilter('default')
-warnings.filterwarnings('error', category=DeprecationWarning, module='signac')
-
 
 class BaseProjectTest(BaseJobTest):
     pass
@@ -251,17 +248,15 @@ class ProjectTest(BaseProjectTest):
         for sp in statepoints:
             self.project.open_job(sp).init()
         jobs = self.project.find_jobs()
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning, module='signac')
-            for i in range(2):  # run this twice
-                jobs_ = set()
-                for i in range(len(self.project)):
-                    job = jobs.next()
-                    self.assertIn(job, self.project)
-                    jobs_.add(job)
-                with self.assertRaises(StopIteration):
-                    job = jobs.next()
-                self.assertEqual(jobs_, set(self.project))
+        for i in range(2):  # run this twice
+            jobs_ = set()
+            for i in range(len(self.project)):
+                job = jobs.next()
+                self.assertIn(job, self.project)
+                jobs_.add(job)
+            with self.assertRaises(StopIteration):
+                job = jobs.next()
+            self.assertEqual(jobs_, set(self.project))
 
     def test_find_jobs_arithmetic_operators(self):
         for i in range(10):
@@ -1426,13 +1421,9 @@ class LinkedViewProjectTest(BaseProjectTest):
         subset = list(self.project.find_job_ids({'b': 0}))
         job_subset = [self.project.open_job(id=id) for id in subset]
 
-        # Catch deprecation warning for use of index.
-        with warnings.catch_warnings(record=True) as w:
-            bad_index = [dict(_id=i) for i in range(3)]
-            with self.assertRaises(ValueError):
-                self.project.create_linked_view(prefix=view_prefix, job_ids=subset, index=bad_index)
-            self.assertEqual(len(w), 1)
-            self.assertEqual(w[0].category, DeprecationWarning)
+        bad_index = [dict(_id=i) for i in range(3)]
+        with self.assertRaises(ValueError):
+            self.project.create_linked_view(prefix=view_prefix, job_ids=subset, index=bad_index)
 
         self.project.create_linked_view(prefix=view_prefix, job_ids=subset)
         all_links = list(_find_all_links(view_prefix))
@@ -1753,9 +1744,7 @@ class UpdateCacheAfterInitJob(signac.contrib.job.Job):
 
     def init(self, *args, **kwargs):
         super(UpdateCacheAfterInitJob, self).init(*args, **kwargs)
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=FutureWarning, module='signac')
-            self._project.update_cache()
+        self._project.update_cache()
 
 
 class UpdateCacheAfterInitJobProject(signac.Project):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Move warning settings to the `setUp` method. Remove old warning catching logic that is no longer actually catching any warnings.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The warning settings were currently having no effect on the tests since they're launched via the unittest module interface. The intended behavior was to cause all `DeprecationWarning`s to error out, which I don't think is the correct behavior because we shouldn't stop testing deprecated behavior until it's actually removed, so I changed the default to ignore `DeprecationWarning` instead and moved it into `setUp` so that it's actually respected. Some of the other warnings catching logic in specific tests was a holdover and is no longer relevant.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
