### PR TITLE
Fix: don't delete invalid statepoints

### DIFF
--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -537,6 +537,8 @@ class Job:
                 except OSError as error:
                     if error.errno not in (errno.EEXIST, errno.EACCES):
                         raise
+            except JobsCorruptedError:
+                raise
             except Exception as error:
                 # Attempt to delete the file on error, to prevent corruption.
                 try:

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -528,17 +528,18 @@ class Job:
             fn_manifest = os.path.join(self.workspace(), self.FN_MANIFEST)
             try:
                 # Prepare the data before file creation and writing.
-                blob = json.dumps(self.statepoint, indent=2)
-
-                try:
-                    # Open the file for writing only if it does not exist yet.
-                    with open(fn_manifest, "w" if force else "x") as file:
-                        file.write(blob)
-                except OSError as error:
-                    if error.errno not in (errno.EEXIST, errno.EACCES):
-                        raise
+                statepoint = self.statepoint()
+                blob = json.dumps(statepoint, indent=2)
             except JobsCorruptedError:
                 raise
+
+            try:
+                # Open the file for writing only if it does not exist yet.
+                with open(fn_manifest, "w" if force else "x") as file:
+                    file.write(blob)
+            except OSError as error:
+                if error.errno not in (errno.EEXIST, errno.EACCES):
+                    raise
             except Exception as error:
                 # Attempt to delete the file on error, to prevent corruption.
                 try:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -18,12 +18,7 @@ import signac.common.config
 import signac.contrib
 from signac import Project  # noqa: F401
 from signac.contrib.job import Job  # noqa: F401
-from signac.errors import (
-    DestinationExistsError,
-    InvalidKeyError,
-    JobsCorruptedError,
-    KeyTypeError,
-)
+from signac.errors import DestinationExistsError, InvalidKeyError, KeyTypeError
 
 try:
     import h5py  # noqa
@@ -632,8 +627,8 @@ class TestJobOpenAndClosing(TestJobBase):
         job2 = self.open_job(test_token)
         try:
             logging.disable(logging.ERROR)
-            with pytest.raises(JobsCorruptedError):
-                job2.init()
+            # Detects the corrupted manifest and overwrites with valid data
+            job2.init()
         finally:
             logging.disable(logging.NOTSET)
         job2.init(force=True)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -482,8 +482,14 @@ class TestProject(TestProjectBase):
                 # Accessing the job state point triggers validation of the
                 # state point manifest file
                 self.project.open_job(id=job.id).statepoint
+            with pytest.raises(JobsCorruptedError):
+                # Initializing the job state point triggers validation of the
+                # state point manifest file
+                self.project.open_job(id=job.id).init()
         finally:
             logging.disable(logging.NOTSET)
+        # Ensure that the corrupted manifest still exists
+        assert os.path.exists(job.fn(job.FN_MANIFEST))
 
     def test_rename_workspace(self):
         job = self.project.open_job(dict(a=0))


### PR DESCRIPTION
## Description
The (unreleased) lazy loading code recently introduced in #239 and/or #451 appears to delete invalid state point files if the state point on disk is invalid AND `job.init()` is called before `job.statepoint`. In my understanding, the only case where a state point file should be deleted is if the initial file creation/write operation fails during `job.init()`.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
