### PR TITLE
Feature/synced collection/thread safe buffering

### DIFF
--- a/signac/core/synced_collections/buffered_collection.py
+++ b/signac/core/synced_collections/buffered_collection.py
@@ -83,14 +83,6 @@ class BufferedCollection(SyncedCollection):
     _BUFFERED_MODE = 0
     _BUFFERED_BACKENDS: List[Any] = []
 
-    # TODO: Include statement about thread-safety, and perhaps see if we can
-    # improve it. The main possible limitation is that while multithreaded
-    # access to different synced collections is safe in non-buffered mode
-    # (because the changes are completely independent), the same is not
-    # necessarily true in buffered mode if the buffer is shared. Additionally
-    # there are issues with buffer flushes occurring in parallel leading to
-    # race conditions.
-
     def __init__(self, *args, **kwargs):
         # The `_buffered` attribute _must_ be defined prior to calling the
         # superclass constructors in order to enable subclasses to override

--- a/signac/core/synced_collections/buffered_collection.py
+++ b/signac/core/synced_collections/buffered_collection.py
@@ -70,6 +70,14 @@ class BufferedCollection(SyncedCollection):
           is to simply call :meth:`~SyncedCollection._load_from_resource`
         - :meth:`~._save_to_buffer`: Stores data while in buffered mode. The default behavior
           is to simply call :meth:`~SyncedCollection._save_to_resource`
+
+    **Thread safety**
+
+    Whether or not buffering is thread safe depends on the buffering method used. In
+    general, both the buffering logic and the standard data read/write logic (i.e.
+    operations like `__setitem__`) must be thread safe for the resulting collection
+    type to be thread safe.
+
     """
 
     _BUFFERED_MODE = 0

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -66,6 +66,14 @@ class JSONCollection(SyncedCollection):
     accessible in the form of a text file with no additional tooling, but is
     likely a poor choice for high performance applications.
 
+    **Thread safety**
+
+    The JSONCollection is thread-safe. To make these collections safe, the
+    ``write_concern`` flag is ignored in multithreaded execution, and the
+    write is **always** performed via a write to temporary file followed by a
+    replacement of the original file. The file replacement operation uses
+    :py:func:`os.replace`, which is guaranteed to be atomic by the Python standard.
+
     Parameters
     ----------
     filename: str

--- a/signac/core/synced_collections/collection_mongodb.py
+++ b/signac/core/synced_collections/collection_mongodb.py
@@ -18,6 +18,10 @@ class MongoDBCollection(SyncedCollection):
     as a single document within the collection provided by the user. The document
     is identified by a unique key provided by the user.
 
+    **Thread safety**
+
+    The MongoDBCollection is not thread-safe.
+
     Parameters
     ----------
     collection : :py:class:`pymongo.collection.Collection`

--- a/signac/core/synced_collections/collection_redis.py
+++ b/signac/core/synced_collections/collection_redis.py
@@ -14,6 +14,10 @@ class RedisCollection(SyncedCollection):
 
     This backend stores data in Redis by associating it with the provided key.
 
+    **Thread safety**
+
+    The RedisCollection is not thread-safe.
+
     Parameters
     ----------
     client : redis.Redis

--- a/signac/core/synced_collections/collection_zarr.py
+++ b/signac/core/synced_collections/collection_zarr.py
@@ -19,6 +19,10 @@ class ZarrCollection(SyncedCollection):
     provides the group within which to store the data and the name of the data in
     the group.
 
+    **Thread safety**
+
+    The ZarrCollection is not thread-safe.
+
     Parameters
     ----------
     group : zarr.hierarchy.Group

--- a/signac/core/synced_collections/file_buffered_collection.py
+++ b/signac/core/synced_collections/file_buffered_collection.py
@@ -21,9 +21,6 @@ from .errors import MetadataError
 from .synced_collection import _fake_lock
 from .utils import SCJSONEncoder
 
-# TODO: Port the extensions from this class's multithreading support to the
-# memory buffered collection.
-
 
 @contextmanager
 def _buffer_lock(self):

--- a/signac/core/synced_collections/file_buffered_collection.py
+++ b/signac/core/synced_collections/file_buffered_collection.py
@@ -12,6 +12,7 @@ import errno
 import hashlib
 import json
 import os
+from threading import RLock
 from typing import Dict, Tuple, Union
 
 from .buffered_collection import BufferedCollection
@@ -33,11 +34,6 @@ class FileBufferedCollection(BufferedCollection):
     might be present. This setting has no effect on the buffering behavior of
     other :class:`BufferedCollection` types.
 
-    Parameters
-    ----------
-    filename: str, optional
-        The filename of the associated JSON file on disk (Default value = None).
-
     .. note::
         Important note for subclasses: This class should be inherited before
         any other collections. This requirement is due to the extensive use of
@@ -46,6 +42,11 @@ class FileBufferedCollection(BufferedCollection):
         of buffering behavior, it transparently hooks into the initialization
         process, but this is dependent on its constructor being called before
         those of other classes.
+
+    Parameters
+    ----------
+    filename: str, optional
+        The filename of the associated JSON file on disk (Default value = None).
 
     Warnings
     --------
@@ -71,6 +72,7 @@ class FileBufferedCollection(BufferedCollection):
     _cached_collections: Dict[int, BufferedCollection] = {}
     _BUFFER_CAPACITY = 32 * 2 ** 20  # 32 MB
     _CURRENT_BUFFER_SIZE = 0
+    _buffer_lock = RLock()
 
     def __init__(self, filename=None, *args, **kwargs):
         super().__init__(filename=filename, *args, **kwargs)

--- a/signac/core/synced_collections/memory_buffered_collection.py
+++ b/signac/core/synced_collections/memory_buffered_collection.py
@@ -126,7 +126,7 @@ class SharedMemoryFileBufferedCollection(BufferedCollection):
 
     """
 
