### PR TITLE
Don't enforce dictionary ordering in signac diff.

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -263,7 +263,9 @@ class TestBasicShell():
         job_b.init()
         out = self.call('python -m signac diff {} {}'.format(job_a.id, job_b.id).split())
         expected = [str(job_a.id), "{'b': 1}", str(job_b.id), "{'b': 0}"]
-        assert out.strip().split(os.linesep) == expected
+        outputs = out.strip().split(os.linesep)
+        for line in expected:
+            assert line in outputs
 
     def test_clone(self):
         self.call('python -m signac init ProjectA'.split())

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -264,8 +264,7 @@ class TestBasicShell():
         out = self.call('python -m signac diff {} {}'.format(job_a.id, job_b.id).split())
         expected = [str(job_a.id), "{'b': 1}", str(job_b.id), "{'b': 0}"]
         outputs = out.strip().split(os.linesep)
-        for line in expected:
-            assert line in outputs
+        assert set(expected) == set(outputs)
 
     def test_clone(self):
         self.call('python -m signac init ProjectA'.split())


### PR DESCRIPTION
## Description
See #311. A test relied on dictionary order for its output, which failed randomly on Python 3.5.

## Motivation and Context
Resolves #311.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
