### PR TITLE
Consolidate .coveragerc into setup.cfg.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-source=signac
-omit=
-    signac/common/configobj/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,13 @@ python-tag = py3
 max-line-length = 100
 exclude = configobj,passlib,cite.py,conf.py
 
+[coverage:run]
+source = signac
+omit =
+    signac/common/configobj/*.py
+
 [tool:pytest]
-filterwarnings = 
+filterwarnings =
 	ignore: .*[The indexing module | get_statepoint] is deprecated.*: DeprecationWarning
 
 [bumpversion:file:setup.py]


### PR DESCRIPTION
## Description
Small package maintenance improvement. We use `setup.cfg` for all supported tools (flake8, bumpversion) except for coverage. This consolidates `.coveragerc` into `setup.cfg`.