### PR TITLE
Feature/synced collection/optimization

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ ignore = E123,E126,E203,E226,E241,E704,W503,W504
 match = ^((?!\.sync-zenodo-metadata|setup|benchmark|mpipool|connection|crypt|host|filesystems|indexing).)*\.py$
 match-dir = ^((?!\.|tests|configobj|db).)*$
 ignore-decorators = "deprecated"
-ignore = D105, D107, D203, D204, D213
+add-ignore = D105, D107, D203, D204, D213
 
 [mypy]
 ignore_missing_imports = True

--- a/signac/core/synced_collections/buffered_collection.py
+++ b/signac/core/synced_collections/buffered_collection.py
@@ -16,7 +16,7 @@ heavy I/O. The specific buffering mechanism must be implemented by each backend
 since it depends on the nature of the underlying data format.
 
 All buffered collections expose a local context manager for buffering. In addition,
-this module exposes a global context manager :func:`buffer_reads_writes` that
+this module exposes a global context manager :func:`buffer_all` that
 indicates to all buffered collections irrespective of data type or backend that
 they should enter buffered mode. These context managers may be nested freely, and
 buffer flushes will occur when all such managers have been exited.
@@ -24,7 +24,7 @@ buffer flushes will occur when all such managers have been exited.
 .. code-block::
 
     with collection1.buffered:
-        with buffer_reads_writes:
+        with buffer_all:
             collection2['foo'] = 1
             collection1['bar'] = 1
             # collection2 will flush when this context exits.
@@ -104,7 +104,7 @@ class BufferedCollection(SyncedCollection):
 
     @staticmethod
     @contextmanager
-    def buffer_reads_writes():
+    def buffer_all():
         """Enter a globally buffer context for all BufferedCollection instances.
 
         All future operations use the buffer whenever possible. Write operations
@@ -231,4 +231,4 @@ class BufferedCollection(SyncedCollection):
         pass
 
 
-buffer_reads_writes = BufferedCollection.buffer_reads_writes
+buffer_all = BufferedCollection.buffer_all

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -16,6 +16,7 @@ from .synced_list import SyncedList
 from .validators import json_format_validator
 
 
+# TODO: This method should be removed in signac 2.0.
 def _convert_key_to_str(data):
     """Recursively convert non-string keys to strings in dicts.
 
@@ -27,8 +28,12 @@ def _convert_key_to_str(data):
     for dicts. These inputs were silently converted to string keys and stored
     since JSON does not support integer keys. This behavior is deprecated and
     will become an error in signac 2.0.
