### PR TITLE
Use mongodb as optional index for statepoints and job docs

### DIFF
--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -38,6 +38,7 @@ from .diff import diff_jobs
 from .db import get_database
 from .core.jsondict import buffer_reads_writes as buffered
 from .core.jsondict import in_buffered_mode as is_buffered
+from .core.pymongodict import buffer_pymongo_reads_writes as pymongo_buffered
 from .core.jsondict import flush_all as flush
 from .core.jsondict import get_buffer_size
 from .core.jsondict import get_buffer_load
@@ -60,6 +61,7 @@ __all__ = ['__version__', 'contrib', 'db', 'errors', 'warnings', 'sync',
            'MasterCrawler',
            'SignacProjectCrawler',
            'buffered', 'is_buffered', 'flush', 'get_buffer_size', 'get_buffer_load',
+           'pymongo_buffered',
            'JSONDict',
            'H5Store', 'H5StoreManager',
            'testing',

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -238,7 +238,7 @@ def main_project(args):
         _print_err("Created access module '{}'.".format(fn))
         return
     if args.index:
-        for doc in project.index():
+        for doc in project.index_from_workspace():
             print(json.dumps(doc))
         return
     if args.workspace:

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -414,7 +414,9 @@ def main_init(args):
     project = init_project(
         name=args.project_id,
         root=os.getcwd(),
-        workspace=args.workspace)
+        workspace=args.workspace,
+        index_host=args.index_host,
+        index_db=args.index_db)
     _print_err("Initialized project '{}'.".format(project))
 
 
@@ -1111,6 +1113,16 @@ def main():
         type=str,
         default='workspace',
         help="The path to the workspace directory.")
+    parser_init.add_argument(
+        '-H', '--index-host',
+        type=str,
+        default=None,
+        help="The database host containing the index.")
+    parser_init.add_argument(
+        '-D', '--index-db',
+        type=str,
+        default=None,
+        help="The name of the database containing the index.")
     parser_init.set_defaults(func=main_init)
 
     parser_project = subparsers.add_parser('project')

--- a/signac/common/connection.py
+++ b/signac/common/connection.py
@@ -49,8 +49,6 @@ def raise_unsupported_auth_mechanism(mechanism):
     raise ValueError(msg.format(mechanism))
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The connection module is deprecated.")
 class DBClientConnector(object):
 
     def __init__(self, host_config, **kwargs):

--- a/signac/common/host.py
+++ b/signac/common/host.py
@@ -5,7 +5,6 @@ import logging
 import warnings
 import getpass
 
-from ..version import __version__
 from ..core import json
 from .config import load_config
 from .errors import ConfigError, AuthenticationError
@@ -17,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 SESSION_PASSWORD_HASH_CACHE = SimpleKeyring()
 SESSION_USERNAME_CACHE = dict()  # type: ignore
+
 
 def get_default_host(config=None):
     if config is None:

--- a/signac/common/host.py
+++ b/signac/common/host.py
@@ -5,7 +5,6 @@ import logging
 import warnings
 import getpass
 
-from deprecation import deprecated
 from ..version import __version__
 from ..core import json
 from .config import load_config
@@ -19,13 +18,6 @@ logger = logging.getLogger(__name__)
 SESSION_PASSWORD_HASH_CACHE = SimpleKeyring()
 SESSION_USERNAME_CACHE = dict()  # type: ignore
 
-"""
-THIS MODULE IS DEPRECATED!
-"""
-
-
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_default_host(config=None):
     if config is None:
         config = load_config()
@@ -45,8 +37,6 @@ def _get_host_config(hostname, config):
         raise ConfigError("Host '{}' not configured.".format(hostname))
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_host_config(hostname=None, config=None):
     if config is None:
         config = load_config()
@@ -59,8 +49,6 @@ def _host_id(hostcfg):
     return json.dumps(hostcfg, sort_keys=True)
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def make_uri(hostcfg):
     ret = hostcfg['url']
     if ret.startswith('mongodb://'):
@@ -127,8 +115,6 @@ def _get_credentials(hostcfg):
     return _get_cached_credentials(hostcfg, default)
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_credentials(hostcfg, ask=True):
     if ask:
         return _get_credentials(hostcfg)
