### PR TITLE
Fix/tarfile import long sp

### DIFF
--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -538,11 +538,23 @@ class _CopyFromTarFileExecutor(object):
         return _copy_to_job_workspace(self.src, self.job, shutil.copytree)
 
 
+def _tarfile_path_join(path, fn):
+    """Replacement for os.path.join that always uses forward slashes.
+
+    Due to this bug in Python tarfile https://bugs.python.org/issue21987 we may
+    or may not have a trailing backslash in the provided path. Rather than
+    checking the exact length, which could lead to backwards incompatibilities,
+    we simply strip trailing slashes and always add them back.
+    """
+    path = path.rstrip('/')
+    return path + '/' + fn
+
+
 def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
 
     def read_sp_manifest_file(path):
         # Must use forward slashes, not os.path.sep.
-        fn_manifest = path + '/' + project.Job.FN_MANIFEST
+        fn_manifest = _tarfile_path_join(path, project.Job.FN_MANIFEST)
         try:
             with closing(tarfile.extractfile(fn_manifest)) as file:
                 if sys.version_info < (3, 6):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1096,8 +1096,8 @@ class ProjectExportImportTest(BaseProjectTest):
         """Test the behavior of tarfile export when the path is >100 chars."""
         target = os.path.join(self._tmp_dir.name, 'data.tar.gz')
         val_length = 100
-        self.project.open_job(dict(a='1'*val_length, b='1'*val_length)).init()
-        self.project.open_job(dict(a='2'*val_length, b='2'*val_length)).init()
+        self.project.open_job(dict(a='1'*val_length)).init()
+        self.project.open_job(dict(a='2'*val_length)).init()
         self.project.export_to(target=target)
         # Jobs are always copied, not moved, when writing to a tarfile, so we
         # must remove them manually to ensure that they're regenerated.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1092,6 +1092,20 @@ class ProjectExportImportTest(BaseProjectTest):
         self.assertEqual(len(self.project), 10)
         self.assertEqual(ids_before_export, list(sorted(self.project.find_job_ids())))
 
+    def test_export_import_tarfile_zipped_longname(self):
+        """Test the behavior of tarfile export when the path is >100 chars."""
+        target = os.path.join(self._tmp_dir.name, 'data.tar.gz')
+        val_length = 100
+        self.project.open_job(dict(a='1'*val_length, b='1'*val_length)).init()
+        self.project.open_job(dict(a='2'*val_length, b='2'*val_length)).init()
+        self.project.export_to(target=target)
+        # Jobs are always copied, not moved, when writing to a tarfile, so we
+        # must remove them manually to ensure that they're regenerated.
+        for job in self.project:
+            job.remove()
+        self.project.import_from(origin=target)
+        self.assertEqual(len(self.project), 2)
+
     def test_export_import_tarfile_zipped(self):
         target = os.path.join(self._tmp_dir.name, 'data.tar.gz')
         for i in range(10):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
As detailed [here](https://bugs.python.org/issue21987), Python tarfiles have inconsistent behavior with respect to trailing backslashes depending on the length of the path. As a result, exporting a signac data space to a tarball and reimporting that data space fails (it simply ignores certain jobs) if the paths are too long because the schema function fails. The issue was introduced by #266 because we are no longer using `os.path.join`, which introduces backward slashes on Windows for tarballs even though those paths actually use forward slashes, but did correctly handle the trailing backslash.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This issue was picked up in development of signac-flow, where the issue arises because the template testing introduces some very long names. It needs to be fixed because tests on signac-flow are using signac master.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
