### PR TITLE
Add inherited members to dict-like classes.

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -107,7 +107,7 @@ The Collection
 ==============
 
 .. autoclass:: Collection
-   :members:
+    :members:
 
 
 The JSONDict
@@ -116,7 +116,8 @@ The JSONDict
 This class implements the interface for the job's :attr:`~signac.contrib.job.Job.statepoint` and :attr:`~signac.contrib.job.Job.document` attributes, but can also be used stand-alone:
 
 .. autoclass:: JSONDict
-   :members:
+    :members:
+    :inherited-members:
 
 
 The H5Store
@@ -126,6 +127,7 @@ This class implements the interface to the job's :attr:`~signac.contrib.job.Job.
 
 .. autoclass:: H5Store
     :members:
+    :inherited-members:
 
 
 The H5StoreManager
@@ -135,6 +137,7 @@ This class implements the interface to the job's :attr:`~signac.contrib.job.Job.
 
 .. autoclass:: H5StoreManager
     :members:
+    :inherited-members:
     :show-inheritance:
 
 


### PR DESCRIPTION
## Description
Documents dict-like methods on JSONDict, H5Store, and inherited methods for H5StoreManager.

## Motivation and Context
After discussion with @DomFijan, we decided we should document dict-like methods on JSONDict and related classes.

## Types of Changes
- [x] Documentation update

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
