### PR TITLE
DOC: Autoreformat doc to confrm to numpydoc.

### DIFF
--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -157,7 +157,7 @@ class _TypedSetDefaultDict(dict):
         ----------
         key : str, float
             The key to get the value.
-        default :
+        default
             Default value if type of key is not float (Default value = None).
 
         Returns
@@ -241,7 +241,7 @@ def _find_with_index_operator(index, op, argument):
         Index for the operator.
     op : str
         logical operator.
-    argument :
+    argument
         Dependent on the choice of logical operator argument (op).
         For better understanding have a look at :meth:`~Collection.find`.
 
@@ -761,7 +761,7 @@ class Collection(object):
         ----------
         key : str
             The key for expression-operator.
-        value :
+        value
             The value for expression-operator.
 
         Returns
@@ -1166,7 +1166,7 @@ class Collection(object):
 
         Parameters
         ----------
-        text_buffer :
+        text_buffer
             The file to write the content serialized to JSON (Default value = sys.stdout).
 
         """
@@ -1189,7 +1189,7 @@ class Collection(object):
 
         Parameters
         ----------
-        file :
+        file
             The file to write the encoded blob to (Default value = sys.stdout).
 
         """
@@ -1212,7 +1212,7 @@ class Collection(object):
 
         Parameters
         ----------
-        file :
+        file
             The filename or a file-like object to write the JSON string to (Default value = None).
 
         Returns
@@ -1236,7 +1236,7 @@ class Collection(object):
 
         Parameters
         ----------
-        file :
+        file
             The json file to read, provided as either a filename or a
             file-like object (Default value = None).
 
@@ -1259,7 +1259,7 @@ class Collection(object):
 
         Parameters
         ----------
-        file :
+        file
             The file to read the documents from or create the file if it does not exist.
         compresslevel : int
             The level of compression to use. Any positive value

--- a/signac/contrib/filterparse.py
+++ b/signac/contrib/filterparse.py
@@ -26,7 +26,7 @@ def _with_message(query, file):
     ----------
     query : dict
         Filter arguments.
-    file :
+    file
         The file where the filter interpretation is printed.
 
     Returns
@@ -166,7 +166,7 @@ def _parse_simple(key, value=None):
     ----------
     key : str
         The filter key.
-    value :
+    value
         The filter value. If None, the filter returns
         True if the provided key exists (Default value = None).
 
@@ -202,7 +202,7 @@ def parse_filter_arg(args, file=sys.stderr):
     ----------
     args : sequence of str
         Filter arguments to parse.
-    file :
+    file
         The file to write message (Default value = sys.stderr).
 
     Returns

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -125,12 +125,10 @@ class _AutoPathFormatter(Formatter):
 
         Parameters
         ----------
-        value :
+        value
             The value to be formatted.
-
-        format_spec :
+        format_spec
             The format specification.
-
 
         Returns
         -------

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -231,7 +231,7 @@ class Job(object):
         ----------
         update : dict
             A mapping used for the state point update.
-        overwrite :
+        overwrite
             Set to true, to ignore whether this update overwrites parameters,
             which are currently part of the job's state point.
             Use with caution! (Default value = False)
@@ -610,23 +610,22 @@ class Job(object):
         ----------
         other : Job
             The other job to synchronize from.
-        strategy :
+        strategy
             A synchronization strategy for file conflicts. If no strategy is provided, a
             :class:`~signac.errors.SyncConflict` exception will be raised upon conflict
             (Default value = None).
         exclude : str
             An filename exclude pattern. All files matching this pattern will be
             excluded from synchronization (Default value = None).
-        doc_sync :
+        doc_sync
             A synchronization strategy for document keys. If this argument is None, by default
             no keys will be synchronized upon conflict.
-        dry_run :
+        dry_run
             If True, do not actually perform the synchronization.
-        kwargs :
+        kwargs
             Extra keyword arguments will be forward to the :meth:`~signac.sync.sync_jobs`
             function which actually excutes the synchronization operation.
-        **kwargs :
-
+        **kwargs
 
         Raises
         ------

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -24,9 +24,9 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     job_ids : iterable
         If None (the default), create the view for the complete data space,
         otherwise only for this iterable of job ids.
-    index :
+    index
         A document index (Default value = None).
-    path :
+    path
         The path (function) used to structure the linked data space (Default value = None).
 
     Returns

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -700,7 +700,7 @@ class Project(object):
         ----------
         index : list
             A document index.
-        _trust :
+        _trust
             (Default value = False).
 
         Returns