-    _cache: Dict[str, Dict[str, Union[bytes, str, Tuple[int, float, int]]]] = {}
+    _cache: Dict[str, Dict[str, Union[bytes, str, Tuple[int, float]]]] = {}
     _cached_collections: Dict[int, BufferedCollection] = {}
     _BUFFER_CAPACITY = 1000  # The number of collections to store in the buffer.
     _CURRENT_BUFFER_SIZE = 0

--- a/signac/core/synced_collections/memory_buffered_collection.py
+++ b/signac/core/synced_collections/memory_buffered_collection.py
@@ -396,8 +396,8 @@ class SharedMemoryFileBufferedCollection(BufferedCollection):
                     self._update(data)
             self._initialize_data_in_cache(modified=False)
 
-            # Set local data to the version in the buffer.
-            self._data = self._cache[self._filename]["contents"]
+        # Set local data to the version in the buffer.
+        self._data = self._cache[self._filename]["contents"]
 
     def _initialize_data_in_cache(self, modified):
         """Create the initial entry for the data in the cache.

--- a/signac/core/synced_collections/synced_attr_dict.py
+++ b/signac/core/synced_collections/synced_attr_dict.py
@@ -175,12 +175,10 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
         # directly set using those rather than looping over data.
         data = {key: value}
         self._validate(data)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 for key, value in data.items():
                     self._data[key] = self._from_base(value, parent=self)
-            self._save()
 
     def reset(self, data=None):
         """Update the instance with new data.
@@ -231,17 +229,13 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
         return self._data.get(key, default)
 
     def pop(self, key, default=None):  # noqa: D102
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             ret = self._data.pop(key, default)
-            self._save()
         return ret
 
     def popitem(self):  # noqa: D102
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             ret = self._data.popitem()
-            self._save()
         return ret
 
     def clear(self):  # noqa: D102
@@ -257,16 +251,13 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
         else:
             other = {}
 
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             # The order here is important to ensure that the promised sequence of
             # overrides is obeyed: kwargs > other > existing data.
             self._update({**self._data, **other, **kwargs})
-            self._save()
 
     def setdefault(self, key, default=None):  # noqa: D102
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             if key in self._data:
                 ret = self._data[key]
             else:
@@ -282,7 +273,6 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
                 with self._suspend_sync():
                     for key, value in data.items():
                         self._data[key] = value
-                self._save()
         return ret
 
     def __getattr__(self, name):