@@ -147,8 +133,6 @@ def _input(prompt, default=''):
         return default
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def check_credentials(hostcfg):
     from pymongo.uri_parser import parse_uri
     auth_m = hostcfg.get('auth_mechanism', 'none')
@@ -170,14 +154,10 @@ def check_credentials(hostcfg):
     return hostcfg
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_connector(hostcfg, **kwargs):
     return DBClientConnector(hostcfg, **kwargs)
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_client(hostcfg, **kwargs):
     connector = get_connector(hostcfg, **kwargs)
     connector.connect()
@@ -185,8 +165,6 @@ def get_client(hostcfg, **kwargs):
     return connector.client
 
 
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The host module is deprecated.")
 def get_database(name, hostname=None, config=None, **kwargs):
     if hostname is None:
         hostname = get_default_host(config)

--- a/signac/common/host.py
+++ b/signac/common/host.py
@@ -8,7 +8,6 @@ import getpass
 from ..core import json
 from .config import load_config
 from .errors import ConfigError, AuthenticationError
-from .connection import DBClientConnector
 from .crypt import get_crypt_context, SimpleKeyring, get_keyring
 
 logger = logging.getLogger(__name__)
@@ -155,6 +154,8 @@ def check_credentials(hostcfg):
 
 
 def get_connector(hostcfg, **kwargs):
+    # lazy import
+    from .connection import DBClientConnector
     return DBClientConnector(hostcfg, **kwargs)
 
 

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -41,7 +41,6 @@ def get_validator():
 cfg = """
 project = string()
 workspace_dir = string(default='workspace')
-index_host = string()
 schema_version = string(default='1')
 
 [General]

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -41,6 +41,7 @@ def get_validator():
 cfg = """
 project = string()
 workspace_dir = string(default='workspace')
+index_host = string()
 schema_version = string(default='1')
 
 [General]

--- a/signac/contrib/indexing.py
+++ b/signac/contrib/indexing.py
@@ -525,7 +525,7 @@ class MasterCrawler(BaseCrawler):
 
         if not has_tags and _is_blank_module(module):
             from .project import get_project
-            for doc in get_project(root=dirpath).index():
+            for doc in get_project(root=dirpath).index_from_workspace():
                 yield doc
 
         if hasattr(module, 'get_indexes'):

--- a/signac/contrib/indexing.py
+++ b/signac/contrib/indexing.py
@@ -469,7 +469,7 @@ class MasterCrawler(BaseCrawler):
         import signac
 
         def get_indexes(root):
-            yield signac.get_project(root).index()
+            yield signac.get_project(root).index_from_workspace()
 
     Tags for indexes yielded from the `get_indexes()` function can be specified
     by assigning them directly to the function:
@@ -477,7 +477,7 @@ class MasterCrawler(BaseCrawler):
     .. code-block:: python
 
         def get_indexes(root):
-            yield signac.get_project(root).index()
+            yield signac.get_project(root).index_from_workspace()
 
         get_indexes.tags = {'foo'}
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -381,10 +381,15 @@ class Job(object):
 
     def add(self):
         """Adds the statepoint to the database index, if one exists.
+        :returns: self if job didn't exist in collection, otherwise None
         """
         if self._project.db is not None:
-            mongodb_doc = {'_id': self._id, 'statepoint': self._statepoint}
-            self._project.index_collection.insert_one(mongodb_doc)
+            mongodb_doc = {'$set': {'statepoint': self._statepoint}}
+            result = self._project.index_collection.update_one({'_id': self._id}, mongodb_doc, upsert=True)
+            if result.upserted_id is not None:
+                return job
+            else:
+                return None
 
     def init(self, force=False):
         """Initialize the job's workspace directory.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -180,14 +180,16 @@ class Project(object):
             'statepoint_cache_miss_warning_threshold', 500)
 
         self.db = None
-        hostname = config['index_host']
+        hostname = None
+        if 'index_host' in config:
+            hostname = config['index_host']
         if hostname is not None:
-            db_name = config['index_db']
-            if db_name is None:
+            if 'index_db' not in config:
                 raise ConfigError("When using a db host for the index, specify " +
                                   "the database, too.")
 
             # open the database connection
+            db_name = config['index_db']
             self.db = database.get_database(db_name, hostname=hostname)
 
             # 'index' is the default name for the collection

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -46,7 +46,7 @@ JOB_ID_REGEX = re.compile('[a-f0-9]{32}')
 ACCESS_MODULE_MINIMAL = """import signac
 
 def get_indexes(root):
