### PR TITLE
Simplify internal function for mkdir -p.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,11 @@ Added
  - Added macOS to CircleCI testing pipeline (#281, #414).
  - Official support for Python 3.9 (#417).
 
+Changed
++++++++
+
+ - Internal refactor and optimization of internal function ``_mkdir_p`` (#421).
+
 [1.5.0] -- 2020-09-20
 ---------------------
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,7 +22,8 @@ Added
 Changed
 +++++++
 
- - Optimized performance of job initialization (#421, #422).
+ - Optimized internal function ``_mkdir_p`` (#421).
+ - Optimized performance of job initialization (#422).
 
 [1.5.0] -- 2020-09-20
 ---------------------

--- a/signac/contrib/filesystems.py
+++ b/signac/contrib/filesystems.py
@@ -13,6 +13,7 @@ from deprecation import deprecated
 
 from ..db import get_database
 from ..version import __version__
+from .utility import _mkdir_p
 
 try:
     import gridfs
@@ -92,8 +93,7 @@ class LocalFS:
         if "x" not in mode:
             raise ValueError(mode)
         fn = self._fn(_id)
-        path = os.path.dirname(fn)
-        os.makedirs(path, exist_ok=True)
+        _mkdir_p(os.path.dirname(fn))
         return open(fn, mode=mode)
 
     def get(self, _id, mode="r"):

--- a/signac/contrib/filesystems.py
+++ b/signac/contrib/filesystems.py
@@ -4,7 +4,6 @@
 """The file system handlers defined in this module
 encapsulate the I/O operations required to store
 and fetch data from different file systems."""
-import errno
 import io
 import os
 import warnings
@@ -93,12 +92,8 @@ class LocalFS:
         if "x" not in mode:
             raise ValueError(mode)
         fn = self._fn(_id)
-        try:
-            path = os.path.dirname(fn)
-            os.makedirs(path)
-        except OSError as error:
-            if not (error.errno == errno.EEXIST and os.path.isdir(path)):
-                raise
+        path = os.path.dirname(fn)
+        os.makedirs(path, exist_ok=True)
         return open(fn, mode=mode)
 
     def get(self, _id, mode="r"):

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -9,6 +9,8 @@ import os
 import sys
 from itertools import chain
 
+from .utility import _mkdir_p
+
 logger = logging.getLogger(__name__)
 
 
@@ -205,7 +207,7 @@ def _make_link(src, dst):
         Destination symbolic link directory/file name.
 
     """
-    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    _mkdir_p(os.path.dirname(dst))
     try:
         os.symlink(src, dst, target_is_directory=True)
     except OSError as error:

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -205,12 +205,7 @@ def _make_link(src, dst):
         Destination symbolic link directory/file name.
 
     """
-    try:
-        os.makedirs(os.path.dirname(dst))
-    # except FileExistsError:
-    except OSError as error:
-        if error.errno != errno.EEXIST:
-            raise
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     try:
         os.symlink(src, dst, target_is_directory=True)
     except OSError as error:

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -281,7 +281,7 @@ def _mkdir_p(path):
         New directory name.
 
     """
-    # Performance: `isdir` is fast and eliminates the need to check `_mkdir_p`
+    # Performance: `isdir` is fast and eliminates the rest of os.makedirs
     # if the path already exists. Typically this function is called in cases
     # where the path already exists. If the path is a file, this check returns
     # False and allows os.makedirs to raise FileExistsError as usual.

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -4,7 +4,6 @@
 """Utilities for signac."""
 
 import argparse
-import errno
 import getpass
 import logging
 import os
@@ -274,7 +273,7 @@ def walkdepth(path, depth=0):
 
 
 def _mkdir_p(path):
-    """Make a new directory.
+    """Make a new directory, or do nothing if the path already exists.
 
     Parameters
     ----------
@@ -282,11 +281,7 @@ def _mkdir_p(path):
         New directory name.
 
     """
-    try:
-        os.makedirs(path)
-    except OSError as error:
-        if not (error.errno == errno.EEXIST and os.path.isdir(path)):
-            raise
+    os.makedirs(path, exist_ok=True)
 
 
 def split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progress: "):

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -273,7 +273,7 @@ def walkdepth(path, depth=0):
 
 
 def _mkdir_p(path):
-    """Make a new directory, or do nothing if the path already exists.
+    """Make a new directory, or do nothing if the directory already exists.
 
     Parameters
     ----------
@@ -281,7 +281,12 @@ def _mkdir_p(path):
         New directory name.
 
     """
-    os.makedirs(path, exist_ok=True)
+    # Performance: `isdir` is fast and eliminates the need to check `_mkdir_p`
+    # if the path already exists. Typically this function is called in cases
+    # where the path already exists. If the path is a file, this check returns
+    # False and allows os.makedirs to raise FileExistsError as usual.
+    if not os.path.isdir(path):
+        os.makedirs(path, exist_ok=True)
 
 
 def split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progress: "):


### PR DESCRIPTION
## Description
Since Python 2 support has been removed, we can replace the internal function `_mkdir_p` with `os.makedirs(path, exist_ok=True)`.

## Motivation and Context
Simplifies internal code. Standard library features should be used where possible.

Cases where _files_ exist with the name for the destination directory raise an error. This was previously caught and tested separately but no longer needs special error handling code.

## Types of Changes
- [x] New feature

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
