### PR TITLE
Use black and isort, managed with pre-commit.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ version: 2.1
 orbs:
   win: circleci/windows@2.2.0  # Enables Windows executors
 
+references:
+  restore_keys: &restore_keys
+    keys:
+      - python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-precommit.txt" }}-{{ checksum ".pre-commit-config.yaml" }}
+
+  save_key: &save_key
+    key: python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-precommit.txt" }}-{{ checksum ".pre-commit-config.yaml" }}
+
 jobs:
   pre-checks:
     docker:
@@ -16,6 +24,10 @@ jobs:
 
     steps:
       - checkout
+
+      - restore_cache:
+          <<: *restore_keys
+
       - run:
           name: Install pre-check dependencies
           command: |
@@ -24,7 +36,13 @@ jobs:
       - run:
           name: Run pre-checks
           command: |
-            pre-commit run --all-files --show-diff-on-failure
+            PRE_COMMIT_HOME=.pre-commit-cache pre-commit run --all-files --show-diff-on-failure
+
+      - save_cache:
+          <<: *save_key
+          paths:
+            - ".pre-commit-cache"
+
 
   linux-python-38: &linux-template
     docker:
@@ -40,12 +58,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-precommit.txt" }}
-            - python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
-            - python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-            - python-env-v7-{{ arch }}
-            - python-env-v7
+          <<: *restore_keys
 
       - run:
           name: Install dependencies
@@ -63,7 +76,7 @@ jobs:
             ${PYTHON} -m pip install --progress-bar off -U -e . -r requirements-dev.txt
 
       - save_cache:
-          key: python-env-v7-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}-{{checksum "requirements-precommit.txt" }}
+          <<: *save_key
           paths:
             - "venv"
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-log.txt
 .noseids
 .coverage
 .tox
+.mypy_cache
 nosetests.xml
 .pytest_cache
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,38 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: ''
     hooks:
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
         exclude: 'setup.cfg'
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
         exclude: 'setup.cfg'
-    -   id: debug-statements
--   repo: https://github.com/asottile/pyupgrade
+      - id: debug-statements
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.3
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         exclude: '(?:configobj/.*)'
         args:
-        - --py36-plus
--   repo: local
+          - --py36-plus
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
     hooks:
-    -   id: flake8
+      - id: black
+        language_version: python3
+  - repo: local
+    hooks:
+      - id: flake8
         name: flake8
         entry: flake8
         language: python
         types: [python]
-    -   id: pydocstyle
+      - id: pydocstyle
         name: pydocstyle
         entry: pydocstyle
         language: python
         types: [python]
         files: ^((?!doc|tests|configobj|db).)*$
-    -   id: mypy
+      - id: mypy
         name: mypy
         entry: mypy
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: ''
+    rev: 'v3.3.0'
     hooks:
       - id: end-of-file-fixer
         exclude: 'setup.cfg'
@@ -8,32 +8,26 @@ repos:
         exclude: 'setup.cfg'
       - id: debug-statements
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.3
+    rev: 'v2.7.3'
     hooks:
       - id: pyupgrade
         exclude: '(?:configobj/.*)'
         args:
           - --py36-plus
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
+  - repo: https://github.com/pycqa/isort
+    rev: '5.6.4'
     hooks:
-      - id: black
-        language_version: python3
-  - repo: local
+      - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: '3.8.4'
     hooks:
       - id: flake8
-        name: flake8
-        entry: flake8
-        language: python
-        types: [python]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: '5.1.1'
+    hooks:
       - id: pydocstyle
-        name: pydocstyle
-        entry: pydocstyle
-        language: python
-        types: [python]
         files: ^((?!doc|tests|configobj|db).)*$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.790'
+    hooks:
       - id: mypy
-        name: mypy
-        entry: mypy
-        language: python
-        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
     rev: '5.6.4'
     hooks:
       - id: isort
+  - repo: https://github.com/psf/black
+    rev: '20.8b1'
+    hooks:
+      - id: black
+        exclude: '(?:configobj/.*)'
   - repo: https://gitlab.com/pycqa/flake8
     rev: '3.8.4'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: '3.8.4'
     hooks:
       - id: flake8