-    yield signac.get_project(root).index()
+    yield signac.get_project(root).index_from_workspace()
 """
 
 ACCESS_MODULE_MASTER = """#!/usr/bin/env python
@@ -54,7 +54,7 @@ ACCESS_MODULE_MASTER = """#!/usr/bin/env python
 import signac
 
 def get_indexes(root):
-    yield signac.get_project(root).index()
+    yield signac.get_project(root).index_from_workspace()
 
 if __name__ == '__main__':
     with signac.Collection.open('index.txt') as index:
@@ -1449,7 +1449,7 @@ class Project(object):
 
         .. code-block:: python
 
-            for doc in project.index({r'.*\.txt', 'TextFile'}):
+            for doc in project.index_from_workspace({r'.*\.txt', 'TextFile'}):
                 print(doc)
 
         :param formats: The format definitions as mapping.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1216,7 +1216,6 @@ class Project(object):
         jobs = []
         if self.db is not None:
             from pymongo import UpdateOne
-            from pymongo.errors import BulkWriteError
             ops = []
 
             for sp in statepoints:
@@ -1226,7 +1225,7 @@ class Project(object):
                 jobs.append(job)
 
             # execute bulk query
-            self.index_collection.bulk_write(ops)
+            self.index_collection.bulk_write(ops, ordered=False)
         else:
             for sp in statepoints:
                 job = self.open_job(sp)

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -184,11 +184,11 @@ class Project(object):
         if hostname is not None:
             db_name = config['index_db']
             if db_name is None:
-                raise ConfigError("When using a db host for the index, specify "+
+                raise ConfigError("When using a db host for the index, specify " +
                                   "the database, too.")
 
             # open the database connection
-            self.db = database.get_database(db_name,hostname=hostname)
+            self.db = database.get_database(db_name, hostname=hostname)
 
             # 'index' is the default name for the collection
             self.index_collection = self.db.index
@@ -1338,7 +1338,7 @@ class Project(object):
                             raise
             yield doc
 
-    def _build_index_pymongo(self,collection):
+    def _build_index_pymongo(self, collection):
         """
         Generate a state point index from a pymongo collection.
         """
@@ -1346,7 +1346,6 @@ class Project(object):
         # Fetch all documents from the collection called 'index'
         for doc in collection.find():
             yield doc
-
 
     def _update_in_memory_cache(self):
         "Update the in-memory state point cache to reflect the workspace."
@@ -1438,7 +1437,7 @@ class Project(object):
             return cache
 
     def index_from_workspace(self, formats=None, depth=0,
-              skip_errors=False, include_job_document=True):
+                             skip_errors=False, include_job_document=True):
         r"""Generate an index of the project's workspace.
 
         This generator function indexes every file in the project's

--- a/signac/core/attrdict.py
+++ b/signac/core/attrdict.py
@@ -15,7 +15,13 @@ class SyncedAttrDict(_SyncedDict):
         ad = SyncedAttrDict(nested_dict)
         assert ad.a.b == 0
     """
-    _PROTECTED_KEYS = ('_data', '_suspend_sync_', '_load', '_save')
+
+    _PROTECTED_KEYS = ['_data', '_suspend_sync_', '_load', '_save']
+
+    def __init__(self, initialdata=None, parent=None, protected_keys=None):
+        if isinstance(protected_keys, list):
+            self._PROTECTED_KEYS += protected_keys
+        super(SyncedAttrDict, self).__init__(initialdata=initialdata, parent=parent)
 
     def __getattr__(self, name):
         try:

--- a/signac/core/pymongodict.py
+++ b/signac/core/pymongodict.py
@@ -3,8 +3,10 @@
 # This software is licensed under the BSD 3-Clause License.
 """Dict implementation with pymongo backend."""
 
-from ..db import database
 from .attrdict import SyncedAttrDict
+from collections.abc import Mapping
+from copy import copy
+
 
 class PyMongoDict(SyncedAttrDict):
     """A dict-like mapping interface to pymongo document.

--- a/signac/core/pymongodict.py
+++ b/signac/core/pymongodict.py
@@ -82,4 +82,9 @@ class PyMongoDict(SyncedAttrDict):
         if data is None:
             data = self._as_dict()
 
