### PR TITLE
Handle non-Job objects in Job equality check.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ next
 Changed
 +++++++
 
- - Optimized job hash and equality checks (#442).
+ - Optimized job hash and equality checks (#442, #455).
 
 
 [1.5.1] -- 2020-12-19

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -138,7 +138,7 @@ class Job:
 
     def __eq__(self, other):
         return (
-            isinstance(other, type(self))
+            (isinstance(other, type(self)) or isinstance(self, type(other)))
             and (self.id == other.id)
             and (
                 os.path.realpath(self.workspace())

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -137,14 +137,11 @@ class Job:
         return hash(self.id)
 
     def __eq__(self, other):
-        return (
-            (isinstance(other, type(self)) or isinstance(self, type(other)))
-            and (self.id == other.id)
-            and (
-                os.path.realpath(self.workspace())
-                == os.path.realpath(other.workspace())
-            )
-        )
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.id == other.id and os.path.realpath(
+            self.workspace()
+        ) == os.path.realpath(other.workspace())
 
     def __str__(self):
         """Return the job's id."""

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -137,8 +137,13 @@ class Job:
         return hash(self.id)
 
     def __eq__(self, other):
-        return (self.id == other.id) and (
-            os.path.realpath(self._wd) == os.path.realpath(other._wd)
+        return (
+            isinstance(other, type(self))
+            and (self.id == other.id)
+            and (
+                os.path.realpath(self.workspace())
+                == os.path.realpath(other.workspace())
+            )
         )
 
     def __str__(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -154,12 +154,15 @@ class TestJob(TestJobBase):
 
         non_job = NonJob(job)
         assert job != non_job
+        assert non_job != job
 
         sub_job = JobSubclass(job)
         assert job == sub_job
+        assert sub_job == job
 
         job2 = self.project.open_job({"a": 0})
         assert job == job2
+        assert job2 == job
 
     def test_isfile(self):
         job = self.project.open_job({"a": 0})

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -131,6 +131,36 @@ class TestJob(TestJobBase):
         job = self.project.open_job({"a": 0})
         assert str(job) == job.id
 
+    def test_eq(self):
+        job = self.project.open_job({"a": 0})
+
+        # Make sure that Jobs can only be equal to other Job instances.
+        class NonJob:
+            """Minimal class that cannot be compared with Job objects."""
+
+            def __init__(self, job):
+                self.id = job.id
+                self._workspace = job.workspace()
+
+        class JobSubclass(Job):
+            """Minimal subclass that can be compared with Job objects."""
+
+            def __init__(self, job):
+                self._id = job.id
+                self._workspace = job.workspace()
+
+            def workspace(self):
+                return self._workspace
+
+        non_job = NonJob(job)
+        assert job != non_job
+
+        sub_job = JobSubclass(job)
+        assert job == sub_job
+
+        job2 = self.project.open_job({"a": 0})
+        assert job == job2
+
     def test_isfile(self):
         job = self.project.open_job({"a": 0})
         fn = "test.txt"


### PR DESCRIPTION
## Description
I caught a couple minor errors in signac-flow tests (to be addressed separately) that were exposed by the changes in #442. This unrelated problem in signac-flow indicated an issue in the new `__eq__` check, which doesn't correctly handle comparisons to non-Job objects. This PR fixes that bug so the `Job` class correctly adheres to the Python data model.

Specifically, the old `__eq__` behavior did nothing to ensure that the objects being tested for equality were Job objects. If a job object and a tuple were compared, the previous `Job` equality test just checked if `hash(job) == hash(tuple_of_data)`, which hid the test failures in signac-flow until #442 was merged and errors were raised by the comparison. However, the comparison _should not_ raise errors or return `False`, and should instead return `NotImplemented` [according to the Python data model](https://docs.python.org/3/reference/datamodel.html#object.__eq__) and some StackOverflow posts I found.

## Motivation and Context
Fixes minor bug in `__eq__` implementation.

[This issue from another library](https://github.com/googleapis/google-cloud-python/issues/3455) and [this section of the Python documentation](https://docs.python.org/3/reference/datamodel.html#object.__eq__) are helpful for explaining the motivation of the change.

I added tests that cover a range of cases.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.