+
+    Note for developers: this method is designed for use as a validator in the
+    synced collections framework, but due to the backwards compatibility requirement
+    it violates the general behavior of validators by modifying the data in place.
+    This behavior can be removed in signac 2.0 once non-str keys become an error.
     """
-    # TODO: This method should be removed in signac 2.0.
     if isinstance(data, dict):
 
         def _str_key(key):
@@ -41,12 +46,13 @@ def _convert_key_to_str(data):
                 key = str(key)
             return key
 
-        return {
-            _str_key(key): _convert_key_to_str(value) for key, value in data.items()
-        }
+        # Get a list of keys a priori to support modification in place.
+        for key in list(data):
+            _convert_key_to_str(data[key])
+            data[_str_key(key)] = data.pop(key)
     elif isinstance(data, list):
-        return [_convert_key_to_str(value) for value in data]
-    return data
+        for i, value in enumerate(data):
+            _convert_key_to_str(value)
 
 
 class JSONCollection(SyncedCollection):
@@ -99,7 +105,7 @@ class JSONCollection(SyncedCollection):
         """Write the data to JSON file."""
         data = self._to_base()
         # Converting non-string keys to string
-        data = _convert_key_to_str(data)
+        # data = _convert_key_to_str(data)
         # Serialize data
         blob = json.dumps(data).encode()
         # When write_concern flag is set, we write the data into dummy file and then
@@ -120,7 +126,7 @@ class JSONCollection(SyncedCollection):
         return self._filename
 
 
-JSONCollection.add_validator(json_format_validator)
+JSONCollection.add_validator(json_format_validator, _convert_key_to_str)
 
 
 class BufferedJSONCollection(FileBufferedCollection, JSONCollection):

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -8,20 +8,13 @@ import json
 import os
 import uuid
 import warnings
-from typing import Any, Dict
 
 from .file_buffered_collection import FileBufferedCollection
 from .synced_attr_dict import SyncedAttrDict
 from .synced_collection import SyncedCollection
 from .synced_list import SyncedList
+from .utils import SCJSONEncoder
 from .validators import json_format_validator
-
-try:
-    import numpy
-
-    NUMPY = True
-except ImportError:
-    NUMPY = False
 
 
 # TODO: This method should be removed in signac 2.0.
@@ -61,33 +54,6 @@ def _convert_key_to_str(data):
     elif isinstance(data, list):
         for i, value in enumerate(data):
             _convert_key_to_str(value)
-
-
-class CustomJSONEncoder(json.JSONEncoder):
-    """Attempt to JSON-encode objects beyond the default supported types.
-
-    This encoder will attempt to obtain a JSON-serializable representation of
-    an object that is otherwise not serializable, by calling the object's
-    `_as_dict()` method.
-    """
-
-    # TODO: If a user tries to access this encoder to manually dump and calls a
-    # dump before any operation, the data won't have been initialized. This
-    # isn't in itself important, since we'll make this private, but consider
-    # whether there are any issues with that. I assume not, since we're
-    # considering making these objects lazy altogether.
-    def default(self, o: Any) -> Dict[str, Any]:  # noqa: D102
-        if NUMPY:
-            if isinstance(o, numpy.number):
-                return o.item()
-            elif isinstance(o, numpy.ndarray):
-                return o.tolist()
-        try:
-            return o._data
-        except AttributeError:
-            # Call the super method, which raises a TypeError if it cannot
-            # encode the object.
-            return super().default(o)
 
 
 class JSONCollection(SyncedCollection):
@@ -139,7 +105,7 @@ class JSONCollection(SyncedCollection):
     def _save_to_resource(self):
         """Write the data to JSON file."""
         # Serialize data
-        blob = json.dumps(self, cls=CustomJSONEncoder).encode()
+        blob = json.dumps(self, cls=SCJSONEncoder).encode()
         # When write_concern flag is set, we write the data into dummy file and then
         # replace that file with original file.
         if self._write_concern:

--- a/signac/core/synced_collections/file_buffered_collection.py
+++ b/signac/core/synced_collections/file_buffered_collection.py
@@ -16,6 +16,7 @@ from typing import Dict, Tuple, Union
 
 from .buffered_collection import BufferedCollection
 from .errors import MetadataError
+from .utils import SCJSONEncoder
 
 
 class FileBufferedCollection(BufferedCollection):
@@ -207,7 +208,7 @@ class FileBufferedCollection(BufferedCollection):
             The underlying encoded data.
 
         """
-        return json.dumps(data).encode()
+        return json.dumps(data, cls=SCJSONEncoder).encode()
 
     @staticmethod
     def _decode(blob):
@@ -236,7 +237,7 @@ class FileBufferedCollection(BufferedCollection):
         in the buffer and the integrity checks performed.
         """
         if self._filename in self._cache:
-            blob = self._encode(self._to_base())
+            blob = self._encode(self)
             cached_data = self._cache[self._filename]
             buffer_size_change = len(blob) - len(cached_data["contents"])
             FileBufferedCollection._CURRENT_BUFFER_SIZE += buffer_size_change

--- a/signac/core/synced_collections/file_buffered_collection.py
+++ b/signac/core/synced_collections/file_buffered_collection.py
@@ -171,7 +171,7 @@ class FileBufferedCollection(BufferedCollection):
                 # multiple collections pointing to the same file, etc).
                 pass
             else:
-                blob = self._encode(self._to_base())
+                blob = self._encode(self._data)
 
                 # If the contents have not been changed since the initial read,
                 # we don't need to rewrite it.
@@ -237,7 +237,7 @@ class FileBufferedCollection(BufferedCollection):
         in the buffer and the integrity checks performed.
         """
         if self._filename in self._cache:
