### PR TITLE
Use Config class to write config during init_project.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ Fixed
 +++++
 
  - Attempting to create a linked view for a Project on Windows now raises an informative error message.
+ - Project configuration is initialized using ConfigObj, allowing the configuration to include commas and special characters (#251, #252).
 
 Deprecated
 ++++++++++

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -24,7 +24,7 @@ from ..core import json
 from ..core.jsondict import JSONDict
 from ..core.h5store import H5StoreManager
 from .collection import Collection
-from ..common.config import load_config, Config
+from ..common.config import get_config, load_config, Config
 from ..sync import sync_projects
 from .job import Job
 from .hashing import calc_id
@@ -1461,10 +1461,11 @@ class Project(object):
             fn_config = os.path.join(root, 'signac.rc')
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
-            with open(fn_config, 'a') as config_file:
-                config_file.write('project={}\n'.format(name))
-                if workspace is not None:
-                    config_file.write('workspace_dir={}\n'.format(workspace))
+            config = get_config(fn_config)
+            config['project'] = name
+            if workspace is not None:
+                config['workspace_dir'] = workspace
+            config.write()
             project = cls.get_project(root=root)
             assert project.get_id() == str(name)
             return project

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -9,6 +9,7 @@ import logging
 import itertools
 import json
 import pickle
+import string
 from tarfile import TarFile
 from zipfile import ZipFile
 from tempfile import TemporaryDirectory
@@ -1793,6 +1794,14 @@ class ProjectInitTest(unittest.TestCase):
         self.assertEqual(project.get_id(), 'testproject')
         self.assertEqual(project.workspace(), os.path.join(root, 'workspace'))
         self.assertEqual(project.root_directory(), root)
+
+    def test_get_project_all_printable_characters(self):
+        root = self._tmp_dir.name
+        with self.assertRaises(LookupError):
+            signac.get_project(root=root)
+        project_name = 'testproject' + string.printable
+        project = signac.init_project(name=project_name, root=root)
+        self.assertEqual(project.get_id(), project_name)
 
     def test_get_project_non_local(self):
         root = self._tmp_dir.name


### PR DESCRIPTION
## Description
This uses the `Config` class (not to be confused with the new immutable `_ProjectConfig` class or the `ConfigObj` class from which it inherits) to initialize projects.

**Potential breaking behavior:** The `signac.rc` files generated after this change will differ from the previous configuration files by whitespace (spaces around the equals signs). The configs are parsed the same as before.

## Motivation and Context
The previous code didn't work if the project name contained commas. Resolves #251.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>
<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt).