-        self._collection.update_one({'_id': self._jobid}, {'$set': {'doc': data}})
+        update_query = {}
+        for key in data.keys():
+            update_query['doc'+'.'+key] = data[key]
+
+        if update_query:
+            self._collection.update_one({'_id': self._jobid}, {'$set': update_query})

--- a/signac/core/pymongodict.py
+++ b/signac/core/pymongodict.py
@@ -6,7 +6,241 @@
 from .attrdict import SyncedAttrDict
 from collections.abc import Mapping
 from copy import copy
+import datetime
+import hashlib
+from contextlib import contextmanager
+import sys
+import json
 
+import logging
+
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError
+from .jsondict import BufferException
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUFFER_SIZE = 32 * 2**20    # 32 MB
+
+# a dictionary of (collection_name, PyMongoBufer) pairs
+_PYMONGO_BUFFERS = dict()
+
+def _hash(blob):
+    """Calculate and return the md5 hash value for the file data."""
+    if blob is not None:
+        # create an oredered dict through json
+        json_str = json.dumps(blob, sort_keys=True)
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+class BufferedDocumentError(BufferException):
+    """Raised when an error occured while flushing one or more buffered documents
+
+    .. attribute:: jobids
+
+        A dictionary of jobids that caused issues during the flush operation,
+        mapped to a possible reason for the issue or None in case that it
+        cannot be determined.
+    """
+
+    def __init__(self, jobids):
+        self.jobids = jobids
+
+    def __str__(self):
+        return "{}({})".format(type(self).__name__, self.jobids)
+
+class PyMongoBuffer:
+    """A cache for aggregating update queries to a collection
+       into a single bulk_write operation.
+    """
+
+    def __init__(self, collection):
+        self.collection = collection
+        self.buffered_mode = True
+        self.buffered_mode_force_write = None
+        self.buffer_size = None
+        self.update_buffer_size = None
+        self.buf = dict()
+        self.update_buf = dict()
+        self.hashes = dict()
+        self.meta = dict()
+
+    def _get_document_metadata(self, jobid):
+        doc = self.collection.find_one(jobid)
+
+        if 'doc_last_modified' in doc:
+            return doc['doc_last_modified']
+        else:
+            return None
+
+    def _store_in_buffer(self, jobid, blob, store_hash=False):
+        assert self.buffered_mode
+        blob_size = sys.getsizeof(blob)
+        buffer_load = self.get_buffer_load()
+        if self.buffer_size > 0:
+            if blob_size > self.buffer_size:
+                return False
+            elif blob_size + buffer_load > self.buffer_size:
+                logger.debug("Buffer overflow, flushing...")
+                self.flush_all()
+
+        self.buf[jobid] = blob
+        if store_hash:
+            if not self.buffered_mode_force_write:
+                self.meta[jobid] = self._get_document_metadata(jobid)
+            self.hashes[jobid] = _hash(blob)
+        return True
+
+    def _store_in_update_buffer(self,jobid, blob):
+        assert self.buffered_mode
+        blob_size = sys.getsizeof(blob)
+        buffer_load = self.get_update_buffer_load()
+        if self.update_buffer_size > 0:
+            if blob_size > self.update_buffer_size:
+                return False
+            elif blob_size + buffer_load > self.update_buffer_size:
+                logger.debug("Write-through buffer overflow, flushing...")
+                self.flush_all()
+
+        # store this update operation
+        if jobid in self.update_buf:
+            self.update_buf[jobid].update(blob)
+        else:
+            self.update_buf[jobid] = blob
+        return True
+
+    def flush_all(self):
+        """Execute all deferred PyMongoDict write operations."""
+        logger.debug("Flushing buffer...")
+        issues = dict()
+        jobids = []
+        time_current = datetime.datetime.utcnow()
+
+        update_blobs = dict()
+        while self.buf:
+            jobid, blob = self.buf.popitem()
+            if not self.buffered_mode_force_write:
+                meta = self.meta.pop(jobid)
+
+            # if there's data in the write cache, update current blob
+            if jobid in self.update_buf:
+                blob.update(self.update_buf.pop(jobid))
+            updated = _hash(blob) != self.hashes.pop(jobid)
+
+            if updated:
+                if not self.buffered_mode_force_write:
+                    new_meta = self._get_document_metadata(jobid)
+                    if new_meta is not None and new_meta != meta:
+                        print(meta,new_meta)
+                        issues[jobid] = 'job document in '+ str(self.collection) + ' appears to have been externally modified.'
+                        continue
+                update_blobs[jobid] = blob
+
+        if issues:
+            raise BufferedDocumentError(issues)
+
+        # now go through the partial updates without local info
+        while self.update_buf:
+            jobid, blob = self.update_buf.popitem()
+            update_blobs[jobid] = blob
+
+        # construct the query
+        ops = []
+        for jobid,blob in update_blobs.items():
+            update_query = {}
+            for key,val in blob.items():
+                update_query['doc'+'.'+key] = val
+            update_query['doc_last_modified'] = time_current
+            ops.append(UpdateOne({'_id': jobid}, {'$set': update_query}))
+
+        if len(ops):
+            try:
+                # submit the query as a parallel bulk write operation
+                self.collection.bulk_write(ops,ordered=False)
+            except BulkWriteError:
+                logger.error(str(error))
+                raise
+
+    def get_buffer_size(self):
+        """Return the current maximum size of the read/write buffer."""
+        return self.buffer_size
+
+    def get_buffer_load(self):
+        """Return the current actual size of the read/write buffer."""
+        return sum((sys.getsizeof(x) for x in self.buf.values()))
+
+    def get_update_buffer_size(self):
+        """Return the current maximum size of the read/write buffer."""
+        return self.update_buffer_size
+
+    def get_update_buffer_load(self):
+        """Return the current actual size of the read/write buffer."""
+        return sum((sys.getsizeof(x) for x in self.update_buf.values()))
+
+    def in_buffered_mode(self):
+        """Return true if in buffered read/write mode."""
+        return self.buffered_mode
+
+
+@contextmanager
+def buffer_pymongo_reads_writes(project, buffer_size=DEFAULT_BUFFER_SIZE,
+                                update_buffer_size=DEFAULT_BUFFER_SIZE,
+                                force_write=False):
+    """Enter a global buffer mode for all PyMongoDict instances.
+
+    All future write operations are written to the buffer, read
+    operations are performed from the buffer whenever possible.
+
+    All write operations are deferred until the flush_all() function
+    is called, the buffer overflows, or upon exiting the buffer mode.
+
+    This context may be entered multiple times, however the buffer size
+    can only be set *once*. Any subsequent specifications of the buffer
+    size are ignored.
+
+    :param buffer_size:
+        Specify the maximum size of the read/write buffer. Defaults
+        to DEFAULT_BUFFER_SIZE. A negative number indicates to not
+        restrict the buffer size.
+    :type buffer_size:
+        int
+    :type force_write:
+        bool, if True, do not check timestamps upon editing the documents.
+        This can further speed up large numbers of edits, but doesn't
+        detect if the document has been update simultaneously by other procesees
+
+    """
+
+    global _PYMONGO_BUFFERS
+
+    if project.db is None:
+        raise BufferException('PyMongo buffered mode requires that the project is configured '
+                              'with an index database.')
+
+    assert project.index_collection is not None
+
+    collection_name = project.index_collection.full_name
+
+    if collection_name in _PYMONGO_BUFFERS:
+        raise BufferException('There alreads exists a buffer context for collection '.format(collection_name))
+
+    # Basic type check (to prevent common user error)
+    if not isinstance(buffer_size, int) or \
+            buffer_size is True or buffer_size is False:    # explicit check against boolean
+        raise TypeError("The buffer size must be an integer!")
+
+    # instantiate the cache pointing to this collection
+    buf = _PYMONGO_BUFFERS[collection_name] = PyMongoBuffer(project.index_collection)
+
+    buf.buffer_size = buffer_size
+    buf.update_buffer_size = update_buffer_size
+    buf.buffered_mode_force_write = force_write
+
+    try:
+        yield
+    finally:
+        buf.flush_all()
+        del _PYMONGO_BUFFERS[collection_name]
 
 class PyMongoDict(SyncedAttrDict):
     """A dict-like mapping interface to pymongo document.
@@ -46,7 +280,8 @@ class PyMongoDict(SyncedAttrDict):
                 "parent or collection/jobid must be None, but not both.")
         self._collection = collection
         self._jobid = jobid
-        super(PyMongoDict, self).__init__(parent=parent)
+        self._deleted_keys = []
+        super(PyMongoDict, self).__init__(parent=parent, protected_keys=['_jobid','_deleted_keys','_collection'])
 
     def reset(self, data):
         """Replace the document contents with data."""
@@ -65,26 +300,94 @@ class PyMongoDict(SyncedAttrDict):
         else:
             raise ValueError("The document must be a mapping.")
 
-    def _load(self):
-        assert self._collection is not None
-        assert self._jobid is not None
+    def _load_from_db(self):
+        logger.debug("Loading document for job {} from {}".format(self._jobid, repr(self._collection)))
         pymongo_doc = self._collection.find_one({'_id': self._jobid})
         if 'doc' in pymongo_doc:
             return pymongo_doc['doc']
         else:
             return dict()
 
-    def _save(self):
+    def _load(self):
         assert self._collection is not None
         assert self._jobid is not None
 
-        data = self._data
+        collection_name = self._collection.full_name
+
+        if collection_name in _PYMONGO_BUFFERS:
+            buf = _PYMONGO_BUFFERS[collection_name]
+            if self._jobid in buf.buf:
+                # Load from buffer:
+                blob = buf.buf[self._jobid]
+            else:
+                # Load from db and store in buffer
+                blob = self._load_from_db()
+                buf._store_in_buffer(self._jobid, blob, store_hash=True)
+
+            # if any updates are pending in the cache, update the blob just loaded
+            if self._jobid in buf.update_buf:
+                blob.update(buf.update_buf.pop(self._jobid))
+                buf._store_in_buffer(self._jobid, blob, store_hash=False)
+
+            return blob
+        else:
+            return self._load_from_db()
+
+    def _save(self, data=None):
+        assert self._collection is not None
+        assert self._jobid is not None
+
         if data is None:
             data = self._as_dict()
 
-        update_query = {}
-        for key in data.keys():
-            update_query['doc'+'.'+key] = data[key]
+        collection_name = self._collection.full_name
 
-        if update_query:
-            self._collection.update_one({'_id': self._jobid}, {'$set': update_query})
+        have_cache = collection_name in _PYMONGO_BUFFERS
+        do_sync = not have_cache or len(self._deleted_keys) > 0
+
+        if do_sync:
+            # in synchronous mode it doesn't matter if we have partial information,
+            # as pymongo will only update select fields anyway
+            update_query = {}
+            for key in data.keys():
+                update_query['doc'+'.'+key] = data[key]
+            update_query['doc_last_modified'] = datetime.datetime.utcnow()
+
+            delete_query = {}
+            for key in self._deleted_keys:
+                delete_query['doc'+'.'+key] = None
+            self._deleted_keys = []
+
+            query = {}
+            if update_query:
+                query['$set'] = update_query
+            if delete_query:
+                query['$unset'] = delete_query
+            if len(query):
+                logger.debug("Updating job {} in {}".format(self._jobid, repr(self._collection)))
+                self._collection.update_one({'_id': self._jobid}, query)
+
+        if collection_name in _PYMONGO_BUFFERS:
+            buf = _PYMONGO_BUFFERS[collection_name]
+
+            # update the buffered object
+            buf._store_in_buffer(self._jobid, data, store_hash=do_sync)
+
+
+    def __delitem__(self, key):
+        # store the key in a list for later removal from the collection
+        self._deleted_keys += [key]
+
+        # this will trigger a load()/save()
+        super(PyMongoDict, self).__delitem__(key)
+
+    def __setitem__(self, key, value):
+        # a special codepath for __setitem__ ensures we can directly write through to the cache
+        have_cache = self._collection is not None and self._collection.full_name in _PYMONGO_BUFFERS
+        if  have_cache:
+            buf = _PYMONGO_BUFFERS[self._collection.full_name]
+            buf._store_in_update_buffer(self._jobid, {key: value})
+            return value
+        else:
+            super(PyMongoDict, self).__setitem__(key, value)
+

--- a/signac/core/pymongodict.py
+++ b/signac/core/pymongodict.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2020 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Dict implementation with pymongo backend."""
+
+from ..db import database
+from .attrdict import SyncedAttrDict
+
+class PyMongoDict(SyncedAttrDict):
+    """A dict-like mapping interface to pymongo document.
+
+    .. code-block:: python
+
+        db = get_database('test', 'myhost')
+        doc = PyMongoDict(db.my_collection, jobid)
+        doc['foo'] = "bar"
+        assert doc.foo == doc['foo'] == "bar"
+        assert 'foo' in doc
+        del doc['foo']
+
+    This class allows access to values through key indexing or attributes
+    named by keys, including nested keys:
+
+    .. code-block:: python
+
+        >>> doc['foo'] = dict(bar=True)
+        >>> doc
+        {'foo': {'bar': True}}
+        >>> doc.foo.bar = False
+        {'foo': {'bar': False}}
+
+    :param collection:
+        A handle to a :class:py:`pymongo.collection.Collection` object.
+    :param jobid:
+        A unique identifier for the pymongo document containing the job doc
+    :param parent:
+        A parent instance of PyMongoDic or None.
+    """
+
+    def __init__(self, collection=None, jobid=None, parent=None):
+        if (collection is None or jobid is None) == (parent is None):
+            raise ValueError(
+                "Illegal argument combination, one of "
+                "parent or collection/jobid must be None, but not both.")
+        self._collection = collection
+        self._jobid = jobid
+        super(PyMongoDict, self).__init__(parent=parent)
+
+    def reset(self, data):
+        """Replace the document contents with data."""
+        if isinstance(data, Mapping):
+            with self._suspend_sync():
+                backup = copy(self._data)
+                try:
+                    self._data = {
+                        self._validate_key(k): self._dfs_convert(v)
+                        for k, v in data.items()
+                    }
+                    self._save()
+                except BaseException:  # rollback
+                    self._data = backup
+                    raise
+        else:
+            raise ValueError("The document must be a mapping.")
+
+    def _load(self):
+        assert self._collection is not None
+        assert self._jobid is not None
+        pymongo_doc = self._collection.find_one({'_id': self._jobid})
+        if 'doc' in pymongo_doc:
+            return pymongo_doc['doc']
+        else:
+            return dict()
+
+    def _save(self):
+        assert self._collection is not None
+        assert self._jobid is not None
+
+        data = self._data
+        if data is None:
+            data = self._as_dict()
+
+        self._collection.update_one({'_id': self._jobid}, {'$set': {'doc': data}})

