### PR TITLE
Optimize buffer load checks.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Changed
 
  - Optimized internal function ``_mkdir_p`` (#421).
  - Optimized performance of job initialization (#422).
+ - Optimized performance of buffer storage (#428).
 
 [1.5.0] -- 2020-09-20
 ---------------------

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -61,7 +61,7 @@ def _hash(blob):
         return m.hexdigest()
 
 
-def _get_filemetadata(filename):
+def _get_file_metadata(filename):
     try:
         return os.path.getsize(filename), os.path.getmtime(filename)
     except OSError as error:
@@ -83,7 +83,7 @@ def _store_in_buffer(filename, blob, store_hash=False):
     _JSONDICT_BUFFER[filename] = blob
     if store_hash:
         if not _BUFFERED_MODE_FORCE_WRITE:
-            _JSONDICT_META[filename] = _get_filemetadata(filename)
+            _JSONDICT_META[filename] = _get_file_metadata(filename)
         _JSONDICT_HASHES[filename] = _hash(blob)
     return True
 
@@ -99,7 +99,7 @@ def flush_all():
         if _hash(blob) != _JSONDICT_HASHES.pop(filename):
             try:
                 if not _BUFFERED_MODE_FORCE_WRITE:
-                    if _get_filemetadata(filename) != meta:
+                    if _get_file_metadata(filename) != meta:
                         issues[
                             filename
                         ] = "File appears to have been externally modified."

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -192,19 +192,25 @@ class TestBufferedMode(TestProjectBase):
                 assert job.doc.a
 
         routine()
+        assert signac.get_buffer_load() == 0
         with signac.buffered():
             assert signac.is_buffered()
             routine()
+            assert signac.get_buffer_load() > 0
+        assert signac.get_buffer_load() == 0
 
         for job in self.project:
             x = job.doc.a
             with signac.buffered():
+                assert signac.get_buffer_load() == 0
                 assert job.doc.a == x
+                assert signac.get_buffer_load() > 0
                 job.doc.a = not job.doc.a
                 assert job.doc.a == (not x)
                 with pytest.deprecated_call():
                     job2 = self.project.open_job(id=job.get_id())
                 assert job2.doc.a == (not x)
+            assert signac.get_buffer_load() == 0
             assert job.doc.a == (not x)
             assert job2.doc.a == (not x)
 


### PR DESCRIPTION
## Description
This PR changes the internal behavior of the buffer. When a new item is added to the buffer, the code checks the current buffer load (size of all items in the buffer) and ensures that the current load plus the size of the new item is less than the maximum buffer size. The function that calculates this buffer size appears to consume a lot of time in my profiles of signac-flow projects with 1000 jobs. I made changes that will increment the buffer load after each store, so that buffer size access can be done in constant time.

The buffer load is reset when the buffer is flushed. I did some manual testing to ensure that the size calculations agree during a normal filling and flushing of the buffer.

## Motivation and Context
The profiling I did on signac-flow involved some status checks with label functions that required job document access for 1000 jobs. This means that ~1000 items were probably stored in the buffer.

### Before
Without this optimization, the `_store_in_buffer` method consumed 18.2 seconds (see the box highlighted in pink, below).
![image](https://user-images.githubusercontent.com/3943761/102023629-8ac96880-3d52-11eb-9b89-e0defacb118a.png)

### After
With this optimization, the `_store_in_buffer` method consumed only 0.719 seconds (see box higlighted in pink). That's a 25x speedup for this case, but the speedup will depend heavily on the input data. I believe this optimization should be strictly faster in all cases.
![image](https://user-images.githubusercontent.com/3943761/102023695-eac00f00-3d52-11eb-8b64-6eb5952ac828.png)


## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.