-            blob = self._encode(self)
+            blob = self._encode(self._data)
             cached_data = self._cache[self._filename]
             buffer_size_change = len(blob) - len(cached_data["contents"])
             FileBufferedCollection._CURRENT_BUFFER_SIZE += buffer_size_change
@@ -317,7 +317,7 @@ class FileBufferedCollection(BufferedCollection):
         additional check helps prevent or transparently error on otherwise
         unsafe access patterns.
         """
-        blob = self._encode(self._to_base())
+        blob = self._encode(self._data)
         metadata = self._get_file_metadata()
 
         self._cache[self._filename] = {

--- a/signac/core/synced_collections/synced_attr_dict.py
+++ b/signac/core/synced_collections/synced_attr_dict.py
@@ -99,9 +99,7 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
         bool
 
         """
-        if _mapping_resolver.get_type(data) == "MAPPING":
-            return True
-        return False
+        return _mapping_resolver.get_type(data) == "MAPPING"
 
     def _update(self, data=None):
         """Update the in-memory representation to match the provided data.

--- a/signac/core/synced_collections/synced_attr_dict.py
+++ b/signac/core/synced_collections/synced_attr_dict.py
@@ -150,7 +150,7 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
                         # Fall through if the new value is not identical to the
                         # existing value and
                         #     1) The existing value is not a SyncedCollection
-                        #        (in which case we would have tried to update it, OR
+                        #        (in which case we would have tried to update it), OR
                         #     2) The existing value is a SyncedCollection, but
                         #       the new value is not a compatible type for _update.
                         self._validate({key: new_value})

--- a/signac/core/synced_collections/synced_collection.py
+++ b/signac/core/synced_collections/synced_collection.py
@@ -9,12 +9,21 @@ from contextlib import contextmanager
 from inspect import isabstract
 from typing import Any, Callable, DefaultDict, List
 
+from .utils import AbstractTypeResolver
+
 try:
     import numpy
 
     NUMPY = True
 except ImportError:
     NUMPY = False
+
+# Identifies types of SyncedCollection, which are the base type for this class.
+_sc_resolver = AbstractTypeResolver(
+    {
+        "SYNCEDCOLLECTION": lambda obj: isinstance(obj, SyncedCollection),
+    }
+)
 
 
 class SyncedCollection(Collection):

--- a/signac/core/synced_collections/synced_collection.py
+++ b/signac/core/synced_collections/synced_collection.py
@@ -66,7 +66,7 @@ class SyncedCollection(Collection):
     callables that accept different data types as input and raise Exceptions if the
     data does not conform to the requirements of a particular backend. For
     example, a JSON validator would raise Exceptions if it detected non-string
-    keys in a dict.
+    keys in a dict. Validators should have no side effects.
 
     Parameters
     ----------

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 class AbstractTypeResolver:
-    r"""Mapping between recognized types and their abstract parents.
+    """Mapping between recognized types and their abstract parents.
 
     Synced collections are heavily reliant on checking the types of objects to
     determine the appropriate type of behavior in various scenarios. For maximum
@@ -28,8 +28,8 @@ class AbstractTypeResolver:
     a workaround by which we can amortize the cost of type checks. Given a set
     of types that must be resolved and a way to identify each of these (which
     may be expensive), it maintains a local cache of all instances of a given
-    type that have previously been observed. This allows :math:`\mathcal{O}(1)`
-    type checks except for the very first time a given type is seen.
+    type that have previously been observed. This reduces the cost of type checking
+    to a simple dict lookup, except for the first time a new type is observed.
 
     Parameters
     ----------

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -80,8 +80,7 @@ class AbstractTypeResolver:
                 if id_func(obj):
                     enum_type = self.type_map[dtype] = adt
                     break
-            if enum_type is None:
-                self.type_map[dtype] = None
+            self.type_map[dtype] = enum_type
 
         return enum_type
 

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -22,7 +22,7 @@ class AbstractTypeResolver:
     generality, most of these checks use the ABCs defined in :py:mod:`collections.abc`.
     The price of this flexibility is that `isinstance` checks with these classes
     are very slow because the ``__instancecheck__`` hooks are implemented in pure
-    Python and reuqire checking many different cases.
+    Python and require checking many different cases.
 
     Rather than attempting to directly optimize this behavior, this class provides
     a workaround by which we can amortize the cost of type checks. Given a set
@@ -71,16 +71,16 @@ class AbstractTypeResolver:
             will return ``None``.
 
         """