--- a/signac/db/__init__.py
+++ b/signac/db/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     warnings.warn("Failed to import pymongo. "
                   "get_database will not be available.", ImportWarning)
 
-    def get_database(*args, **kwargs):
+    def get_database(name, hostname=None, config=None):
         """Get a database handle.
 
         This function is only available if pymongo is installed."""

--- a/signac/db/database.py
+++ b/signac/db/database.py
@@ -2,8 +2,7 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 from ..common import host
-from deprecation import deprecated
-from ..version import __version__
+
 
 def get_database(name, hostname=None, config=None):
     """Get a database handle.

--- a/signac/db/database.py
+++ b/signac/db/database.py
@@ -5,13 +5,6 @@ from ..common import host
 from deprecation import deprecated
 from ..version import __version__
 
-"""
-THIS MODULE IS DEPRECATED!
-"""
-
-
-@deprecated(deprecated_in="1.3", removed_in="2.0", current_version=__version__,
-            details="The database package is deprecated.")
 def get_database(name, hostname=None, config=None):
     """Get a database handle.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -297,7 +297,7 @@ class TestProject(TestProjectBase):
             assert 0 == len(list(self.project.find_job_ids(doc_filter={'b': 5})))
             for job_id in self.project.find_job_ids():
                 assert self.project.open_job(id=job_id).id == job_id