@@ -744,7 +744,6 @@ class Project(object):
                          2: {'3a530c13bfaf57517b4e81ecab6aec7f'},
                          3: {'5c2658722218d48a5eb1e0ef7c26240b'}})
 
-
         Values that are constant over the complete data space can be optionally
         ignored with the `exclude_const` argument set to True.
 
@@ -753,7 +752,7 @@ class Project(object):
         exclude_const : bool
             Exclude entries that are shared by all jobs
             that are part of the index (Default value = False).
-        index :
+        index
             A document index.
 
         Yields
@@ -777,10 +776,10 @@ class Project(object):
         exclude_const : bool
             Exclude all state point keys that are shared by all jobs within this project
             (Default value = False).
-        subset :
+        subset
             A sequence of jobs or job ids specifying a subset over which the state point
             schema should be detected (Default value = None).
-        index :
+        index
             A document index (Default value = None).
 
         Returns
@@ -818,7 +817,7 @@ class Project(object):
         doc_filter : dict
             A mapping of key-value pairs that all
             indexed job documents are compared against (Default value = None).
-        index :
+        index
              A document index. If not provided, an index will be computed
             (Default value = None).
 
@@ -853,10 +852,10 @@ class Project(object):
         filter : Mapping
             A mapping of key-value pairs that all indexed job state points are
             compared against (Default value = None).
-        doc_filter :
+        doc_filter
             A mapping of key-value pairs that all indexed job documents are
             compared against (Default value = None).
-        index :
+        index
             A document index. If not provided, an index will be computed
             (Default value = None).
 
@@ -958,7 +957,7 @@ class Project(object):
             The state point grouping parameter(s) passed as a string,
             iterable of strings, or a callable that will be passed one
             argument, the job (Default value = None).
-        default :
+        default
             A default value to be used when a given state point key is not present (must
             be sortable).
 
@@ -1005,7 +1004,7 @@ class Project(object):
             The state point grouping parameter(s) passed as a string, iterable of strings,
             or a function that will be passed one argument, :meth:`~signac.job.Job.document`.
             (Default value = None).
-        default :
+        default
             A default value to be used when a given state point key is not present (must
             be sortable).
 
@@ -1020,9 +1019,8 @@ class Project(object):
 
         Parameters
         ----------
-        *args :
-
-        **kwargs :
+        *args
+        **kwargs
 
         Returns
         -------
@@ -1281,9 +1279,9 @@ class Project(object):
         job_ids : iterable
             If None (the default), create the view for the complete data space,
             otherwise only for this iterable of job ids.
-        index :
+        index
             A document index (Default value = None).
-        path :
+        path
             The path (function) used to structure the linked data space (Default value = None).
 
         Returns
@@ -1345,7 +1343,7 @@ class Project(object):
             The job whose state point shall be updated.
         update : mapping
             A mapping used for the state point update.
-        overwrite :
+        overwrite
             Set to true to ignore whether this update overwrites parameters,
             which are currently part of the job's state point. Use with caution!
             (Default value = False).
@@ -1372,8 +1370,8 @@ class Project(object):
         ----------
         job : :class:`~signac.contrib.job.Job`
             The job to copy into this project.
-        copytree :
-             (Default value = syncutil.copytree)
+        copytree
+            (Default value = syncutil.copytree)
 
         Returns
         -------
@@ -1410,16 +1408,16 @@ class Project(object):
         ----------
         other : :class:`~signac.Project`
             The other project to synchronize this project with.
-        strategy :
+        strategy
             A file synchronization strategy (Default value = None).
-        exclude :
+        exclude
             Files with names matching the given pattern will be excluded
             from the synchronization (Default value = None).
-        doc_sync :
+        doc_sync
             The function applied for synchronizing documents (Default value = None).
-        selection :
+        selection
             Only sync the given jobs (Default value = None).
-        **kwargs :
+        **kwargs
             This method also accepts the same keyword arguments as the
             :meth:`~signac.sync.sync_projects` function.
 
@@ -1497,18 +1495,18 @@ class Project(object):
 
         Parameters
         ----------
-        target :
+        target
             A path to a directory to export to. The target can not already exist.
             Besides directories, possible targets are tar files (`.tar`), gzipped tar files
             (`.tar.gz`), zip files (`.zip`), bzip2-compressed files (`.bz2`),
             and xz-compressed files (`.xz`).
-        path :
+        path
             The path (function) used to structure the exported data space.
             This argument must either be a callable which returns a path (str) as a function
             of `job`, a string where fields are replaced using the job-state point dictionary,
             or `False`, which means that we just use the job-id as path.
             Defaults to the equivalent of ``{{auto}}``.