-        dtype = type(obj)
+        obj_type = type(obj)
         enum_type = None
         try:
-            enum_type = self.type_map[dtype]
+            enum_type = self.type_map[obj_type]
         except KeyError:
-            for adt, id_func in self.abstract_type_identifiers.items():
+            for data_type, id_func in self.abstract_type_identifiers.items():
                 if id_func(obj):
-                    enum_type = self.type_map[dtype] = adt
+                    enum_type = self.type_map[obj_type] = data_type
                     break
-            self.type_map[dtype] = enum_type
+            self.type_map[obj_type] = enum_type
 
         return enum_type
 

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2020 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Define common utilities."""
+
+
+class AbstractTypeResolver:
+    r"""Mapping between recognized types and their abstract parents.
+
+    Synced collections are heavily reliant on checking the types of objects to
+    determine the appropriate type of behavior in various scenarios. For maximum
+    generality, most of these checks use the ABCs defined in :py:mod:`collections.abc`.
+    The price of this flexibility is that `isinstance` checks with these classes
+    are very slow because the ``__instancecheck__`` hooks are implemented in pure
+    Python and reuqire checking many different cases.
+
+    Rather than attempting to directly optimize this behavior, this class provides
+    a workaround by which we can amortize the cost of type checks. Given a set
+    of types that must be resolved and a way to identify each of these (which
+    may be expensive), it maintains a local cache of all instances of a given
+    type that have previously been observed. This allows :math:`\mathcal{O}(1)`
+    type checks except for the very first time a given type is seen.
+
+    Parameters
+    ----------
+    abstract_type_identifiers : collections.abc.Mapping
+        A mapping from a string identifier for a group of types (e.g. ``MAPPING``)
+        to a callable that can be used to identify that type. Due to insertion order
+        guarantees of dictionaries in Python>=3.6 (officially 3.7), it is beneficial
+        to order this dictionary with the most frequently occuring types first.
+
+    Attributes
+    ----------
+    abstract_type_identifiers : Dict[str, Callable[Any, bool]]
+        A mapping from string identifiers for an abstract type to callables that
+        accepts an object and returns True if the object is of the key type and
+        False if not.
+    type_map : Dict[Type, str]
+        A mapping from concrete types to the corresponding named abstract type
+        from :attr:`type_enum`.
+
+    """
+
+    def __init__(self, abstract_type_identifiers):
+        self.abstract_type_identifiers = abstract_type_identifiers
+        self.type_map = {}
+
+    def get_type(self, obj):
+        """Get the type string corresponding to this data type.
+
+        Parameters
+        ----------
+        obj : Any
+            Any object whose type to check
+
+        Returns
+        -------
+        str
+            The name of the type, where valid types are the keys of the dict
+            argument to the constructor. If the object's type cannot be identified,
+            will return ``None``.
+
+        """
+        dtype = type(obj)
+        enum_type = None
+        try:
+            enum_type = self.type_map[dtype]
+        except KeyError:
+            for adt, id_func in self.abstract_type_identifiers.items():
+                if id_func(obj):
+                    enum_type = self.type_map[dtype] = adt
+                    break
+
+        return enum_type

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -70,5 +70,7 @@ class AbstractTypeResolver:
                 if id_func(obj):
                     enum_type = self.type_map[dtype] = adt
                     break
+            if enum_type is None:
+                self.type_map[dtype] = None
 
         return enum_type

--- a/signac/core/synced_collections/validators.py
+++ b/signac/core/synced_collections/validators.py
@@ -11,9 +11,9 @@ types as needed.
 """
 
 from collections.abc import Mapping, Sequence