-            index = list(self.project.index())
+            index = list(self.project.index_from_workspace())
             for job_id in self.project.find_job_ids(index=index):
                 assert self.project.open_job(id=job_id).id == job_id
 
@@ -545,15 +545,15 @@ class TestProject(TestProjectBase):
             logging.disable(logging.NOTSET)
 
     def test_index(self):
-        docs = list(self.project.index(include_job_document=True))
+        docs = list(self.project.index_from_workspace(include_job_document=True))
         assert len(docs) == 0
-        docs = list(self.project.index(include_job_document=False))
+        docs = list(self.project.index_from_workspace(include_job_document=False))
         assert len(docs) == 0
         statepoints = [{'a': i} for i in range(5)]
         for sp in statepoints:
             self.project.open_job(sp).document['test'] = True
         job_ids = set((job.id for job in self.project.find_jobs()))
-        docs = list(self.project.index())
+        docs = list(self.project.index_from_workspace())
         job_ids_cmp = set((doc['_id'] for doc in docs))
         assert job_ids == job_ids_cmp
         assert len(docs) == len(statepoints)
@@ -561,7 +561,7 @@ class TestProject(TestProjectBase):
             with self.project.open_job(sp):
                 with open('test.txt', 'w'):
                     pass
-        docs = list(self.project.index({'.*' + re.escape(os.path.sep) + r'test\.txt': 'TextFile'}))
+        docs = list(self.project.index_from_workspace({'.*' + re.escape(os.path.sep) + r'test\.txt': 'TextFile'}))
         assert len(docs) == 2 * len(statepoints)
         assert len(set((doc['_id'] for doc in docs))) == len(docs)
 
