### PR TITLE
Add __contains__ method to JobsCursor for O(1) containment check instead of requiring O(N) iteration.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,11 @@ Version 1
 next
 ----
 
+Added
++++++
+
+ - Implemented ``JobsCursor.__contains__`` check (#449).
+
 Changed
 +++++++
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -703,7 +703,7 @@ class Project:
     __len__ = num_jobs
 
     def __contains__(self, job):
-        """Determine whether job is in the project's data space.
+        """Determine whether a job is in the project's data space.
 
         Parameters
         ----------
@@ -2373,12 +2373,34 @@ class JobsCursor:
     def __len__(self):
         # Highly performance critical code path!!
         if self._filter or self._doc_filter:
-            # We use the standard function for determining job ids if and only if
-            # any of the two filter is provided.
+            # We use the standard function for determining job ids if a filter
+            # is provided.
             return len(self._project._find_job_ids(self._filter, self._doc_filter))
         else:
-            # Without filter we can simply return the length of the whole project.
-            return self._project.__len__()
+            # Without filters, we can simply return the length of the whole project.
+            return len(self._project)
+
+    def __contains__(self, job):
+        """Determine whether a job is in this cursor.
+
+        Parameters
+        ----------
+        job : :class:`~signac.contrib.job.Job`
+            The job to check.
+
+        Returns
+        -------
+        bool
+            True if the job matches the filter criteria and is initialized for this project.
+
+        """
+        if self._filter or self._doc_filter:
+            # We use the standard function for determining job ids if a filter
+            # is provided.
+            return job.id in self._project._find_job_ids(self._filter, self._doc_filter)
+        else:
+            # Without filters, we can simply check if the job is in the project.
+            return job in self._project
 
     def __iter__(self):
         # Code duplication here for improved performance.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -2394,13 +2394,16 @@ class JobsCursor:
             True if the job matches the filter criteria and is initialized for this project.
 
         """
+        if job not in self._project:
+            # Exit early if the job is not in the project.
+            return False
         if self._filter or self._doc_filter:
             # We use the standard function for determining job ids if a filter
             # is provided.
             return job.id in self._project._find_job_ids(self._filter, self._doc_filter)
-        else:
-            # Without filters, we can simply check if the job is in the project.
-            return job in self._project
+        # Without filters, we can simply check if the job is in the project.
+        # By the early-exit condition, we know the job must be contained.
+        return True
 
     def __iter__(self):
         # Code duplication here for improved performance.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -2393,11 +2393,14 @@ class JobsCursor:
 
         """
         if job not in self._project:
-            # Exit early if the job is not in the project.
+            # Exit early if the job is not in the project. This is O(1).
             return False
         if self._filter or self._doc_filter:
             # We use the standard function for determining job ids if a filter
-            # is provided.
+            # is provided. This is O(N) and could be optimized by caching the
+            # ids of state points that match a state point filter. Caching the
+            # matches for a document filter is not safe because the document
+            # can change.
             return job.id in self._project._find_job_ids(self._filter, self._doc_filter)
         # Without filters, we can simply check if the job is in the project.
         # By the early-exit condition, we know the job must be contained.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -648,6 +648,13 @@ class TestProject(TestProjectBase):
         job.init()
         assert job in self.project
 
+    def test_JobsCursor_contains(self):
+        cursor = self.project.find_jobs()
+        job = self.open_job(dict(a=0))
+        assert job not in cursor
+        job.init()
+        assert job in cursor
+
     def test_job_move(self):
         root = self._tmp_dir.name
         project_a = signac.init_project("ProjectA", os.path.join(root, "a"))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -313,6 +313,23 @@ class TestProject(TestProjectBase):
         assert 1 == len(list(self.project.find_jobs({"a": 0})))
         assert 0 == len(list(self.project.find_jobs({"a": 5})))
 
+    def test_find_jobs_JobsCursor_contains(self):
+        statepoints = [{"a": i} for i in range(5)]
+        for sp in statepoints:
+            self.project.open_job(sp).document["test"] = True
+        cursor_all = self.project.find_jobs()
+        for sp in statepoints:
+            assert self.project.open_job(sp) in cursor_all
+        cursor_first = self.project.find_jobs(statepoints[0])
+        for sp in statepoints:
+            if sp["a"] == 0:
+                assert self.project.open_job(sp) in cursor_first
+            else:
+                assert self.project.open_job(sp) not in cursor_first
+        cursor_doc = self.project.find_jobs(doc_filter={"test": True})
+        for sp in statepoints:
+            assert self.project.open_job(sp) in cursor_doc
+
     def test_find_jobs_next(self):
         statepoints = [{"a": i} for i in range(5)]
         for sp in statepoints:


### PR DESCRIPTION
## Description
The aggregation feature exposed a performance-critical feature missing in the `JobsCursor` class, namely that it doesn't have a fast way to check if a job is contained in the `JobsCursor`.

## Motivation and Context
Changes job-in-cursor checks from O(N) to O(1) for cases where filters are not provided (this is the most common case, such as when iterating over the whole project).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