-from enum import Enum, auto
 
 from ...errors import InvalidKeyError, KeyTypeError
+from .utils import AbstractTypeResolver
 
 try:
     import numpy
@@ -23,26 +23,13 @@ except ImportError:
     NUMPY = False
 
 
-"""Instance checks for abcs are expensive. Moreover, even for base classes isinstance
-is slower than a dict lookup. Therefore, we can be much faster by only calling isinstance
-when we have not seen a type before, then caching it; it's very unlikely that a user
-will be using many _different_ data types in a given run."""
-
-
-class AbstractTypes(Enum):
-    """Simple representation of ABCs to avoid instance checks."""
-
-    GENERIC = auto()
-    MAPPING = auto()
-    NON_STR_SEQUENCE = auto()
-
-
-_TYPE_CACHE = {
-    str: AbstractTypes.GENERIC,
-    dict: AbstractTypes.MAPPING,
-    list: AbstractTypes.NON_STR_SEQUENCE,
-    tuple: AbstractTypes.NON_STR_SEQUENCE,
-}
+_no_dot_in_key_type_resolver = AbstractTypeResolver(
+    {
+        "MAPPING": lambda obj: isinstance(obj, Mapping),
+        "NON_STR_SEQUENCE": lambda obj: isinstance(obj, Sequence)
+        and not isinstance(obj, str),
+    }
+)
 
 
 def no_dot_in_key(data):
@@ -63,18 +50,9 @@ def no_dot_in_key(data):
     """
     VALID_KEY_TYPES = (str, int, bool, type(None))
 
-    dtype = type(data)
-    try:
-        switch_type = _TYPE_CACHE[dtype]
-    except KeyError:
-        if isinstance(data, Mapping):
-            switch_type = _TYPE_CACHE[dtype] = AbstractTypes.MAPPING
-        elif isinstance(data, Sequence) and not isinstance(data, str):
-            switch_type = _TYPE_CACHE[dtype] = AbstractTypes.NON_STR_SEQUENCE
-        else:
-            switch_type = _TYPE_CACHE[dtype] = AbstractTypes.GENERIC
+    switch_type = _no_dot_in_key_type_resolver.get_type(data)
 
-    if switch_type == AbstractTypes.MAPPING:
+    if switch_type == "MAPPING":
         for key, value in data.items():
             if isinstance(key, str):
                 if "." in key:
@@ -86,31 +64,19 @@ def no_dot_in_key(data):
                     f"Mapping keys must be str, int, bool or None, not {type(key).__name__}"
                 )
             no_dot_in_key(value)
-    elif switch_type == AbstractTypes.NON_STR_SEQUENCE:
+    elif switch_type == "NON_STR_SEQUENCE":
         for value in data:
             no_dot_in_key(value)
 
 
-class AbstractTypesJSON(Enum):
-    """Simple representation of ABCs to avoid instance checks."""
-
-    BASE = auto()
-    MAPPING = auto()
-    SEQUENCE = auto()
-    NUMPY = auto()
-    INVALID = auto()
-
-
-_TYPE_CACHE_JSON = {
-    str: AbstractTypesJSON.BASE,
-    int: AbstractTypesJSON.BASE,
-    float: AbstractTypesJSON.BASE,
-    bool: AbstractTypesJSON.BASE,
-    type(None): AbstractTypesJSON.BASE,
-    dict: AbstractTypesJSON.MAPPING,
-    list: AbstractTypesJSON.SEQUENCE,
-    tuple: AbstractTypesJSON.SEQUENCE,
-}
+_json_format_validator_type_resolver = AbstractTypeResolver(
+    {
+        "BASE": lambda obj: isinstance(obj, (str, int, float, bool, type(None))),
+        "MAPPING": lambda obj: isinstance(obj, Mapping),
+        "SEQUENCE": lambda obj: isinstance(obj, Sequence),
+        "NUMPY": lambda obj: NUMPY and isinstance(obj, (numpy.ndarray, numpy.number)),
+    }
+)
 
 
 def json_format_validator(data):
@@ -129,25 +95,11 @@ def json_format_validator(data):
         If the data type of ``data`` is not supported.
 
     """