+        exclude: '(?:configobj/.*)'
   - repo: https://github.com/pycqa/pydocstyle
     rev: '5.1.1'
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,7 @@ Please see the [Support](https://docs.signac.io/projects/signac-core/en/latest/s
 
 ### Code Style
 
-Code must adhere to the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) with the exception that lines may have up to 100 characters.
-
-We recommend to use [flake8](http://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/) to find and fix any code style issues prior to committing and pushing.
+The [pre-commit tool](https://pre-commit.com/) is used to enforce code style guidelines. Use `pip install pre-commit` to install the tool and `pre-commit install` to configure pre-commit hooks.
 
 ## Reviewing Pull Requests
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Added
 
  - Support for h5py version 3 (#411).
  - Added pyupgrade to pre-commit hooks (#413).
+ - Code is formatted with ``black`` and ``isort`` pre-commit hooks (#415).
 
 [1.5.0] -- 2020-09-20
 ---------------------

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -32,14 +32,14 @@ for example with `venv <https://docs.python.org/3/library/venv.html>`_:
 
     ~ $ python -m venv ~/envs/signac-dev
     ~ $ source ~/envs/signac-dev/bin/activate
-    (signac-dev) ~ $ pip install flake8
+    (signac-dev) ~ $ pip install pre-commit
 
 or alternatively with `conda <https://conda.io/docs/>`_:
 
 .. code-block:: bash
 
-    ~ $ conda create -n signac-dev python=3 flake8
-    ~ $ activate signac-dev
+    ~ $ conda create -n signac-dev -c conda-forge python=3 pre-commit
+    ~ $ conda activate signac-dev
 
 Then clone your fork and install the package from source with:
 
@@ -51,14 +51,15 @@ Then clone your fork and install the package from source with:
 The ``-e`` option stands for *editable*, which means that the package is directly loaded from the source code repository.
 That means any changes made to the source code are immediately reflected upon reloading the Python interpreter.
 
-Finally, we recommend to setup a `Flake8 <http://flake8.pycqa.org/en/latest/>`_ git commit hook with:
+The `pre-commit tool <https://pre-commit.com/>`__ is used to enforce code style guidelines.
+To install the tool and configure pre-commit hooks, execute:
 
 .. code-block:: bash
 
-    (signac-dev) signac $ flake8 --install-hook git
-    (signac-dev) signac $ git config --bool flake8.strict true
+    (signac-dev) signac $ pip install pre-commit
+    (signac-dev) signac $ pre-commit install
 
-With the *flake8* hook, your code will be checked for syntax and style before you make a commit.
+With the pre-commit hook, your code will be checked for syntax and style before you make a commit.
 The continuous integration pipeline for the package will perform these checks as well, so running these tests before committing / pushing will prevent the pipeline from failing due to style-related issues.
 
 The development workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,5 @@ exclude = '''
 '''
 
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
-line_length = 88
+profile = "black"
+skip_glob = signac/common/configobj/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,5 @@ exclude = '''
 '''
 
 [tool.isort]
-profile = "black"
-skip_glob = signac/common/configobj/*
+profile = 'black'
+skip_glob = 'signac/common/configobj/*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude = '''
     | \.venv
     | build
     | dist
-    | signac/common/configobj
+    | signac/common/configobj/.*
   )/
 )
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,4 @@
 [tool.black]
-line-length = 100
-skip-string-normalization = true
 target-version = ['py36']
 include = '\.pyi?$'
 exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,11 @@ exclude = '''
   )/
 )
 '''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 100
+skip-string-normalization = true
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | build
+    | dist
+    | signac/common/configobj
+  )/
+)
+'''

--- a/requirements-precommit.txt
+++ b/requirements-precommit.txt
@@ -1,4 +1,1 @@
-flake8==3.8.4
-mypy==0.790
 pre-commit==2.8.2
-pydocstyle==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,17 @@ description-file = README.md
 [bdist_wheel]
 python-tag = py3
 
+[tool.black]
+exclude = configobj,passlib,cite.py,conf.py
+line-length = 100
+
 [flake8]
 max-line-length = 100
 exclude = configobj,conf.py
 # Use select to ignore unwanted flake8 plugins
 select = E,F,W
 # Specify errors to ignore by default
-ignore = E123,E126,E226,E241,E704,W503,W504
+ignore = E123,E126,E203, E226,E241,E704,W503,W504
 
 [pydocstyle]
 match = ^((?!\.sync-zenodo-metadata|setup|benchmark|mpipool|connection|crypt|host|filesystems|indexing).)*\.py$

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,17 +10,13 @@ description-file = README.md
 [bdist_wheel]
 python-tag = py3
 
-[tool.black]
-exclude = configobj,passlib,cite.py,conf.py
-line-length = 100
-
 [flake8]
 max-line-length = 100
-exclude = configobj,conf.py
+exclude = configobj
 # Use select to ignore unwanted flake8 plugins
 select = E,F,W
 # Specify errors to ignore by default
-ignore = E123,E126,E203, E226,E241,E704,W503,W504
+ignore = E123,E126,E203,E226,E241,E704,W503,W504
 
 [pydocstyle]
 match = ^((?!\.sync-zenodo-metadata|setup|benchmark|mpipool|connection|crypt|host|filesystems|indexing).)*\.py$


### PR DESCRIPTION
## Description
1. This PR introduces `black` and `isort` for automatically fixing code style.
2. The checks for `flake8`, `pydocstyle`, and `mypy` are the same as before, except they are no longer "local" hooks (they use the pre-commit virtual environment instead).

**I am seeking reviewer feedback on the new configuration before committing reformatted code.**

For an example of what the style looks like, see #416. I applied all the changes in that PR.

## Motivation and Context
1. The development team decided to adopt `black` as a code formatter at the previous developer meeting. I hope this will make the process of development faster as a whole. While there is a nonzero cost to having a pre-commit workflow with many hooks, it is worth it if this kind of change can reduce the number of iterations and "nitpick" style comments needed during PR review.

2. Consolidating pre-commit hooks (and not using local hooks) will make it easier to install and manage linters/fixers.

## Types of Changes
- [x] New feature

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.


Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).`
