### PR TITLE
Fix coverage configuration to read from setup.cfg.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest --cov signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ ignore = D105, D107, D203, D204, D213
 ignore_missing_imports = True
 
 [coverage:run]
+branch = True
 source = signac
 omit = 
 	*/signac/common/configobj/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ ignore_missing_imports = True
 
 [coverage:run]
 branch = True
+concurrency = thread,multiprocessing
+parallel = True
 source = signac
 omit = 
 	*/signac/common/configobj/*.py


### PR DESCRIPTION
## Description
I fixed our coverage settings so that it reads the options from `setup.cfg`. The code coverage should exclude the vendored configobj code but it wasn't, because the options were being overlooked. I'll merge this after I verify the correct results show up on the Codecov website.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.