@@ -571,7 +571,7 @@ class TestProject(TestProjectBase):
             self.project.open_job(sp).document['test'] = True
         job_ids = set((job.id for job in self.project.find_jobs()))
         index = dict()
-        for doc in self.project.index():
+        for doc in self.project.index_from_workspace():
             index[doc['_id']] = doc
         assert len(index) == len(job_ids)
         assert set(index.keys()) == set(job_ids)
@@ -588,7 +588,7 @@ class TestProject(TestProjectBase):
                 file.write('test\n')
         formats = {r'.*' + re.escape(os.path.sep) + r'test\.txt': 'TextFile'}
         index = dict()
-        for doc in self.project.index(formats):
+        for doc in self.project.index_from_workspace(formats):
             index[doc['_id']] = doc
         assert len(index) == 2 * len(job_ids)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -561,7 +561,8 @@ class TestProject(TestProjectBase):
             with self.project.open_job(sp):
                 with open('test.txt', 'w'):
                     pass
-        docs = list(self.project.index_from_workspace({'.*' + re.escape(os.path.sep) + r'test\.txt': 'TextFile'}))
+        docs = list(self.project.index_from_workspace({'.*' + re.escape(os.path.sep) +
+                                                       r'test\.txt': 'TextFile'}))
         assert len(docs) == 2 * len(statepoints)
         assert len(set((doc['_id'] for doc in docs))) == len(docs)
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -149,8 +149,8 @@ class TestBasicShell():
         project.open_job({'a': 0}).init()
         assert len(project) == 1
         with pytest.deprecated_call():
