### PR TITLE
Fixed race condition when workspace is created. Resolves #267

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,11 @@ Fixed
 
  - Fixed issues on Windows with ``H5Store``, project import/export, and operations that move files (#264, #266).
 
+Changed
++++++++
+
+ - Workspace directory is created with ``Project`` instance (#231267 #271).
+
 
 [1.3.0] -- 2019-12-20
 ---------------------
@@ -36,7 +41,7 @@ Added
 Changed
 +++++++
 
- - Implemented ``Project.__contains__`` check in constant time (#231).
+ - Implemented ``Project.__contains__`` check in constant time (#267, #271).
 
 Fixed
 +++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,12 +14,18 @@ Added
 +++++
 
  - Added Windows to platforms tested with continuous integration (#264, #266).
+ 
+Changed
++++++++
+
+ - Workspace directory is created when ``Project`` is initialized (#267, #271).
+
 
 Fixed
 +++++
 
  - Fixed issues on Windows with ``H5Store``, project import/export, and operations that move files (#264, #266).
- - Workspace directory is created when ``Project`` is initialized (#267, #271).
+
 
 
 [1.3.0] -- 2019-12-20

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ Fixed
 Changed
 +++++++
 
- - Workspace directory is created with ``Project`` instance (#231267 #271).
+ - Workspace directory is created with ``Project`` instance (#267, #271).
 
 
 [1.3.0] -- 2019-12-20
@@ -41,7 +41,7 @@ Added
 Changed
 +++++++
 
- - Implemented ``Project.__contains__`` check in constant time (#267, #271).
+ - Implemented ``Project.__contains__`` check in constant time (#231).
 
 Fixed
 +++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,11 +19,7 @@ Fixed
 +++++
 
  - Fixed issues on Windows with ``H5Store``, project import/export, and operations that move files (#264, #266).
-
-Changed
-+++++++
-
- - Workspace directory is created with ``Project`` instance (#267, #271).
+ - Workspace directory is created when ``Project`` is initialized (#267, #271).
 
 
 [1.3.0] -- 2019-12-20

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -76,4 +76,8 @@ contributors:
     given-names: Brandon
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0001-7739-7796"
+  -
+    family-names: Sharma
+    given-names: Vishav
+    affiliation: "National Institute of Technology, Hamirpur"
 ...

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -163,7 +163,7 @@ class Project(object):
             except OSError:
                 logger.error(
                     "Error occurred while trying to create "
-                    "workspace directory for project {}".format(self.id))
+                    "workspace directory for project {}.".format(self.id))
                 raise 
 
         # Internal caches

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -164,6 +164,7 @@ class Project(object):
                 logger.error(
                     "Error occurred while trying to create "
                     "workspace directory for project {}".format(self.id))
+                raise 
 
         # Internal caches
         self._index_cache = dict()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -162,7 +162,7 @@ class Project(object):
                 _mkdir_p(self._wd)
             except OSError:
                 logger.error(
-                    "Error occured while trying to create "
+                    "Error occurred while trying to create "
                     "workspace directory for project {}".format(self.id))
 
         # Internal caches

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -164,7 +164,7 @@ class Project(object):
                 logger.error(
                     "Error occurred while trying to create "
                     "workspace directory for project {}.".format(self.id))
-                raise 
+                raise
 
         # Internal caches
         self._index_cache = dict()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -155,14 +155,15 @@ class Project(object):
         # Prepare project document
         self._fn_doc = os.path.join(self._rd, self.FN_DOCUMENT)
         self._document = None
-        
-        # Prepare Workspace Directory 
+
+        # Prepare Workspace Directory
         if not os.path.isdir(self._wd):
             try:
                 _mkdir_p(self._wd)
             except OSError:
-                logger.error("Error occured while trying to create "
-                         "workspace directory for project {}".format(self.id))
+                logger.error(
+                    "Error occured while trying to create "
+                    "workspace directory for project {}".format(self.id))
 
         # Internal caches
         self._index_cache = dict()

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -155,6 +155,14 @@ class Project(object):
         # Prepare project document
         self._fn_doc = os.path.join(self._rd, self.FN_DOCUMENT)
         self._document = None
+        
+        # Prepare Workspace Directory 
+        if not os.path.isdir(self._wd):
+            try:
+                _mkdir_p(self._wd)
+            except OSError:
+                logger.error("Error occured while trying to create "
+                         "workspace directory for project {}".format(self.id))
 
         # Internal caches
         self._index_cache = dict()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -98,6 +98,11 @@ class ProjectTest(BaseProjectTest):
         self.project.config['workspace_dir'] = '${SIGNAC_ENV_DIR_TEST}'
         self.assertEqual(self._tmp_wd, self.project.workspace())
 
+    def test_workspace_directory_exists(self):
+        root = self._tmp_dir.name
+        project_ = Project.init_project('Project_w', os.path.join(root, 'w'))
+        self.assertTrue(os.path.exists(project_.workspace()))
+
     def test_fn(self):
         self.assertEqual(
             self.project.fn('test/abc'),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -214,7 +214,8 @@ class ProjectTest(BaseProjectTest):
             norm_path(os.path.join(self.project.root_directory(), self.project.workspace())))
 
     def test_no_workspace_warn_on_find(self):
-        self.assertFalse(os.path.exists(self.project.workspace()))
+        if os.path.exists(self.project.workspace()):
+            os.rmdir(self.project.workspace())
         with self.assertLogs(level='INFO') as cm:
             list(self.project.find_jobs())
             # Python < 3.8 will return 2 messages.
@@ -234,6 +235,8 @@ class ProjectTest(BaseProjectTest):
     def test_workspace_read_only_path(self):
         # Create file where workspace would be, thus preventing the creation
         # of the workspace directory.
+        if os.path.exists(self.project.workspace()):
+            os.rmdir(self.project.workspace())
         with open(os.path.join(self.project.workspace()), 'w'):
             pass
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -99,9 +99,7 @@ class ProjectTest(BaseProjectTest):
         self.assertEqual(self._tmp_wd, self.project.workspace())
 
     def test_workspace_directory_exists(self):
-        root = self._tmp_dir.name
-        project_ = Project.init_project('Project_w', os.path.join(root, 'w'))
-        self.assertTrue(os.path.exists(project_.workspace()))
+        self.assertTrue(os.path.exists(self.project.workspace()))
 
     def test_fn(self):
         self.assertEqual(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Project initialization add a empty Workspace directory if deleted by user.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Solves issue #267 .

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


