### PR TITLE
Optimize _dfs_convert by exiting early for common types.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Changed
  - Optimized internal function ``_mkdir_p`` (#421).
  - Optimized performance of job initialization (#422).
  - Optimized performance of buffer storage (#428).
+ - Optimized performance of creating/loading synced data structures (#429).
 
 [1.5.0] -- 2020-09-20
 ---------------------

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -125,15 +125,13 @@ class _SyncedDict(MutableMapping):
                 for k in root:
                     ret[k] = root[k]
             return ret
-        elif type(root) is tuple:
-            return _SyncedList(root, self)
-        elif type(root) is list:
-            return _SyncedList(root, self)
+        elif type(root) in (list, tuple):
+            return _SyncedList(root, parent=self)
         elif NUMPY:
             if isinstance(root, numpy.number):
                 return root.item()
             elif isinstance(root, numpy.ndarray):
-                return _SyncedList(root.tolist(), self)
+                return _SyncedList(root.tolist(), parent=self)
         return root
 
     @classmethod

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -112,7 +112,10 @@ class _SyncedDict(MutableMapping):
             )
 
     def _dfs_convert(self, root):
-        if type(root) is type(self):
+        if isinstance(root, (bool, float, int, type(None), str)):
+            # Allow common types to exit early
+            return root
+        elif type(root) is type(self):
             for k in root:
                 root[k] = self._dfs_convert(root[k])
         elif isinstance(root, Mapping):

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -137,7 +137,11 @@ class _SyncedDict(MutableMapping):
     @classmethod
     def _convert_to_dict(cls, root):
         """Convert (nested) values to dict."""
-        if type(root) == cls:
+        if type(root) in (bool, float, int, type(None), str):
+            # Allow common types to exit early. This must use type equality
+            # checks instead of isinstance() to avoid catching NumPy values.
+            return root
+        elif type(root) is cls:
             ret = dict()
             with root._suspend_sync():
                 for k in root:
@@ -190,7 +194,7 @@ class _SyncedDict(MutableMapping):
                         self._dfs_update(self._data, data)
                     for value in self._data:
                         if isinstance(value, Mapping):
-                            assert type(value) == type(self)
+                            assert type(value) is type(self)
             else:
                 self._parent.load()
 

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -112,8 +112,9 @@ class _SyncedDict(MutableMapping):
             )
 
     def _dfs_convert(self, root):
-        if isinstance(root, (bool, float, int, type(None), str)):
-            # Allow common types to exit early
+        if type(root) in (bool, float, int, type(None), str):
+            # Allow common types to exit early. This must use type equality
+            # checks instead of isinstance() to avoid catching NumPy values.
             return root
         elif type(root) is type(self):
             for k in root:


### PR DESCRIPTION
## Description
The internal function `_dfs_convert` recursively converts containers into their synced equivalents. That is, when reading a state point or document, the `_dfs_convert` function will change a `dict` into a synced dictionary.

**Observation:** Most signac jobs have state points and documents that are relatively flat. That is, most values in a state point or document are common non-container types (string, float, int, bool) and only a few are (dict, list).

I noticed that the code path taken for non-container types must exhaustively test whether the value is a `Mapping`, tuple, list, or NumPy type. Only at the very end it returns the raw value.

Matching the "fast path" to the expected distribution of data is a micro-optimization, but it pays off. Benchmarks are below.

## Motivation and Context
Speeds up all operations in signac that involved synced structures (e.g. reading data from a state point or document).

### Benchmark:
I measured the total time for checking status, running, and submitting a sample workflow of 1000 jobs in signac flow with 3 operations with pre/post conditions. The state points and documents had no nested dicts/lists.

**Before:** 86.0 seconds total, 7.749 seconds spent in `_dfs_convert`.
**After:** 78.3 seconds total, 1.378 seconds spent in `_dfs_convert`.

This suggests a speedup of ~5x in that function, but it will depend heavily on the data sizes and types used.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
