### PR TITLE
Fix/dot format bug

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -571,17 +571,14 @@ def main_sync(args):
         only_in_src = diff_src.difference(diff_dst)
         diff_value = diff_src.intersection(diff_dst)
         if only_in_src:
-            keys_formatted = ('.'.join(k) for k in only_in_src)
-            _print_err("Keys found only in the source schema: {}".format(', '.join(keys_formatted)))
+            _print_err("Keys found only in the source schema: {}".format(', '.join(only_in_src)))
         if only_in_dst:
-            keys_formatted = ('.'.join(k) for k in only_in_dst)
             _print_err(
-                "Keys found only in the destination schema: {}".format(', '.join(keys_formatted)))
+                "Keys found only in the destination schema: {}".format(', '.join(only_in_dst)))
         if diff_value:
-            keys_formatted = ('.'.join(k) for k in diff_value)
             _print_err(
                 "Keys having different values in source and destination: {}"
-                .format(', '.join(keys_formatted)))
+                .format(', '.join(diff_value)))
     except DocumentSyncConflict as error:
         _print_err(MSG_SYNC_SPECIFY_KEY.format(keys=', '.join(error.keys)))
     except FileSyncConflict as error:

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -568,7 +568,7 @@ def main_sync(args):
         diff_src = error.schema_src.difference(error.schema_dst)
         diff_dst = error.schema_dst.difference(error.schema_src)
         only_in_dst = diff_dst.difference(diff_src)
-        only_in_src = diff_src.difference(diff_src)
+        only_in_src = diff_src.difference(diff_dst)
         diff_value = diff_src.intersection(diff_dst)
         if only_in_src:
             keys_formatted = ('.'.join(k) for k in only_in_src)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -534,7 +534,7 @@ class TestJobSync(TestJobBase):
         assert job_dst.document['a'] == job_src.document['a']
 
 
-class ProjectSyncTest():
+class TestProjectSync():
 
     @pytest.fixture(autouse=True)
     def setUp(self, request):


### PR DESCRIPTION
Fixes issue #375. 

## Description
- Rename `ProjectSyncTest` to `TestProjectSync` so pytest recognizes the tests.
- Correct a typo in checking difference between `src` and `dst` in the CLI sync
- Correct the formatting for CLI sync error output.


## Motivation and Context
see #375 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