-        copytree :
+        copytree
             The function used for the actual copying of directory tree
             structures. Defaults to :func:`shutil.copytree`.
             Can only be used when the target is a directory.
@@ -1553,18 +1551,18 @@ class Project(object):
 
         Parameters
         ----------
-        origin :
+        origin
             The path to the data space origin, which is to be imported. This may be a path to
             a directory, a zip file, or a tarball archive (Default value = None).
-        schema :
+        schema
             An optional schema function, which is either a string or a function that accepts a
             path as its first and only argument and returns the corresponding state point as dict.
             (Default value = None).
-        sync :
+        sync
             If ``True``, the project will be synchronized with the imported data space. If a
             dict of keyword arguments is provided, the arguments will be used for
             :meth:`~signac.Project.sync` (Default value = None).
-        copytree :
+        copytree
             Specify which exact function to use for the actual copytree operation.
             Defaults to :func:`shutil.copytree`.
 
@@ -1625,9 +1623,9 @@ class Project(object):
         fn_statepoints : str
             The filename of the file containing the state points, defaults
             to :attr:`~signac.Project.FN_STATEPOINTS`.
-        index :
+        index
             A document index (Default value = None).
-        job_ids :
+        job_ids
             An iterable of job ids that should get repaired. Defaults to all jobs.
 
         Raises
@@ -1719,7 +1717,7 @@ class Project(object):
 
         Parameters
         ----------
-        include_job_document :
+        include_job_document
             Whether to include the job document in the index (Default value =
             False).
 
@@ -2064,7 +2062,7 @@ class Project(object):
             the specified root directory, otherwise only return projects
             with a root directory identical to the specified root argument
             (Default value = True).
-        \*\*kwargs :
+        \*\*kwargs
             Optional keyword arguments that are forwarded to the
             :class:`.Project` class constructor.
 
@@ -2151,10 +2149,10 @@ def TemporaryProject(name=None, cls=None, **kwargs):
     name : str
         An optional name for the temporary project.
         Defaults to a unique random string.
-    cls :
+    cls
         The class of the temporary project.
         Defaults to :class:`~signac.Project`.
-    \*\*kwargs :
+    \*\*kwargs
         Optional keyword arguments that are forwarded to the TemporaryDirectory class
         constructor, which is used to create a temporary root directory.
 
@@ -2310,7 +2308,7 @@ class JobsCursor(object):
         key : str, iterable, or function
             The state point grouping parameter(s) passed as a string, iterable of strings,
             or a function that will be passed one argument, the job (Default value = None).
-        default :
+        default
             A default value to be used when a given state point key is not present (must
             be sortable).
 
@@ -2348,7 +2346,6 @@ class JobsCursor(object):
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
 
-
                     Returns
                     -------
                     State point value corresponding to the key.
@@ -2371,12 +2368,10 @@ class JobsCursor(object):
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
 
-
                     Returns
                     -------
                     tuple
                         State point values.
