### PR TITLE
Optimize job __hash__ and __eq__ checks.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,15 @@ The **signac** package follows `semantic versioning <https://semver.org/>`_.
 Version 1
 =========
 
+next
+----
+
+Changed
++++++++
+
+ - Optimized job hash and equality checks (#442).
+
+
 [1.5.1] -- 2020-12-19
 ---------------------
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -134,7 +134,7 @@ class Job:
         return self._id
 
     def __hash__(self):
-        return hash(os.path.realpath(self._wd))
+        return hash(self._wd)
 
     def __str__(self):
         """Return the job's id."""
@@ -146,7 +146,9 @@ class Job:
         )
 
     def __eq__(self, other):
-        return hash(self) == hash(other)
+        return (hash(self) == hash(other)) and (
+            os.path.realpath(self._wd) == os.path.realpath(other._wd)
+        )
 
     def workspace(self):
         """Return the job's unique workspace directory.

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -134,7 +134,7 @@ class Job:
         return self._id
 
     def __hash__(self):
-        return hash(self._wd)
+        return hash(self.id)
 
     def __str__(self):
         """Return the job's id."""

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -136,6 +136,11 @@ class Job:
     def __hash__(self):
         return hash(self.id)
 
+    def __eq__(self, other):
+        return (self.id == other.id) and (
+            os.path.realpath(self._wd) == os.path.realpath(other._wd)
+        )
+
     def __str__(self):
         """Return the job's id."""
         return str(self.id)
@@ -143,11 +148,6 @@ class Job:
     def __repr__(self):
         return "{}(project={}, statepoint={})".format(
             self.__class__.__name__, repr(self._project), self._statepoint
-        )
-
-    def __eq__(self, other):
-        return (hash(self) == hash(other)) and (
-            os.path.realpath(self._wd) == os.path.realpath(other._wd)
         )
 
     def workspace(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -664,13 +664,16 @@ class TestProject(TestProjectBase):
         assert job in project_b
         assert job not in project_a
         assert job == job_b
+        assert hash(job) == hash(job_b)
         with job:
             job.document["a"] = 0
             with open("hello.txt", "w") as file:
                 file.write("world!")
         job_ = project_b.open_job(job.statepoint())
         assert job == job_
+        assert hash(job) == hash(job_)
         assert job_ == job_b
+        assert hash(job_) == hash(job_b)
         assert job_.isfile("hello.txt")
         assert job_.document["a"] == 0
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -655,7 +655,6 @@ class TestProject(TestProjectBase):
         job = project_a.open_job(dict(a=0))
         job_b = project_b.open_job(dict(a=0))
         assert job != job_b
-        assert hash(job) != hash(job_b)
         assert job not in project_a
         assert job not in project_b
         job.init()
@@ -665,16 +664,13 @@ class TestProject(TestProjectBase):
         assert job in project_b
         assert job not in project_a
         assert job == job_b
-        assert hash(job) == hash(job_b)
         with job:
             job.document["a"] = 0
             with open("hello.txt", "w") as file:
                 file.write("world!")
         job_ = project_b.open_job(job.statepoint())
         assert job == job_
-        assert hash(job) == hash(job_)
         assert job_ == job_b
-        assert hash(job_) == hash(job_b)
         assert job_.isfile("hello.txt")
         assert job_.document["a"] == 0
 


### PR DESCRIPTION
## Description
In signac-flow's aggregation feature, it is fairly common to check membership: `job in list(job1, job2, ...)`. This is currently very slow in signac.

By [Python's membership test rules](https://docs.python.org/3.6/reference/expressions.html#membership-test-details), `x in y` is equivalent to `any(x is e or x == e for e in y)`.

Currently, the `__eq__` check requires a call to `os.path.realpath`, which is fairly expensive. For a directory path like `/a/b/c/d/e/f`, `realpath` must check whether `/a`, `/a/b`, `/a/b/c`, etc. are symlinks, and if so, resolve them to their target location. That requires a lot of system calls just to check if jobs are equal. You can see that definition [here](https://github.com/python/cpython/blob/fbc7723778be01b8f3bb72d2dcac15ab9fbb9923/Lib/posixpath.py#L390).

I propose weakening the `__hash__` function (which should always be fast in the proposed optimization) and using the hash as a fast way to rule out equality. This optimization is valid because `a == b` implies `hash(a) == hash(b)` (see the [Python data model section on hashing](https://docs.python.org/3.6/reference/datamodel.html#object.__hash__) for details). Using the contrapositive, we can check for hash collision (the job's hash is simply `hash(job.id)`, a property that is known by the job) and then only check the `realpath` if hashes collide.

## Motivation and Context
For a workspace of 30,000 jobs, this speeds up `job in list(project)` by a factor of ~70. (6.05 seconds without the optimization, 0.086 seconds with optimization). (Note that `job in project` would use the project's `__contains__` method, so we need to check against a list-of-jobs,)

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
