### PR TITLE
Apply fixes from minirst.

### DIFF
--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -56,7 +56,7 @@ def _flatten(container):
     Parameters
     ----------
     container :
-            list/tuple of elements.
+        list/tuple of elements.
 
     Yields
     ------
@@ -313,7 +313,6 @@ def _check_logical_operator_argument(op, argument):
     ----------
     op : str
         logical-operator.
-
     argument : list
         list of arguments for logical-operator.
 

--- a/signac/contrib/filterparse.py
+++ b/signac/contrib/filterparse.py
@@ -46,7 +46,6 @@ def _read_index(project, fn_index=None):
     ----------
     project : :class:`~signac.Project`
         Project handle.
-
     fn_index : str
         File name of the index (Default value = None).
 
@@ -167,7 +166,6 @@ def _parse_simple(key, value=None):
     ----------
     key : str
         The filter key.
-
     value :
         The filter value. If None, the filter returns
         True if the provided key exists (Default value = None).
@@ -204,7 +202,6 @@ def parse_filter_arg(args, file=sys.stderr):
     ----------
     args : sequence of str
         Filter arguments to parse.
-
     file :
         The file to write message (Default value = sys.stderr).
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -519,7 +519,6 @@ def _convert_schema_path_to_regex(schema_path):
     schema_path : str
         Path of schema.
 
-
     Returns
     -------
     schema_regex : str
@@ -614,7 +613,6 @@ def _with_consistency_check(schema_function, read_sp_manifest_file):
     ----------
     schema_function : callable
         Schema function.
-
     read_sp_manifest_file : callable
         Function to read state point manifest.
 

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -29,6 +29,12 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     path :
         The path (function) used to structure the linked data space (Default value = None).
 
+    Returns
+    -------
+    dict
+        A dictionary that maps the source directory paths to the linked
+        directory paths.
+
     Raises
     ------
     OSError
@@ -38,12 +44,6 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
         When the selected data space is provided with an insufficient index.
     RuntimeError
         When state points contain [os.sep, " ", "*"].
-
-    Returns
-    -------
-    dict
-        A dictionary that maps the source directory paths to the linked
-        directory paths.
 
     """
     from .import_export import _make_path_function

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -225,8 +225,8 @@ def _find_all_links(root, leaf='job'):
         The name of the leaf directories in the view
         directory tree (Default value = 'job').
 
-    Yield
-    -----
+    Yields
+    ------
     str
         Relative path to root from ``leaf``.
 
@@ -305,8 +305,8 @@ def _get_branches(root, branch=None):
         used in recursive calls to build up the branches starting
         at the root (Default value = None).
 
-    Yield
-    -----
+    Yields
+    ------
     list
         Branches for the root node.
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -2756,12 +2756,12 @@ def get_job(root=None):
     LookupError
         If this job cannot be found.
 
-    For example, when the current directory is a job workspace directory:
+    Examples
+    --------
+    When the current directory is a job workspace directory:
 
-    .. code-block:: python
-
-        >>> signac.get_job()
-        signac.contrib.job.Job(project=..., statepoint={...})
+    >>> signac.get_job()
+    signac.contrib.job.Job(project=..., statepoint={...})
 
     """
     return Project.get_job(root=root)

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -2722,7 +2722,6 @@ def get_project(root=None, search=True, **kwargs):
     **kwargs :
         Forwarded to :meth:`~signac.Project.get_project`.
 
-
     Returns
     -------
     :class:`~signac.Project`

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -93,18 +93,18 @@ def prompt_password(prompt='Password: '):
 def add_verbosity_argument(parser, default=0):
     """Add a verbosity argument to parser.
 
-    Notes
-    -----
-    The argument is '-v' or '--verbosity'.
-    Add multiple '-v' arguments, e.g. '-vv' or '-vvv' to
-    increase the level of verbosity.
-
     Parameters
     ----------
     parser : :class:`argparse.ArgumentParser`
         The parser to which to add a verbosity argument.
     default : int
         The default level, defaults to 0.
+
+    Notes
+    -----
+    The argument is '-v' or '--verbosity'.
+    Add multiple '-v' arguments, e.g. '-vv' or '-vvv' to
+    increase the level of verbosity.
 
     """
     parser.add_argument(
@@ -120,18 +120,18 @@ def add_verbosity_argument(parser, default=0):
 def add_verbosity_action_argument(parser, default=0):
     """Add a verbosity argument to parser.
 
-    Notes
-    -----
-    The argument is '-v'.
-    Add multiple '-v' arguments, e.g. '-vv' or '-vvv' to
-    increase the level of verbosity.
-
     Parameters
     ----------
     parser : :class:`argparse.ArgumentParser`
         The parser to which to add a verbosity argument.
     default :
         The default level, defaults to 0.
+
+    Notes
+    -----
+    The argument is '-v'.
+    Add multiple '-v' arguments, e.g. '-vv' or '-vvv' to
+    increase the level of verbosity.
 
     """
     parser.add_argument(
@@ -155,7 +155,7 @@ def set_verbosity_level(verbosity, default=None, increment=10):
     default :
         The default verbosity level, defaults to logging.ERROR.
     increment :
-         (Default value = 10).
+        (Default value = 10).
 
     """
     if default is None:
@@ -215,7 +215,6 @@ def walkdepth(path, depth=0):
     ----------
     path :str
         Directory passed to walk (transverse from).
-
     depth : int
         (Default value = 0)
 


### PR DESCRIPTION
## Description
I used a very early-stage tool from @Carreau to lint our NumPy docstrings. https://github.com/Carreau/minirst

It found a few errors in the docstring style. A later-stage "stable" version of this tool could be a helpful CI linter. I will merge this PR immediately when CI passes because the changes are minor.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update