### PR TITLE
Fix/issue 281

### DIFF
--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -671,6 +671,11 @@ class TestH5StoreMultiThreading(TestH5StoreBase):
         assert self.get_h5store()["x"] in set(range(100))
 
 
+def _read_from_h5store(filename, **kwargs):
+    with H5Store(filename, **kwargs) as h5s:
+        list(h5s)
+
+
 class TestH5StoreMultiProcessing(TestH5StoreBase):
     def test_single_writer_multiple_reader_same_process(self):
         with self.open_h5store() as writer:
@@ -688,12 +693,12 @@ class TestH5StoreMultiProcessing(TestH5StoreBase):
     def test_single_writer_multiple_reader_same_instance(self):
         from multiprocessing import Process
 
-        def _read_from_h5store(filename, **kwargs):
-            with H5Store(self._fn_store, mode="r", swmr=True) as h5s:
-                list(h5s)
-
         def read():
-            p = Process()
+            p = Process(
+                target=_read_from_h5store,
+                args=(self._fn_store,),
+                kwargs=(dict(mode="r", swmr=True, libver="latest")),
+            )
             p.start()
             p.join()
             # Ensure the process succeeded

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -683,7 +683,7 @@ class TestH5StoreMultiProcessing(TestH5StoreBase):
                         assert reader2["test"]
 
     @pytest.mark.skipif(
-        WINDOWS, reason="This test fails for an unknown reason on Windows."
+        python_implementation() != "CPython", reason="SWMR mode not available."
     )
     def test_single_writer_multiple_reader_same_instance(self):
         from multiprocessing import Process


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

The test modified by this PR was reading from an hdf5 file in one process while writing to it in a separate process using nested contexts. Even a single concurrent read is not safe while writing in other processes, but I suspect that parallel-safe reads for a single reader might be an implementation detail in some versions of hdf5 but not others (leading to the intermittently successful behavior on OS X and the consistently correct behavior on Linux). Given that a number of the other tests explicitly test SWMR, however, I'm not sure why this test doesn't have it enabled. Perhaps @bdice or @klywang can shed some light on that, I believe they wrote/inspected/modified various versions of these tests.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #281. In addition, the test will now pass on Windows.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