-            assert len(list(project.index())) == 1
-            assert len(list(signac.index())) == 1
+            assert len(list(project.index_from_workspace())) == 1
+            assert len(list(signac.index_from_workspace())) == 1
         doc = json.loads(self.call('python -m signac index'.split()))
         assert 'statepoint' in doc
         assert doc['statepoint'] == {'a': 0}

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -150,7 +150,7 @@ class TestBasicShell():
         assert len(project) == 1
         with pytest.deprecated_call():
             assert len(list(project.index_from_workspace())) == 1
-            assert len(list(signac.index_from_workspace())) == 1
+            assert len(list(signac.index())) == 1
         doc = json.loads(self.call('python -m signac index'.split()))
         assert 'statepoint' in doc
         assert doc['statepoint'] == {'a': 0}


### PR DESCRIPTION
## Description

Use `mongodb` as an optional backend (*via* pymongo). Store state points and job docs in the database instead of creating a directory for every statepoint. Local workspaces are still created by calling `job.open()` explicitly. Jobs are added to the database only with `job.add()`.

To enable the database backend, configure a database host (`myhost`) as described [here](https://docs.signac.io/en/latest/configuration.html#host-configuration) and put these variables into the configuration (`signac.rc`):

```
index_host = myhost
index_db = signac
```

## Motivation and Context
We aim to overcome a scalability issue in signac for large indices (>100,000), when the file system limits the number of subdirectories, i.e. state points, to be created. By decoupling state points from local workspace directories, distributed workers could e.g. create those directories on node-local flash memory as needed for a subset of the entire workspace, while connecting to the central database to store and retrieve job information.

A reference implementation using `mongodb` as a persistent backend on an OLCF OpenShift cluster is underway (actually, figuring out how to allow network access to the cluster took most of the time, rather than implementing these changes :-), which follow ideas by @csadorf.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