-
 
                     """
                     return tuple(job.sp[k] for k in key)
@@ -2390,7 +2385,6 @@ class JobsCursor(object):
                     ----------
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
-
 
                     Returns
                     -------
@@ -2456,7 +2450,7 @@ class JobsCursor(object):
             The state point grouping parameter(s) passed as a string, iterable of strings,
             or a function that will be passed one argument, :meth:`~signac.job.Job.document`.
             (Default value = None).
-        default :
+        default
             A default value to be used when a given state point key is not present (must
             be sortable).
 
@@ -2470,7 +2464,6 @@ class JobsCursor(object):
                     ----------
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
-
 
                     Returns
                     -------
@@ -2489,7 +2482,6 @@ class JobsCursor(object):
                     job : class:`~signac.contrib.job.Job`
                         The job instance.
 
-
                     Returns
                     -------
                     Document value corresponding to the key.
@@ -2506,7 +2498,6 @@ class JobsCursor(object):
                     ----------
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
-
 
                     Returns
                     -------
@@ -2525,7 +2516,6 @@ class JobsCursor(object):
                     ----------
                     job : :class:`~signac.contrib.job.Job`
                         The job instance.
-
 
                     Returns
                     -------
@@ -2574,7 +2564,8 @@ class JobsCursor(object):
 
         See Also
         --------
-        :meth:`~signac.Project.export_to` : For full details on how to use this function.
+        :meth:`~signac.Project.export_to`
+            For full details on how to use this function.
 
         Parameters
         ----------
@@ -2771,7 +2762,7 @@ def get_project(root=None, search=True, **kwargs):
         specified root directory, otherwise only return projects with a root
         directory identical to the specified root argument (Default value =
         True).
-    \*\*kwargs :
+    \*\*kwargs
         Optional keyword arguments that are forwarded to
         :meth:`~signac.Project.get_project`.
 

--- a/signac/contrib/schema.py
+++ b/signac/contrib/schema.py
@@ -26,7 +26,7 @@ def _collect_by_type(values):
 
     Parameters
     ----------
-    values :
+    values
         An iterable of values.
 
     Returns
@@ -48,7 +48,7 @@ def _build_job_statepoint_index(exclude_const, index):
     ----------
     exclude_const : bool
         Excludes state point keys whose values are constant across the index.
-    index :
+    index
         An iterable of state points.
 
     Yields
@@ -78,7 +78,7 @@ def _build_job_statepoint_index(exclude_const, index):
 
         Parameters
         ----------
-        x :
+        x
             Dictionary from which ``_DictPlaceholder`` values will be removed.
 
         Returns
@@ -118,7 +118,7 @@ class ProjectSchema(object):
 
         Parameters
         ----------
-        statepoint_index :
+        statepoint_index
             State point index.
 
         Returns
@@ -158,7 +158,7 @@ class ProjectSchema(object):
 
             Parameters
             ----------
-            x :
+            x
                 Value to convert to string.
 
             Returns
@@ -181,7 +181,7 @@ class ProjectSchema(object):
             ----------
             type_ : type
                 Type of values.
-            values :
+            values
                 An iterable of values.
 
             Returns
@@ -210,7 +210,7 @@ class ProjectSchema(object):
 
             Parameters
             ----------
-            values :
+            values
                 An iterable of values.
 
             Returns
@@ -321,7 +321,7 @@ class ProjectSchema(object):
 
         Parameters
         ----------
-        jobs_or_statepoints :
+        jobs_or_statepoints
             An iterable of jobs or state points.
 
         Returns

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -124,7 +124,7 @@ def add_verbosity_action_argument(parser, default=0):
     ----------
     parser : :class:`argparse.ArgumentParser`
         The parser to which to add a verbosity argument.
-    default :
+    default
         The default level, defaults to 0.
 
     Notes
@@ -150,11 +150,11 @@ def set_verbosity_level(verbosity, default=None, increment=10):
 
     Parameters
     ----------
-    verbosity :
+    verbosity
         The verbosity level as integer.
-    default :
+    default
         The default verbosity level, defaults to logging.ERROR.
-    increment :
+    increment
         (Default value = 10).
 
     """
@@ -213,7 +213,7 @@ def walkdepth(path, depth=0):
 
     Parameters
     ----------
-    path :str
+    path : str
         Directory passed to walk (transverse from).
     depth : int
         (Default value = 0)
@@ -275,7 +275,7 @@ def split_and_print_progress(iterable, num_chunks=10, write=None, desc='Progress
         List of values to be chunked.
     num_chunks : int
         Number of chunks to split the given iterable (Default value = 10).
-    write :
+    write
         Logging level used to log messages (Default value = None).
     desc : str
         Prefix of message to log (Default value = 'Progress: ').
@@ -411,7 +411,7 @@ def _encode_tree(x):
 
     Parameters
     ----------
-    x :
+    x
         type to encode.
 
     Returns
@@ -432,7 +432,7 @@ def _nested_dicts_to_dotted_keys(t, encode=_encode_tree, key=None):
     ----------
     t : dict
         A mapping instance with nested dicts, e.g. {'a': {'b': 'c'}}.
-    encode :
+    encode
         By default, values are encoded to be hashable. Use ``None`` to skip encoding.
     key : str
         Key of root at current point in the recursion, used to

--- a/signac/syncutil.py
+++ b/signac/syncutil.py
@@ -38,7 +38,7 @@ def copytree(src, dst, copy_function=shutil.copy2, symlinks=False):
         Source directory tree.
     dst : str
         Destination directory tree.
-    copy_function :
+    copy_function
         Function used to copy (Default value = ``shutil.copy2``).
     symlinks : bool
         Whether to copy symlinks (Default value = False).


### PR DESCRIPTION
One thing which is misparsed by numpydoc is

         Returns
         -------
    -    NoneType or :class:`~signac.sync.FileTransferStats`
    +    NoneType or : class:`~signac.sync.FileTransferStats`
             Returns stats if ``collect_stats`` is ``True``, else ``None``.

Which I of course did not add; So that might be a bug in NumPyDoc.

Partial work toward #344

## Types of Changes

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>


## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.