### PR TITLE
Optimize H5Store init.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Changed
 +++++++
 
  - Optimized job hash and equality checks (#442).
+ - Optimized ``H5Store`` initialization (#443).
 
 
 [1.5.1] -- 2020-12-19

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -327,7 +327,7 @@ class H5Store(MutableMapping):
     def __init__(self, filename, **kwargs):
         if not (isinstance(filename, str) and len(filename) > 0):
             raise ValueError("H5Store filename must be a non-empty string.")
-        self._filename = os.path.realpath(filename)
+        self._filename = os.path.abspath(filename)
         self._file = None
         self._kwargs = kwargs
 


### PR DESCRIPTION
## Description
Optimizes the `H5Store` initializer to use `os.path.abspath` instead of `os.path.realpath`. As mentioned in #442, the cost of `realpath` is fairly high and it isn't necessary to use a "real" path in this case.

(Note that this optimization would *not* apply to `job.document` or anything that must interface with signac's buffering logic, in my understanding. Buffering relies on "real" paths to ensure that data is correctly loaded in the buffer.)

## Motivation and Context
Speeds up H5Store initialization.

I noticed this optimization while using a signac-flow project with a condition that checks for a key in `job.data`. For my simple test case with 157 jobs, the time spent in the condition function went from 2.72 seconds to 2.15 seconds (21% faster).

Note: Another 20-30% of the time could be trimmed by adding lazy state point loading and avoiding the state point validation when accessing the `job.data` (which never needs to know the state point).

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