--- a/signac/core/synced_collections/synced_collection.py
+++ b/signac/core/synced_collections/synced_collection.py
@@ -100,6 +100,22 @@ class SyncedCollection(Collection):
     example, a JSON validator would raise Exceptions if it detected non-string
     keys in a dict. Validators should have no side effects.
 
+    **Thread safety**
+
+    Whether or not SyncedCollection objects are thread-safe depends on the
+    implementation of the backend. Thread-safety of SyncedCollection objects
+    is predicated on backends providing an atomic write operation. All concrete
+    collection types use mutexes to guard against concurrent write operations,
+    while allowing read operations to happen freely. The validity of this mode
+    of access depends on the write operations of a SyncedCollection being
+    atomic, specifically the `:meth:`~._save_to_resource` method.
+
+    Backends that support multithreaded execution will have multithreaded
+    support turned on by default. This support can be enabled or disabled using
+    the :meth:`enable_multithreading` and :meth:`disable_multithreading`
+    methods.
+
+
     Parameters
     ----------
     parent : SyncedCollection, optional

--- a/signac/core/synced_collections/synced_list.py
+++ b/signac/core/synced_collections/synced_list.py
@@ -185,52 +185,42 @@ class SyncedList(SyncedCollection, MutableSequence):
 
     def __setitem__(self, key, value):
         self._validate(value)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data[key] = self._from_base(data=value, parent=self)
-            self._save()
 
     def __reversed__(self):
-        with self._thread_lock():
-            self._load()
+        self._load()
         return reversed(self._data)
 
     def __iadd__(self, iterable):
         # Convert input to a list so that iterators work as well as iterables.
         iterable_data = list(iterable)
         self._validate(iterable_data)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data += [
                     self._from_base(data=value, parent=self) for value in iterable_data
                 ]
-            self._save()
         return self
 
     def insert(self, index, item):  # noqa: D102
         self._validate(item)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data.insert(index, self._from_base(data=item, parent=self))
-            self._save()
 
     def append(self, item):  # noqa: D102
         self._validate(item)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data.append(self._from_base(data=item, parent=self))
-            self._save()
 
     def extend(self, iterable):  # noqa: D102
         # Convert iterable to a list to ensure generators are exhausted only once
         iterable_data = list(iterable)
         self._validate(iterable_data)
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data.extend(
                     [
@@ -238,14 +228,11 @@ class SyncedList(SyncedCollection, MutableSequence):
                         for value in iterable_data
                     ]
                 )
-            self._save()
 
     def remove(self, value):  # noqa: D102
-        with self._thread_lock():
-            self._load()
+        with self._load_and_save():
             with self._suspend_sync():
                 self._data.remove(self._from_base(data=value, parent=self))
-            self._save()
 
     def clear(self):  # noqa: D102
         self._data = []

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -40,7 +40,6 @@ class SyncedDictTest(SyncedCollectionTest):
     def test_init_positional(self, synced_collection_positional):
         assert len(synced_collection_positional) == 0
 
-    @pytest.mark.xfail(reason="Currently error checking on construction is flawed.")
     def test_invalid_kwargs(self, synced_collection):
         # JSONDict raise an error when neither filename nor parent is passed.
         with pytest.raises(ValueError):
@@ -402,7 +401,6 @@ class SyncedDictTest(SyncedCollectionTest):
         if not type(synced_collection)._supports_threading:
             return
 
-        # TODO: Add a corresponding test for lists.
         from concurrent.futures import ThreadPoolExecutor
         from json.decoder import JSONDecodeError
         from threading import current_thread
@@ -452,7 +450,6 @@ class SyncedListTest(SyncedCollectionTest):
     def test_init(self, synced_collection):
         assert len(synced_collection) == 0
 
-    @pytest.mark.xfail(reason="Currently error checking on construction is flawed.")
     def test_invalid_kwargs(self, synced_collection):
         # JSONList raise an error when neither filename nor parent is passed.
         with pytest.raises(ValueError):

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -402,6 +402,7 @@ class SyncedDictTest(SyncedCollectionTest):
         if not type(synced_collection)._supports_threading:
             return
 
+        # TODO: Add a corresponding test for lists.
         from concurrent.futures import ThreadPoolExecutor
         from json.decoder import JSONDecodeError
         from threading import current_thread

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -28,7 +28,7 @@ class BufferedJSONCollectionTest(JSONCollectionTest):
 
     def load(self, collection):
         """Load the data corresponding to a SyncedCollection from disk."""
-        with open(collection._filename) as f:
+        with open(collection.filename) as f:
             return json.load(f)
 
 
@@ -333,7 +333,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             # Reset buffer capacity for other tests.
             self._collection_type.set_buffer_capacity(original_buffer_capacity)
 
-    @pytest.mark.skip
     def test_multithreaded_buffering(self):
         """Test that buffering in a multithreaded context is safe."""
         from concurrent.futures import ThreadPoolExecutor
@@ -372,7 +371,9 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
                             "simultaneously modifying the buffer."
                         ) from e
 
-                    assert all(dicts[i] == dict_data[i] for i in range(num_dicts))
+                    # assert all(dicts[i] == dict_data[i] for i in range(num_dicts))
+                    for i in range(num_dicts):
+                        assert dicts[i] == dict_data[i]
         finally:
             # Reset buffer capacity for other tests.
             self._collection_type.set_buffer_capacity(original_buffer_capacity)

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -358,8 +358,28 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
                     # for i in range(num_dicts):
                     #     dicts[i].update(dict_data[i])
+                    # TODO: Add separate tests for setitem and update.
+                    # TODO: Add a test that only loads the data into the buffer
+                    # but doesn't save anything. This will trigger a flush for
+                    # the old buffering mode (which needs to be thread safe)
+                    # but not in the new one.
+                    # TODO: Add a context manager that does a load-yield-save.
+                    # This whole cycle needs to be atomic, which is why
+                    # this buffering test currently fails. The buffered modes
+                    # can override this to introduce a lock if they need to.
+                    # Destructive ops like reset and clear won't go through
+                    # this, but in those cases just adding a thread lock on the
+                    # save_to_buffer should be safe enough because you don't
+                    # run into the case of one thing reading, then another
+                    # reading and writing, then the original writing, which can
+                    # break things. Note that for this reason overriding this
+                    # context manager with a lock won't change the need for
+                    # acquiring and releasing the locks in the save_to and
+                    # load_from_buffer methods.
                     def update_dict(sd, data):
-                        sd.update(data)
+                        # sd.update(data)
+                        for k, v in data.items():
+                            sd[k] = v
 
                     num_threads = 10
                     try:

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -254,7 +254,7 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             on_disk_dict = self.load(synced_collection)
             assert on_disk_dict["inside_second"] == 4
 
-    @pytest.mark.skip("Not currently sure what the expected behavior is.")
+    @pytest.mark.skip("This is an example of unsupported (and undefined) behavior).")
     def test_nested_copied_collection_invalid(self, synced_collection):
         """Test the behavior of invalid modifications of copied objects."""
         synced_collection2 = self._collection_type(filename=synced_collection._filename)
@@ -267,9 +267,9 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         with pytest.raises(MetadataError):
             with synced_collection.buffered():
                 synced_collection["inside_first"] = 2
-                # TODO: Currently, modifying synced_collection2 here causes
-                # problems.  It is unbuffered, so it directly writes to file.
-                # Then, when entering global buffering in the context below,
+                # Modifying synced_collection2 here causes problems. It is
+                # unbuffered, so it directly writes to file.  Then, when
+                # entering global buffering in the context below,
                 # synced_collection2 sees that synced_collection has already
                 # saved data for this file to the buffer, so it loads that
                 # data, which also means that synced_collection2 becomes
@@ -277,12 +277,10 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
                 # entered buffered mode. As a result, when the global buffering
                 # exits, we see metadata errors because synced_collection2 lost
                 # track of the fact that it saved changes to the file made
-                # prior to entering the global buffer. We _could_ fix this by
-                # changing the behavior of _load_buffer to not load the data
-                # from the cache if it exists, if the object is new to
-                # cached_collections then we would save a new version. However,
-                # I'm not sure that's the correct answer. Is there a true
-                # canonical source of truth in this scenario?
+                # prior to entering the global buffer. While this case could be
+                # given some specific behavior, there's no obvious canonical
+                # source of truth here, so we simply choose to skip it
+                # altogether.
                 synced_collection2["inside_first"] = 3
 
                 on_disk_dict = self.load(synced_collection)

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -453,7 +453,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
         capacity, even for read-only operations.
         """
         original_buffer_capacity = self._collection_type.get_buffer_capacity()
-        self._collection_type.disable_multithreading()
         try:
             # Choose some arbitrarily low value that will ensure intermittent
             # forced buffer flushes.
@@ -659,7 +658,6 @@ class TestBufferedJSONList(BufferedJSONCollectionTest, TestJSONList):
         capacity, even for read-only operations.
         """
         original_buffer_capacity = self._collection_type.get_buffer_capacity()
-        self._collection_type.disable_multithreading()
         try:
             # Choose some arbitrarily low value that will ensure intermittent
             # forced buffer flushes.

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -344,10 +344,10 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             new_buffer_capacity = 20
             self._collection_type.set_buffer_capacity(new_buffer_capacity)
 
-            with buffer_all():
-                with TemporaryDirectory(
-                    prefix="jsondict_buffered_multithreaded"
-                ) as tmp_dir:
+            with TemporaryDirectory(
+                prefix="jsondict_buffered_multithreaded"
+            ) as tmp_dir:
+                with buffer_all():
                     num_dicts = 100
                     dicts = []
                     dict_data = []
@@ -371,11 +371,15 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
                             "simultaneously modifying the buffer."
                         ) from e
 
+                    # First validate inside buffer.
                     # assert all(dicts[i] == dict_data[i] for i in range(num_dicts))
                     for i in range(num_dicts):
                         assert dicts[i] == dict_data[i]
+                # Now validate outside buffer.
+                for i in range(num_dicts):
+                    assert dicts[i] == dict_data[i]
         finally:
-            # Reset buffer capacity for other tests.
+            # Reset buffer capacity for other tests in case this fails.
             self._collection_type.set_buffer_capacity(original_buffer_capacity)
 
     def test_buffer_first_load(self, synced_collection):

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -395,10 +395,11 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(update_dict)
 
-    # def test_multithreaded_buffering_reset(self):
-    #     def reset_dict(sd, data):
-    #         sd.reset(data)
-    #     self.multithreaded_buffering_test(reset_dict)
+    def test_multithreaded_buffering_reset(self):
+        def reset_dict(sd, data):
+            sd.reset(data)
+
+        self.multithreaded_buffering_test(reset_dict)
 
     def test_buffer_first_load(self, synced_collection):
         """Ensure that existing data is preserved if the first load is in buffered mode."""

--- a/tests/test_synced_collections/test_mongodb_collection.py
+++ b/tests/test_synced_collections/test_mongodb_collection.py
@@ -14,8 +14,9 @@ try:
     import pymongo
 
     try:
-        # test the mongodb server
-        MongoClient = pymongo.MongoClient()
+        # Test the mongodb server. Set a short timeout so that tests don't
+        # appear to hang while waiting for a connection.
+        MongoClient = pymongo.MongoClient(serverSelectionTimeoutMS=1000)
         tmp_collection = MongoClient["test_db"]["test"]
         tmp_collection.insert_one({"test": "0"})
         ret = tmp_collection.find_one({"test": "0"})


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

This PR makes both implemented buffering modes thread-safe. This PR is a best effort attempt at achieving thread safety. There may still be edge cases that I did not catch, and it may be possible in at least some cases to reduce the locking serialization using more narrowly scoped mutexes. However, these changes are resilient to the different error cases that I tested (included as new tests), and since the purpose of buffered mode is to reduce I/O operations, once we're in buffered mode the code will be effectively serialized by Python anyway, so there's limited performance to be regained by allowing multithreaded I/O operations in practical use cases (although there will be edge cases where that's not the case, such as when reading a large number of files once after entering a buffer).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes as much of #397 as is in scope for the synced collections project. Process parallelism can still cause problems, but making the containers themselves safe for multiprocessing is out of scope for these objects. Calling code making use of these containers in a multiprocessing environment should be responsible for ensuring parallel safety.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