-    dtype = type(data)
+    switch_type = _json_format_validator_type_resolver.get_type(data)
 
-    try:
-        switch_type = _TYPE_CACHE_JSON[dtype]
-    except KeyError:
-        if isinstance(data, (str, int, float, bool, type(None))):
-            switch_type = _TYPE_CACHE_JSON[dtype] = AbstractTypesJSON.BASE
-        if isinstance(data, Mapping):
-            switch_type = _TYPE_CACHE_JSON[dtype] = AbstractTypesJSON.MAPPING
-        elif isinstance(data, Sequence):
-            switch_type = _TYPE_CACHE_JSON[dtype] = AbstractTypesJSON.SEQUENCE
-        elif NUMPY and isinstance(data, (numpy.ndarray, numpy.number)):
-            switch_type = _TYPE_CACHE_JSON[dtype] = AbstractTypesJSON.NUMPY
-        else:
-            switch_type = _TYPE_CACHE_JSON[dtype] = AbstractTypesJSON.INVALID
-
-    if switch_type == AbstractTypesJSON.BASE:
+    if switch_type == "BASE":
         return
-    elif switch_type == AbstractTypesJSON.MAPPING:
+    elif switch_type == "MAPPING":
         for key, value in data.items():
             # Support for non-str keys will be removed in version 2.0.
             # See issue: https://github.com/glotzerlab/signac/issues/316.
@@ -156,10 +108,10 @@ def json_format_validator(data):
                     f"Keys must be str, int, bool or None, not {type(key).__name__}"
                 )
             json_format_validator(value)
-    elif switch_type == AbstractTypesJSON.SEQUENCE:
+    elif switch_type == "SEQUENCE":
         for value in data:
             json_format_validator(value)
