### PR TITLE
Fix/make project config immutable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,11 @@ Fixed
 
  - Attempting to create a linked view for a Project on Windows now raises an informative error message.
 
+Deprecated
+++++++++++
+
+ - Modifying the project config, to be removed in 2.0 (#246).
+
 Removed
 +++++++
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,7 +38,7 @@ Fixed
 Deprecated
 ++++++++++
 
- - Modifying the project config, to be removed in 2.0 (#246).
+ - In-memory modification of the project configuration, to be removed in 2.0 (#246).
 
 Removed
 +++++++

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -24,7 +24,7 @@ from ..core import json
 from ..core.jsondict import JSONDict
 from ..core.h5store import H5StoreManager
 from .collection import Collection
-from ..common.config import load_config
+from ..common.config import load_config, Config
 from ..sync import sync_projects
 from .job import Job
 from .hashing import calc_id
@@ -95,6 +95,15 @@ class JobSearchIndex(object):
         return self._collection._find(filter)
 
 
+class ProjectConfig(Config):
+    """Extends the project config to make it immutable."""
+    def __setitem__(self, key, value):
+        warnings.warn("Modifying the project configuration is deprecated "
+                      "behavior and will be removed in version 2.0.",
+                      DeprecationWarning)
+        return super(ProjectConfig, self).__setitem__(key, value)
+
+
 class Project(object):
     """The handle on a signac project.
 
@@ -120,7 +129,7 @@ class Project(object):
     def __init__(self, config=None):
         if config is None:
             config = load_config()
-        self._config = config
+        self._config = ProjectConfig(config)
 
         # Ensure that the project id is configured.
         self.get_id()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -95,11 +95,11 @@ class JobSearchIndex(object):
         return self._collection._find(filter)
 
 
-class ProjectConfig(Config):
+class _ProjectConfig(Config):
     """Extends the project config to make it immutable."""
     def __init__(self, *args, **kwargs):
         self._mutable = True
-        super(ProjectConfig, self).__init__(*args, **kwargs)
+        super(_ProjectConfig, self).__init__(*args, **kwargs)
         self._mutable = False
 
     def __setitem__(self, key, value):
@@ -111,7 +111,7 @@ class ProjectConfig(Config):
 
             from packaging import version
             assert version.parse(__version__) < version.parse("2.0")
-        return super(ProjectConfig, self).__setitem__(key, value)
+        return super(_ProjectConfig, self).__setitem__(key, value)
 
 
 class Project(object):
@@ -139,7 +139,7 @@ class Project(object):
     def __init__(self, config=None):
         if config is None:
             config = load_config()
-        self._config = ProjectConfig(config)
+        self._config = _ProjectConfig(config)
 
         # Ensure that the project id is configured.
         self.get_id()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -97,10 +97,15 @@ class JobSearchIndex(object):
 
 class ProjectConfig(Config):
     """Extends the project config to make it immutable."""
+    def __init__(self, *args, **kwargs):
+        self._mutable = True
+        super(ProjectConfig, self).__init__(*args, **kwargs)
+
     def __setitem__(self, key, value):
-        warnings.warn("Modifying the project configuration is deprecated "
-                      "behavior and will be removed in version 2.0.",
-                      DeprecationWarning)
+        if not self._mutable:
+            warnings.warn("Modifying the project configuration is deprecated "
+                          "behavior and will be removed in version 2.0.",
+                          DeprecationWarning)
         return super(ProjectConfig, self).__setitem__(key, value)
 
 
@@ -130,6 +135,7 @@ class Project(object):
         if config is None:
             config = load_config()
         self._config = ProjectConfig(config)
+        self._config._mutable = False
 
         # Ensure that the project id is configured.
         self.get_id()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -108,6 +108,9 @@ class ProjectConfig(Config):
                           "initialization is deprecated as of version 1.3 and "
                           "will be removed in version 2.0.",
                           DeprecationWarning)
+
+            from packaging import version
+            assert version.parse(__version__) < version.parse("2.0")
         return super(ProjectConfig, self).__setitem__(key, value)
 
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -100,11 +100,13 @@ class ProjectConfig(Config):
     def __init__(self, *args, **kwargs):
         self._mutable = True
         super(ProjectConfig, self).__init__(*args, **kwargs)
+        self._mutable = False
 
     def __setitem__(self, key, value):
         if not self._mutable:
-            warnings.warn("Modifying the project configuration is deprecated "
-                          "behavior and will be removed in version 2.0.",
+            warnings.warn("Modifying the project configuration after project "
+                          "initialization is deprecated as of version 1.3 and "
+                          "will be removed in version 2.0.",
                           DeprecationWarning)
         return super(ProjectConfig, self).__setitem__(key, value)
 
@@ -135,7 +137,6 @@ class Project(object):
         if config is None:
             config = load_config()
         self._config = ProjectConfig(config)
-        self._config._mutable = False
 
         # Ensure that the project id is configured.
         self.get_id()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -74,6 +74,12 @@ class ProjectTest(BaseProjectTest):
     def test_workspace_directory(self):
         self.assertEqual(self._tmp_wd, self.project.workspace())
 
+    def test_config_modification(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.project.config['foo'] = 'bar'
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].category, DeprecationWarning)
+
     def test_workspace_directory_with_env_variable(self):
         os.environ['SIGNAC_ENV_DIR_TEST'] = self._tmp_wd
         self.project.config['workspace_dir'] = '${SIGNAC_ENV_DIR_TEST}'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,6 +75,10 @@ class ProjectTest(BaseProjectTest):
         self.assertEqual(self._tmp_wd, self.project.workspace())
 
     def test_config_modification(self):
+        # In-memory modification of the project configuration is
+        # deprecated as of 1.3, and will be removed in version 2.0.
+        # This unit test should reflect that change beginning 2.0,
+        # and check that the project configuration is immutable.
         with warnings.catch_warnings(record=True) as w:
             self.project.config['foo'] = 'bar'
             self.assertEqual(len(w), 1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Makes the project config immutable. Note that I had to make the `_mutable` attribute set after construction because the constructor of `ConfigObj` calls `__setitem__` internally, so constructing the `ProjectConfig` object would always throw warnings (or error in the future). I'm open to alternative suggestions on how to resolve that.

## Motivation and Context
Resolves #81, supersedes #244 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [x] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
