### PR TITLE
Attempt to exit early from _init if a job manifest exists and is valid.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,11 @@ Added
  - Added macOS to CircleCI testing pipeline (#281, #414).
  - Official support for Python 3.9 (#417).
 
+Changed
++++++++
+
+ - ``Job.init()`` exits early for jobs that are initialized (#422).
+
 [1.5.0] -- 2020-09-20
 ---------------------
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -492,8 +492,6 @@ class Job:
         try:
             with open(fn_manifest, "rb") as file:
                 assert calc_id(json.loads(file.read().decode())) == self._id
-        except OSError:
-            raise
         except (AssertionError, ValueError):
             raise JobsCorruptedError([self._id])
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -449,6 +449,16 @@ class Job:
         """
         fn_manifest = os.path.join(self._wd, self.FN_MANIFEST)
 
+        # Attempt early exit if the manifest exists and is valid
+        try:
+            self._check_manifest()
+        except Exception:
+            # Any exception means this method cannot exit early
+            pass
+        else:
+            # The manifest is exists and is valid, exit early
+            return
+
         # Create the workspace directory if it did not exist yet.
         try:
             _mkdir_p(self._wd)
@@ -481,14 +491,13 @@ class Job:
             self._check_manifest()
 
     def _check_manifest(self):
-        """Check whether the manifest file is correct (if it exists)."""
+        """Check whether the manifest file exists and is correct."""
         fn_manifest = os.path.join(self._wd, self.FN_MANIFEST)
         try:
             with open(fn_manifest, "rb") as file:
                 assert calc_id(json.loads(file.read().decode())) == self._id
-        except OSError as error:
-            if error.errno != errno.ENOENT:
-                raise error
+        except OSError:
+            raise
         except (AssertionError, ValueError):
             raise JobsCorruptedError([self._id])
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -453,42 +453,38 @@ class Job:
         try:
             self._check_manifest()
         except Exception:
-            # Any exception means this method cannot exit early
-            pass
-        else:
-            # The manifest is exists and is valid, exit early
-            return
+            # Any exception means this method cannot exit early.
 
-        # Create the workspace directory if it did not exist yet.
-        try:
-            _mkdir_p(self._wd)
-        except OSError:
-            logger.error(
-                "Error occured while trying to create "
-                "workspace directory for job '{}'.".format(self)
-            )
-            raise
-
-        try:
-            # Ensure to create the binary to write before file creation
-            blob = json.dumps(self._statepoint, indent=2)
+            # Create the workspace directory if it did not exist yet.
+            try:
+                _mkdir_p(self._wd)
+            except OSError:
+                logger.error(
+                    "Error occurred while trying to create "
+                    "workspace directory for job '{}'.".format(self)
+                )
+                raise
 
             try:
-                # Open the file for writing only if it does not exist yet.
-                with open(fn_manifest, "w" if force else "x") as file:
-                    file.write(blob)
-            except OSError as error:
-                if error.errno not in (errno.EEXIST, errno.EACCES):
-                    raise
-        except Exception as error:
-            # Attempt to delete the file on error, to prevent corruption.
-            try:
-                os.remove(fn_manifest)
-            except Exception:  # ignore all errors here
-                pass
-            raise error
-        else:
-            self._check_manifest()
+                # Prepare the data before file creation and writing
+                blob = json.dumps(self._statepoint, indent=2)
+
+                try:
+                    # Open the file for writing only if it does not exist yet.
+                    with open(fn_manifest, "w" if force else "x") as file:
+                        file.write(blob)
+                except OSError as error:
+                    if error.errno not in (errno.EEXIST, errno.EACCES):
+                        raise
+            except Exception as error:
+                # Attempt to delete the file on error, to prevent corruption.
+                try:
+                    os.remove(fn_manifest)
+                except Exception:  # ignore all errors here
+                    pass
+                raise error
+            else:
+                self._check_manifest()
 
     def _check_manifest(self):
         """Check whether the manifest file exists and is correct."""


### PR DESCRIPTION
## Description
Many methods/properties of `Job` invoke a call to `job.init()`, including the first access to `job.document` and all accesses to `job.stores` and `job.data`.

This PR optimizes `job.init()` for jobs that are already initialized, by exiting early.

## Motivation and Context
This is a performance enhancement for many common data access operations in signac.

Performance results for the script below:

| Test           | `master` | This branch (b4917d8) | Speedup         |
|----------------|----------|-----------------------|-----------------|
| First init     | 3.426s   | 3.546s                | 0.966x (slower) |
| Already init'd | 2.623s   | 1.774s                | 1.479x (faster) |

```python
import signac

project = signac.init_project('test')

for i in range(20000):
    project.open_job({'a': i, 'b': i*2, 'c': i*3}).init()
```

## Types of Changes
- [x] New feature

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
