### PR TITLE
Add support for h5py >=3.0.0.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac** package follows `semantic versioning <https://semver.org/>`_.
 Version 1
 =========
 
+next
+----
+
+Added
++++++
+
+ - Support for h5py version 3 (#411).
+
 [1.5.0] -- 2020-09-20
 ---------------------
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -130,6 +130,7 @@ def _h5set(store, grp, key, value, path=None):
 
 def _h5get(store, grp, key, path=None):
     """Retrieve the underlying data for a key from its h5py container."""
+    import h5py
     path = path + '/' + key if path else key
     result = grp[key]
 
@@ -153,6 +154,11 @@ def _h5get(store, grp, key, path=None):
             return None
         elif shape:
             return result
+        elif h5py.version.version_tuple.major >= 3 and \
+                h5py.check_dtype(vlen=result.dtype) is str:
+            # h5py >=3.0.0 returns strings as bytes. This returns str for
+            # consistency with past behavior in signac.
+            return result.asstr()[()]
         else:
             return result[()]
     except AttributeError:


### PR DESCRIPTION
## Description
This PR adds support for h5py major version 3 and should be merged before #409 (to show that the code functions both before and after the upgrade).

The h5py package changed its default handling of strings in version 3. See this page for info: https://docs.h5py.org/en/latest/strings.html

This PR adds a shim to detect string data, so that it can be returned as `str` and not `bytes`. I tested this locally with h5py 2.10.0 and 3.0.0, and it should work for older versions of h5py as well (that's why I used the older function `check_dtype` instead of `check_string_dtype`, which was added in 2.10).


## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
