### PR TITLE
fix doc build warning requiring string

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -71,8 +71,8 @@ master_doc = "index"
 project = "signac"
 copyright = "The Regents of the University of Michigan"
 author = (
-    "Carl S. Adorf, Vyas Ramasubramani, Bradley D. Dice, ",
-    "Michael M. Henry, Brandon Butler, Paul M. Dodd, Sharon C. Glotzer",
+    "Carl S. Adorf, Vyas Ramasubramani, Bradley D. Dice, "
+    "Michael M. Henry, Brandon Butler, Paul M. Dodd, Sharon C. Glotzer"
 )
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Fix a regression due to auto formatting causing warning in docs build. The error was:
```
$ sphinx-build -b html ./doc ./build/html
Running Sphinx v3.1.1
making output directory... done
WARNING: The config value `author' has type `tuple', defaults to `str'.

Extension error:
Handler <function check_confval_types at 0x7f9275c54158> for event 'config-inited' threw an exception
```
Note I'm not actually sure where author info appears in the built website.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The issue was introduced in commit b67a78dabfb6a367f878e6e3edc7a8ea3193b508 as part of #416 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