-    elif switch_type == AbstractTypesJSON.NUMPY:
+    elif switch_type == "NUMPY":
         if numpy.iscomplex(data).any():
             raise TypeError(
                 "NumPy object with complex value(s) is not JSON serializable"

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 
 import pytest
 
-from signac.core.synced_collections.collection_json import JSONDict
 from signac.core.synced_collections.synced_collection import SyncedCollection
 from signac.errors import InvalidKeyError, KeyTypeError
 
@@ -387,17 +386,6 @@ class SyncedDictTest(SyncedCollectionTest):
             synced_collection[key] = testdata
             assert key in synced_collection
             assert synced_collection[key] == testdata
-
-    # The following test tests the support for non-str keys
-    # for JSON backend which will be removed in version 2.0.
-    # See issue: https://github.com/glotzerlab/signac/issues/316.
-    def test_keys_non_str_valid_type(self, synced_collection, testdata):
-        if isinstance(synced_collection, JSONDict):
-            for key in (0, None, True):
-                with pytest.deprecated_call(match="Use of.+as key is deprecated"):
-                    synced_collection[key] = testdata
-                assert str(key) in synced_collection
-                assert synced_collection[str(key)] == testdata
 
     def test_keys_invalid_type(self, synced_collection, testdata):
         class A:

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 import pytest
 from test_json_collection import JSONCollectionTest, TestJSONDict, TestJSONList
 
-from signac.core.synced_collections.buffered_collection import buffer_reads_writes
+from signac.core.synced_collections.buffered_collection import buffer_all
 from signac.core.synced_collections.collection_json import (
     BufferedJSONCollection,
     BufferedJSONDict,
@@ -131,7 +131,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         synced_collection["buffered"] = testdata
         assert "buffered" in synced_collection
         assert synced_collection["buffered"] == testdata
-        with buffer_reads_writes():
+        with buffer_all():
             assert "buffered" in synced_collection
             assert synced_collection["buffered"] == testdata
             synced_collection["buffered2"] = 1
@@ -140,7 +140,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         assert len(synced_collection) == 2
         assert "buffered2" in synced_collection
         assert synced_collection["buffered2"] == 1
-        with buffer_reads_writes():
+        with buffer_all():
             del synced_collection["buffered"]
             assert len(synced_collection) == 1
             assert "buffered" not in synced_collection
@@ -150,7 +150,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         assert synced_collection["buffered2"] == 1
 
         with pytest.raises(BufferedError):
-            with buffer_reads_writes():
+            with buffer_all():
                 synced_collection["buffered2"] = 2
                 self.store({"test": 1})
                 assert synced_collection["buffered2"] == 2
@@ -162,7 +162,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         assert len(synced_collection) == 0
 
         for outer_buffer, inner_buffer in itertools.product(
-            [synced_collection.buffered, buffer_reads_writes], repeat=2
+            [synced_collection.buffered, buffer_all], repeat=2
         ):
             err_msg = (
                 f"outer_buffer: {outer_buffer.__qualname__}, "
@@ -200,7 +200,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             assert "inside_first" in synced_collection2
             assert "inside_first" in on_disk_dict2
 
-            with buffer_reads_writes():
+            with buffer_all():
                 synced_collection["inside_second"] = 3
                 synced_collection2["inside_second"] = 3
 
@@ -248,7 +248,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             assert synced_collection["inside_first"] == 2
             assert "inside_first" not in on_disk_dict
 
-            with buffer_reads_writes():
+            with buffer_all():
                 synced_collection["inside_second"] = 3
                 synced_collection2["inside_second"] = 4
 
@@ -295,7 +295,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
                 assert synced_collection["inside_first"] == 2
                 assert on_disk_dict["inside_first"] == 3
 
-                with buffer_reads_writes():
+                with buffer_all():
                     synced_collection["inside_second"] = 3
                     synced_collection2["inside_second"] = 4
 
@@ -351,12 +351,12 @@ class TestBufferedJSONList(BufferedJSONCollectionTest, TestJSONList):
 
     def test_global_buffered(self, synced_collection):
         assert len(synced_collection) == 0
-        with buffer_reads_writes():
+        with buffer_all():
             synced_collection.reset([1, 2, 3])
             assert len(synced_collection) == 3
         assert len(synced_collection) == 3
         assert synced_collection == [1, 2, 3]
-        with buffer_reads_writes():
+        with buffer_all():
             assert len(synced_collection) == 3
             assert synced_collection == [1, 2, 3]
             synced_collection[0] = 4
@@ -367,7 +367,7 @@ class TestBufferedJSONList(BufferedJSONCollectionTest, TestJSONList):
 
         # metacheck failure
         with pytest.raises(BufferedError):
-            with buffer_reads_writes():
+            with buffer_all():
                 synced_collection.reset([1])
                 assert synced_collection == [1]
                 # Unfortunately the resolution of os.stat is

--- a/tests/test_synced_collections/test_json_collection.py
+++ b/tests/test_synced_collections/test_json_collection.py
@@ -53,6 +53,16 @@ class TestJSONDict(JSONCollectionTest, SyncedDictTest):
 
     _collection_type = JSONDict
 
+    # The following test tests the support for non-str keys
+    # for JSON backend which will be removed in version 2.0.
+    # See issue: https://github.com/glotzerlab/signac/issues/316.
+    def test_keys_non_str_valid_type(self, synced_collection, testdata):
+        for key in (0, None, True):
+            with pytest.deprecated_call(match="Use of.+as key is deprecated"):
+                synced_collection[key] = testdata
+            assert str(key) in synced_collection
+            assert synced_collection[str(key)] == testdata
+
 
 class TestJSONList(JSONCollectionTest, SyncedListTest):
 

--- a/tests/test_synced_collections/test_utils.py
+++ b/tests/test_synced_collections/test_utils.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2020 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+import json
+import os
+from collections.abc import Collection, MutableSequence
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from signac.core.synced_collections.collection_json import JSONDict
+from signac.core.synced_collections.synced_list import SyncedList
+from signac.core.synced_collections.utils import AbstractTypeResolver, SCJSONEncoder
+
+try:
+    import numpy
+
+    NUMPY = True
+except ImportError:
+    NUMPY = False
+
+
+def test_type_resolver():
+    resolver = AbstractTypeResolver(
+        {
+            "dict": lambda obj: isinstance(obj, dict),
+            "tuple": lambda obj: isinstance(obj, tuple),
+            "str": lambda obj: isinstance(obj, str),
+            "mutablesequence": lambda obj: isinstance(obj, MutableSequence),
+            "collection": lambda obj: isinstance(obj, Collection),
+            "set": lambda obj: isinstance(obj, set),
+        }
+    )
+
+    assert resolver.get_type({}) == "dict"
+    assert resolver.get_type((0, 1)) == "tuple"
+    assert resolver.get_type("abc") == "str"
+    assert resolver.get_type([]) == "mutablesequence"
+
+    # Make sure that order matters; collection should be found before list.
+    assert resolver.get_type(set()) == "collection"
+
+
+def test_json_encoder():
+    def encode_flat_dict(d):
+        """A limited JSON-encoding method for a flat dict or SyncedDict of ints."""
+        if hasattr(d, "_data"):
+            d = d._data
+
+        return "{" + ", ".join(f'"{k}": {v}' for k, v in d.items()) + "}"
+
+    # Raw dictionaries should be encoded transparently.
+    data = {"foo": 1, "bar": 2, "baz": 3}
+    assert json.dumps(data) == encode_flat_dict(data)
+    assert json.dumps(data, cls=SCJSONEncoder) == json.dumps(data)
+
+    with TemporaryDirectory() as tmp_dir:
+        fn = os.path.join(tmp_dir, "test_json_encoding.json")
+        synced_data = JSONDict(fn)
+        synced_data.update(data)
+        with pytest.raises(TypeError):
+            json.dumps(synced_data)
+        assert json.dumps(synced_data, cls=SCJSONEncoder) == encode_flat_dict(
+            synced_data
+        )
+
+        if NUMPY:
+            array = numpy.random.rand(3)
+            synced_data["foo"] = array
+            assert isinstance(synced_data["foo"], SyncedList)
+            assert (
+                json.loads(json.dumps(synced_data, cls=SCJSONEncoder)) == synced_data()
+            )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

This PR optimizes all JSON-based SyncedCollections, including the buffered mode. I benchmarked a number of operations comparing the new JSONDict to the old one on two machines, a 2020 Macbook Pro and our Linux workstations using a slow network file system (as opposed to faster scratch space). I'm happy to share some plots for those interested. Brief summary: depending on the operation being benchmarked, whether buffering is enabled, and the operating system, I see performance improvements in the range of 1.3x-2.7x. In general the biggest performance improvements are observed for operations that change the dict since they touch all of the code paths that I optimized. Some more detailed information:

- Overall I see bigger improvements on the Mac than on the Linux machines. I have not benchmarked the exact bottlenecks on the Linux machines, but I assume that these differences are mostly related to file I/O; the Mac has an SSD, so the I/O costs will be much lower and we can more directly observe the differences in the code complexity.
- Operations that mutate dicts (__setitem__ or update) are 2.2-2.7x faster on the Mac, whereas they are 1.2-2.2x faster on the Linux workstation. 
- Operations that only access data without changing it (__getitem__, keys, values, __call__) are 1.4-2.2x faster on the Mac. These operations gain a little less performance than the mutating operations because they require only a save, not a load call. On the Linux workstations this drops to more like a 1.2-1.8x speed bump.
- On the Mac, buffering only increases performance by about 20% for most operations. Moreover, for some operations it is actually slower. The new JSONDict is also faster than the old JSONDict, even when the new JSONDict does not have buffering activated. Again, this is largely a function of the fast SSD. However, it reveals serious bottlenecks with our buffering strategy that we could exploit; I'll make another issue to discuss that and link it when I do.
- On the Linux workstations, buffering increases performance by up to an order of magnitude, so that's more as expected. The old buffered JSONDict is 4x faster than the new unbuffered JSONDict, but once buffering is enabled the new JSONDict wins by about 2.5x again.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
