### PR TITLE
Fix typo in the name of JobsCursor class.

### DIFF
--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -974,7 +974,7 @@ class Project:
     def groupby(self, key=None, default=None):
         """Group jobs according to one or more state point parameters.
 
-        This method can be called on any :class:`~signac.contrib.project.JobCursor` such as
+        This method can be called on any :class:`~signac.contrib.project.JobsCursor` such as
         the one returned by :meth:`~signac.Project.find_jobs` or by iterating over a
         project.
 
@@ -1024,7 +1024,7 @@ class Project:
     def groupbydoc(self, key=None, default=None):
         """Group jobs according to one or more document values.
 
-        This method can be called on any :class:`~signac.contrib.project.JobCursor` such as
+        This method can be called on any :class:`~signac.contrib.project.JobsCursor` such as
         the one returned by :meth:`~signac.Project.find_jobs` or by iterating over a
         project.
 
@@ -2409,7 +2409,7 @@ class JobsCursor:
     def groupby(self, key=None, default=None):
         """Group jobs according to one or more state point parameters.
 
-        This method can be called on any :class:`~signac.contrib.project.JobCursor` such as
+        This method can be called on any :class:`~signac.contrib.project.JobsCursor` such as
         the one returned by :meth:`~signac.Project.find_jobs` or by iterating over a
         project.
 


### PR DESCRIPTION
## Description
Fixes a typo. I will merge immediately.
