### PR TITLE
Feature/synced collection/replace jsondict

### DIFF
--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -26,10 +26,10 @@ from .contrib import (
 )
 from .contrib import filesystems as fs
 from .contrib import get_job, get_project, index, index_files, init_project
+from .contrib.job import get_buffer_load, get_buffer_size
 from .core.h5store import H5Store, H5StoreManager
 from .core.jsondict import JSONDict
 from .core.jsondict import flush_all as flush
-from .core.jsondict import get_buffer_load, get_buffer_size
 from .core.synced_collections.buffered_collection import buffer_all as buffered
 from .core.synced_collections.buffered_collection import is_buffered
 from .db import get_database

--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -26,7 +26,7 @@ from .contrib import (
 )
 from .contrib import filesystems as fs
 from .contrib import get_job, get_project, index, index_files, init_project
-from .contrib.job import get_buffer_load, get_buffer_size
+from .contrib.job import get_buffer_load, get_buffer_size, set_buffer_size
 from .core.h5store import H5Store, H5StoreManager
 from .core.jsondict import JSONDict
 from .core.jsondict import flush_all as flush
@@ -69,6 +69,7 @@ __all__ = [
     "flush",
     "get_buffer_size",
     "get_buffer_load",
+    "set_buffer_size",
     "JSONDict",
     "H5Store",
     "H5StoreManager",

--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -28,10 +28,10 @@ from .contrib import filesystems as fs
 from .contrib import get_job, get_project, index, index_files, init_project
 from .contrib.job import get_buffer_load, get_buffer_size, set_buffer_size
 from .core.h5store import H5Store, H5StoreManager
-from .core.jsondict import JSONDict
 from .core.jsondict import flush_all as flush
 from .core.synced_collections.buffered_collection import buffer_all as buffered
 from .core.synced_collections.buffered_collection import is_buffered
+from .core.synced_collections.collection_json import JSONDict
 from .db import get_database
 from .diff import diff_jobs
 from .version import __version__

--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -28,10 +28,10 @@ from .contrib import filesystems as fs
 from .contrib import get_job, get_project, index, index_files, init_project
 from .core.h5store import H5Store, H5StoreManager
 from .core.jsondict import JSONDict
-from .core.jsondict import buffer_reads_writes as buffered
 from .core.jsondict import flush_all as flush
 from .core.jsondict import get_buffer_load, get_buffer_size
-from .core.jsondict import in_buffered_mode as is_buffered
+from .core.synced_collections.buffered_collection import buffer_all as buffered
+from .core.synced_collections.buffered_collection import is_buffered
 from .db import get_database
 from .diff import diff_jobs
 from .version import __version__

--- a/signac/contrib/errors.py
+++ b/signac/contrib/errors.py
@@ -28,8 +28,8 @@ class DestinationExistsError(Error, RuntimeError):
 
     Parameters
     ----------
-    destination :
-        The destination object causing the error.
+    destination : str
+        The destination causing the error.
 
     """
 

--- a/signac/contrib/hashing.py
+++ b/signac/contrib/hashing.py
@@ -6,7 +6,7 @@
 import hashlib
 import json
 
-from ..core.synced_collections.utils import SCJSONEncoder
+from ..core.synced_collections.utils import SyncedCollectionJSONEncoder
 from ..errors import KeyTypeError
 
 # We must use the standard library json for exact consistency in formatting
@@ -31,7 +31,7 @@ def calc_id(spec):
 
     """
     try:
-        blob = json.dumps(spec, cls=SCJSONEncoder, sort_keys=True)
+        blob = json.dumps(spec, cls=SyncedCollectionJSONEncoder, sort_keys=True)
     except TypeError:
         raise KeyTypeError
     m = hashlib.md5()

--- a/signac/contrib/hashing.py
+++ b/signac/contrib/hashing.py
@@ -6,6 +6,9 @@
 import hashlib
 import json
 
+from ..core.synced_collections.utils import SCJSONEncoder
+from ..errors import KeyTypeError
+
 # We must use the standard library json for exact consistency in formatting
 
 
@@ -27,7 +30,10 @@ def calc_id(spec):
         Encoded hash in hexadecimal format.
 
     """
-    blob = json.dumps(spec, sort_keys=True)
+    try:
+        blob = json.dumps(spec, cls=SCJSONEncoder, sort_keys=True)
+    except TypeError:
+        raise KeyTypeError
     m = hashlib.md5()
     m.update(blob.encode())
     return m.hexdigest()

--- a/signac/contrib/hashing.py
+++ b/signac/contrib/hashing.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 
 from ..core.synced_collections.utils import SyncedCollectionJSONEncoder
-from ..errors import KeyTypeError
 
 # We must use the standard library json for exact consistency in formatting
 
@@ -30,10 +29,7 @@ def calc_id(spec):
         Encoded hash in hexadecimal format.
 
     """
-    try:
-        blob = json.dumps(spec, cls=SyncedCollectionJSONEncoder, sort_keys=True)
-    except TypeError:
-        raise KeyTypeError
+    blob = json.dumps(spec, cls=SyncedCollectionJSONEncoder, sort_keys=True)
     m = hashlib.md5()
     m.update(blob.encode())
     return m.hexdigest()

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -766,7 +766,7 @@ def _copy_to_job_workspace(src, job, copytree):
             raise DestinationExistsError(job)
         raise
     else:
-        job._init()
+        job.init()
     return dst
 
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -620,7 +620,8 @@ class Job:
                     raise
 
                 self._statepoint.save(force=force)
-                # Re-load from disk as a validation.
+                # Re-load as a validation (required to detect invalid data on
+                # disk).
                 statepoint = self._statepoint.load(self.id)
 
             # Update the project's state point cache if the saved file is valid.

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -336,10 +336,6 @@ class Job:
         if isinstance(new_statepoint, JSONDict):
             new_statepoint = new_statepoint()
 
-        # This technically isn't 100% equivalent to the old logic, because this
-        # doesn't check workspace equality. However, since the old logic opened
-        # the new job using self._project it wouldn't actually be possible to
-        # have two different projects, so checking the id is sufficient.
         new_id = calc_id(new_statepoint)
         if self._id == new_id:
             return

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -243,9 +243,10 @@ class Job:
             raise ValueError("Either statepoint or _id must be provided.")
         elif statepoint is not None:
             self._statepoint_requires_init = False
-            self._statepoint = _StatepointDict(jobs=[self], data=statepoint)
-            self._id = calc_id(self._statepoint()) if _id is None else _id
-            self._statepoint._filename = self._statepoint_filename
+            self._id = calc_id(statepoint) if _id is None else _id
+            self._statepoint = _StatepointDict(
+                jobs=[self], filename=self._statepoint_filename, data=statepoint
+            )
 
             # Update the project's state point cache immediately if opened by state point
             self._project._register(self.id, statepoint)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -881,9 +881,14 @@ class Job:
 
 def get_buffer_load():
     """Get the actual size of the buffer."""
-    return BufferedJSONDict.get_buffer_size()
+    return BufferedJSONDict.get_current_buffer_size()
 
 
 def get_buffer_size():
     """Get the maximum available capacity of the buffer."""
     return BufferedJSONDict.get_buffer_capacity()
+
+
+def set_buffer_size(new_size):
+    """Set the maximum available capacity of the buffer."""
+    return BufferedJSONDict.set_buffer_capacity(new_size)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -35,7 +35,7 @@ class _StatepointDict(JSONDict):
            Job directory migrations.
     """
 
-    _PROTECTED_KEYS = ("_jobs", "filename")
+    _PROTECTED_KEYS = ("_jobs",)
 
     def __init__(
         self,

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -27,10 +27,12 @@ logger = logging.getLogger(__name__)
 class _LoadAndSaveSingleThread:
     """A context manager for :class:`SyncedCollection` to wrap saving and loading.
 
-    Unclear how to mesh thread-safety with the fact that I'm introducing locks on a per-file level,
-    but the save operation changes the filename within the context _and_ multiple jobs could
-    point to the same statepoint. When the filename is changed by reset_statepoint, I need some
-    way to consistently also repoint the locks.
+    It's also not obvious how to achieve thread-safety for statepoint
+    modifications within the current framework because when multiple copies of
+    a job (shallow copies owning the same statepoint) exist and one of them is
+    modified, the calls to reset_statepoint will invalidate the per-file locks
+    because the folders are moved. Since statepoint accesses do not need to be
+    thread safe, this context manager simply removes that functionality.
     """
 
     def __init__(self, collection):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -407,11 +407,7 @@ class Job:
 
         """
         if self._statepoint._requires_init:
-            # Load the state point lazily.
-            try:
-                statepoint = self._statepoint.load(self.id)
-            except (JSONDecodeError, AssertionError):
-                raise JobsCorruptedError([self.id])
+            statepoint = self._statepoint.load(self.id)
 
             # Update the project's state point cache when loaded lazily
             self._project._register(self.id, statepoint)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -122,10 +122,27 @@ class _StatepointDict(JSONDict):
     def load(self, job_id):
         """Force a load from disk.
 
-        Unlike normal JSONDict objects, this class requires the ability to load
-        on command. These loads typically occur when the state point must be
-        validated against the data on disk; at all other times, the in-memory
-        data is assumed to be accurate to avoid unnecessary I/O.
+        Unlike normal JSONDict objects, this class requires the ability to
+        load on command. These loads typically occur when the state point
+        must be validated against the data on disk; at all other times, the
+        in-memory data is assumed to be accurate to avoid unnecessary I/O.
+
+        Parameters
+        ----------
+        job_id : str
+            Job id used to validate contents on disk.
+
+        Returns
+        -------
+        data : dict
+            Dictionary of state point data.
+
+        Raises
+        ------
+        JobsCorruptedError
+            If the data on disk is invalid or its hash does not match the job
+            id.
+
         """
         try:
             data = self._load_from_resource()

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -48,7 +48,7 @@ class _StatePointDict(JSONDict):
         *args,
         **kwargs,
     ):
-        # Multiple Python Job objects can share a single `_StatepointDict`
+        # Multiple Python Job objects can share a single `_StatePointDict`
         # instance because they are shallow copies referring to the same data
         # on disk. We need to store these jobs in a shared list here so that
         # shallow copies can point to the same place and trigger each other to
@@ -113,8 +113,8 @@ class _StatePointDict(JSONDict):
             job._id = new_id
             job._initialize_lazy_properties()
 
-        # Remove the temporary statepoint file if it was created. Have to do it
-        # here because we need to get the updated job statepoint filename.
+        # Remove the temporary state point file if it was created. Have to do it
+        # here because we need to get the updated job state point filename.
         try:
             os.remove(job._statepoint_filename + "~")
         except OSError as error:

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -14,7 +14,7 @@ from deprecation import deprecated
 from ..core import json
 from ..core.attrdict import SyncedAttrDict
 from ..core.h5store import H5StoreManager
-from ..core.jsondict import JSONDict
+from ..core.synced_collections.collection_json import BufferedJSONDict
 from ..sync import sync_jobs
 from ..version import __version__
 from .errors import DestinationExistsError, JobsCorruptedError
@@ -376,7 +376,8 @@ class Job:
 
             If you need a deep copy that will not modify the underlying
             persistent JSON file, use :attr:`~Job.document` instead of :attr:`~Job.doc`.
-            For more information, see :attr:`~Job.statepoint` or :class:`~signac.JSONDict`.
+            For more information, see
+            :class:`~signac.core.synced_collections.collection_json.BufferedJSONDict`.
 
         See :ref:`signac document <signac-cli-document>` for the command line equivalent.
 
@@ -386,10 +387,11 @@ class Job:
             The job document handle.
 
         """
+        # TODO: Fix this docstring explaining how to get a deep copy.
         if self._document is None:
             self.init()
             fn_doc = os.path.join(self.workspace(), self.FN_DOCUMENT)
-            self._document = JSONDict(filename=fn_doc, write_concern=True)
+            self._document = BufferedJSONDict(filename=fn_doc, write_concern=True)
         return self._document
 
     @document.setter
@@ -398,7 +400,7 @@ class Job:
 
         Parameters
         ----------
-        new_doc : :class:`~signac.JSONDict`
+        new_doc : :class:`~signac.core.synced_collections.collection_json.BufferedJSONDict`
             The job document handle.
 
         """
@@ -412,7 +414,8 @@ class Job:
 
             If you need a deep copy that will not modify the underlying
             persistent JSON file, use :attr:`~Job.document` instead of :attr:`~Job.doc`.
-            For more information, see :attr:`~Job.statepoint` or :class:`~signac.JSONDict`.
+            For more information, see
+            :class:`~signac.core.synced_collections.collection_json.BufferedJSONDict`.
 
         """
         return self.document

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -31,7 +31,7 @@ class _sp_save_hook:
 
     When a job's state point is changed, in addition
     to the contents of the file being modified this hook
-    calls :meth:`~Job._reset_sp` to rehash the state
+    calls :meth:`~Job.reset_statepoint` to rehash the state
     point, compute a new job id, and move the folder.
 
     Parameters
@@ -50,7 +50,7 @@ class _sp_save_hook:
     def save(self):
         """Reset the state point for all the jobs."""
         for job in self.jobs:
-            job._reset_sp()
+            job.reset_statepoint(job.statepoint())
 
 
 class Job:
@@ -237,19 +237,6 @@ class Job:
         self._cwd = []
         logger.info(f"Moved '{self}' -> '{dst}'.")
 
-    def _reset_sp(self, new_statepoint=None):
-        """Check for new state point requested to assign this job.
-
-        Parameters
-        ----------
-        new_statepoint : dict
-            The job's new state point (Default value = None).
-
-        """
-        if new_statepoint is None:
-            new_statepoint = self.statepoint()
-        self.reset_statepoint(new_statepoint)
-
     def update_statepoint(self, update, overwrite=False):
         """Update the state point of this job.
 
@@ -358,7 +345,7 @@ class Job:
             The new state point to be assigned.
 
         """
-        self._reset_sp(new_statepoint)
+        self.reset_statepoint(new_statepoint)
 
     @property
     def sp(self):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -100,7 +100,6 @@ class _StatePointDict(JSONDict):
                 else:
                     raise
             else:
-                # os.remove(self.filename + "~")
                 should_init = True
         except OSError as error:
             # The most likely reason we got here is because the state point
@@ -113,6 +112,14 @@ class _StatePointDict(JSONDict):
         for job in self._jobs:
             job._id = new_id
             job._initialize_lazy_properties()
+
+        # Remove the temporary statepoint file if it was created. Have to do it
+        # here because we need to get the updated job statepoint filename.
+        try:
+            os.remove(job._statepoint_filename + "~")
+        except OSError as error:
+            if error.errno != errno.ENOENT:
+                raise
 
         # Since all the jobs are equivalent, just grab the filename from the
         # last one and init it. Also migrate the lock for multithreaded support.

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -55,7 +55,7 @@ class _StatepointDict(JSONDict):
            job is opened by id and they're not present in the cache.
     """
 
-    _PROTECTED_KEYS = ("_jobs", "_requires_init")
+    _PROTECTED_KEYS = ("_jobs",)
     _LoadSaveType = _LoadAndSaveSingleThread  # type: ignore
 
     def __init__(
@@ -69,7 +69,6 @@ class _StatepointDict(JSONDict):
         **kwargs,
     ):
         self._jobs = list(jobs)
-        self._requires_init = data is None
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -81,9 +80,7 @@ class _StatepointDict(JSONDict):
 
     def _load(self):
         """Don't attempt a load unless no data was initially provided."""
-        if self._requires_init:
-            super()._load()
-            self._requires_init = False
+        pass
 
     def _save(self):
         """Don't save to disk by default."""
@@ -94,6 +91,10 @@ class _StatepointDict(JSONDict):
         """Need a way to force a save to disk."""
         if force or not os.path.isfile(self._filename):
             super()._save()
+
+    def load(self):
+        """Need a way to force a save to disk."""
+        super()._load()
 
     def move(self, new_filename):
         """Move to new filename."""
@@ -353,6 +354,7 @@ class Job:
             )
 
             try:
+                self._statepoint.load()
                 statepoint = self._statepoint()
             except ValueError:
                 # This catches JSONDecodeError, a subclass of ValueError

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -14,7 +14,9 @@ from deprecation import deprecated
 from ..core import json
 from ..core.attrdict import SyncedAttrDict
 from ..core.h5store import H5StoreManager
-from ..core.synced_collections.collection_json import BufferedJSONDict
+from ..core.synced_collections.collection_json import (
+    MemoryBufferedJSONDict as BufferedJSONDict,
+)
 from ..sync import sync_jobs
 from ..version import __version__
 from .errors import DestinationExistsError, JobsCorruptedError

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -107,10 +107,7 @@ class _StatepointDict(JSONDict):
         # Update each job instance.
         for job in self._jobs:
             job._id = new_id
-            job._wd = None
-            job._document = None
-            job._stores = None
-            job._cwd = []
+            job._initialize_lazy_properties()
 
         # Since all the jobs are equivalent, just grab the filename from the
         # last one and init it. Also migrate the lock for multithreaded support.
@@ -228,9 +225,7 @@ class Job:
 
     def __init__(self, project, statepoint=None, _id=None):
         self._project = project
-
-        # Prepare wd in advance so that the attribute exists in checks below.
-        self._wd = None
+        self._initialize_lazy_properties()
 
         if statepoint is None and _id is None:
             raise ValueError("Either statepoint or _id must be provided.")
@@ -251,13 +246,11 @@ class Job:
             )
             self._statepoint_requires_init = True
 
-        # Prepare job document
+    def _initialize_lazy_properties(self):
+        """Initialize all properties that are designed to be loaded lazily."""
+        self._wd = None
         self._document = None
-
-        # Prepare job H5StoreManager
         self._stores = None
-
-        # Prepare current working directory for context management
         self._cwd = []
 
     @deprecated(

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -77,7 +77,8 @@ class _StatepointDict(JSONDict):
         # All elements of the job list are shallow copies of each other, so any
         # one of them is representative.
         job = self._jobs[0]
-        if job._id == new_id:
+        old_id = job._id
+        if old_id == new_id:
             return
 
         tmp_statepoint_file = self.filename + "~"
@@ -105,7 +106,6 @@ class _StatepointDict(JSONDict):
 
         # Update each job instance.
         for job in self._jobs:
-            old_id = job._id
             job._id = new_id
             job._wd = None
             job._document = None

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -68,6 +68,10 @@ class _StatepointDict(JSONDict):
         *args,
         **kwargs,
     ):
+        # A job-statepoint mapping need not be unique because multiple Python
+        # Job objects can point to the same data on disk. We need to store
+        # these jobs in a shared list here so that shallow copies can point to
+        # the same place and trigger each other to update.
         self._jobs = list(jobs)
         super().__init__(
             filename=filename,
@@ -799,6 +803,8 @@ class Job:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        # Note that we append to a list of jobs rather than replacing to
+        # support transparent id updates between shallow copies of a job.
         self.statepoint._jobs.append(self)
 
     def __deepcopy__(self, memo):

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -517,31 +517,6 @@ class Job:
         """
         self.stores[self.KEY_DATA] = new_data
 
-    def _check_manifest(self):
-        """Check whether the manifest file exists and is correct.
-
-        Returns
-        -------
-        manifest : dict
-            State point data.
-
-        Raises
-        ------
-        JobsCorruptedError
-            If the manifest hash is not equal to the job id.
-
-        """
-        fn_manifest = os.path.join(self.workspace(), self.FN_MANIFEST)
-        try:
-            manifest = JSONDict(fn_manifest)()
-        except ValueError:
-            # This catches JSONDecodeError, a subclass of ValueError
-            raise JobsCorruptedError([self.id])
-
-        if calc_id(manifest) != self.id:
-            raise JobsCorruptedError([self.id])
-        return manifest
-
     def init(self, force=False):
         """Initialize the job's workspace directory.
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -26,9 +26,7 @@ from .. import syncutil
 from ..common.config import Config, get_config, load_config
 from ..core import json
 from ..core.h5store import H5StoreManager
-from ..core.synced_collections.collection_json import (
-    MemoryBufferedJSONDict as BufferedJSONDict,
-)
+from ..core.synced_collections.collection_json import BufferedJSONDict
 from ..sync import sync_projects
 from ..version import SCHEMA_VERSION, __version__
 from .collection import Collection

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -26,7 +26,7 @@ from .. import syncutil
 from ..common.config import Config, get_config, load_config
 from ..core import json
 from ..core.h5store import H5StoreManager
-from ..core.jsondict import JSONDict
+from ..core.synced_collections.collection_json import BufferedJSONDict
 from ..sync import sync_projects
 from ..version import SCHEMA_VERSION, __version__
 from .collection import Collection
@@ -496,13 +496,13 @@ class Project:
 
         Returns
         -------
-        :class:`~signac.JSONDict`
+        :class:`~signac.core.synced_collections.collection_json.BufferedJSONDict`
             The project document.
 
         """
         if self._document is None:
             fn_doc = os.path.join(self.root_directory(), self.FN_DOCUMENT)
-            self._document = JSONDict(filename=fn_doc, write_concern=True)
+            self._document = BufferedJSONDict(filename=fn_doc, write_concern=True)
         return self._document
 
     @document.setter
@@ -525,7 +525,7 @@ class Project:
 
         Returns
         -------
-        :class:`~signac.JSONDict`
+        :class:`~signac.core.synced_collections.collection_json.BufferedJSONDict`
             The project document.
 
         """

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -26,7 +26,9 @@ from .. import syncutil
 from ..common.config import Config, get_config, load_config
 from ..core import json
 from ..core.h5store import H5StoreManager
-from ..core.synced_collections.collection_json import BufferedJSONDict
+from ..core.synced_collections.collection_json import (
+    MemoryBufferedJSONDict as BufferedJSONDict,
+)
 from ..sync import sync_projects
 from ..version import SCHEMA_VERSION, __version__
 from .collection import Collection

--- a/signac/core/synced_collections/buffered_collection.py
+++ b/signac/core/synced_collections/buffered_collection.py
@@ -36,6 +36,7 @@ buffer flushes will occur when all such managers have been exited.
 """
 
 import logging
+import warnings
 from inspect import isabstract
 from typing import Any, List
 
@@ -207,7 +208,7 @@ _BUFFER_ALL_CONTEXT = _CounterFuncContext(BufferedCollection._flush_all_backends
 
 # This function provides a more familiar module-scope, function-based interface
 # for enabling buffering rather than calling the class's static method.
-def buffer_all():
+def buffer_all(force_write=None, buffer_size=None):
     """Return a global buffer context for all BufferedCollection instances.
 
     All future operations use the buffer whenever possible. Write operations
@@ -217,4 +218,25 @@ def buffer_all():
     manager represents a promise to buffer whenever possible, but does not
     guarantee that no writes will occur under all circumstances.
     """
+    if force_write is not None:
+        warnings.warn(
+            DeprecationWarning(
+                "The force_write parameter is deprecated and will be removed in "
+                "signac 2.0. This functionality is no longer supported."
+            )
+        )
+    if buffer_size is not None:
+        warnings.warn(
+            DeprecationWarning(
+                "The buffer_size parameter is deprecated and will be removed in "
+                "signac 2.0. The buffer size should be set using the "
+                "set_buffer_capacity method of FileBufferedCollection or any of its "
+                "subclasses."
+            )
+        )
     return _BUFFER_ALL_CONTEXT
+
+
+def is_buffered():
+    """Check the global buffered mode setting."""
+    return bool(_BUFFER_ALL_CONTEXT)

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -114,7 +114,7 @@ class JSONCollection(SyncedCollection):
             if error.errno == errno.ENOENT:
                 return None
             else:
-                raise error
+                raise
 
     def _save_to_resource(self):
         """Write the data to JSON file."""

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -8,6 +8,7 @@ import json
 import os
 import uuid
 import warnings
+from typing import Tuple
 
 from .memory_buffered_collection import SharedMemoryFileBufferedCollection
 from .serialized_file_buffered_collection import SerializedFileBufferedCollection
@@ -215,7 +216,7 @@ class JSONDict(JSONCollection, SyncedAttrDict):
 
     """
 
-    _PROTECTED_KEYS = ("_filename",)
+    _PROTECTED_KEYS: Tuple[str, ...] = ("_filename",)
 
     def __init__(
         self,
@@ -294,7 +295,7 @@ class JSONList(JSONCollection, SyncedList):
 class BufferedJSONDict(BufferedJSONCollection, SyncedAttrDict):
     """A buffered :class:`JSONDict`."""
 
-    _PROTECTED_KEYS = (
+    _PROTECTED_KEYS: Tuple[str, ...] = (
         "_filename",
         "_buffered",
         "_is_buffered",
@@ -344,7 +345,7 @@ class BufferedJSONList(BufferedJSONCollection, SyncedList):
 class MemoryBufferedJSONDict(MemoryBufferedJSONCollection, SyncedAttrDict):
     """A buffered :class:`JSONDict`."""
 
-    _PROTECTED_KEYS = SyncedAttrDict._PROTECTED_KEYS + (
+    _PROTECTED_KEYS: Tuple[str, ...] = SyncedAttrDict._PROTECTED_KEYS + (
         "_filename",
         "_buffered",
         "_is_buffered",

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -226,7 +226,6 @@ class JSONDict(JSONCollection, SyncedAttrDict):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -282,7 +281,6 @@ class JSONList(JSONCollection, SyncedList):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -311,7 +309,6 @@ class BufferedJSONDict(BufferedJSONCollection, SyncedAttrDict):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -334,7 +331,6 @@ class BufferedJSONList(BufferedJSONCollection, SyncedList):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -363,7 +359,6 @@ class MemoryBufferedJSONDict(MemoryBufferedJSONCollection, SyncedAttrDict):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,
@@ -386,7 +381,6 @@ class MemoryBufferedJSONList(MemoryBufferedJSONCollection, SyncedList):
         *args,
         **kwargs,
     ):
-        self._validate_constructor_args({"filename": filename}, data, parent)
         super().__init__(
             filename=filename,
             write_concern=write_concern,

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -112,6 +112,8 @@ class JSONCollection(SyncedCollection):
         except OSError as error:
             if error.errno == errno.ENOENT:
                 return None
+            else:
+                raise error
 
     def _save_to_resource(self):
         """Write the data to JSON file."""

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -15,7 +15,7 @@ from .serialized_file_buffered_collection import SerializedFileBufferedCollectio
 from .synced_attr_dict import SyncedAttrDict
 from .synced_collection import SyncedCollection
 from .synced_list import SyncedList
-from .utils import SCJSONEncoder
+from .utils import SyncedCollectionJSONEncoder
 from .validators import json_format_validator
 
 
@@ -119,7 +119,7 @@ class JSONCollection(SyncedCollection):
     def _save_to_resource(self):
         """Write the data to JSON file."""
         # Serialize data
-        blob = json.dumps(self, cls=SCJSONEncoder).encode()
+        blob = json.dumps(self, cls=SyncedCollectionJSONEncoder).encode()
         # When write_concern flag is set, we write the data into dummy file and then
         # replace that file with original file. We also enable this mode
         # irrespective of the write_concern flag if we're running in

--- a/signac/core/synced_collections/collection_json.py
+++ b/signac/core/synced_collections/collection_json.py
@@ -100,9 +100,10 @@ class JSONCollection(SyncedCollection):
 
         Returns
         -------
-        Collection
+        Collection or None
             An equivalent unsynced collection satisfying :meth:`is_base_type` that
-            contains the data in the JSON file.
+            contains the data in the JSON file. Will return None if the file does
+            not exist.
 
         """
         try:

--- a/signac/core/synced_collections/collection_mongodb.py
+++ b/signac/core/synced_collections/collection_mongodb.py
@@ -131,9 +131,6 @@ class MongoDBDict(MongoDBCollection, SyncedAttrDict):
     def __init__(
         self, collection=None, uid=None, data=None, parent=None, *args, **kwargs
     ):
-        self._validate_constructor_args(
-            {"collection": collection, "uid": uid}, data, parent
-        )
         super().__init__(
             collection=collection, uid=uid, data=data, parent=parent, *args, **kwargs
         )
@@ -177,9 +174,6 @@ class MongoDBList(MongoDBCollection, SyncedList):
     def __init__(
         self, collection=None, uid=None, data=None, parent=None, *args, **kwargs
     ):
-        self._validate_constructor_args(
-            {"collection": collection, "uid": uid}, data, parent
-        )
         super().__init__(
             collection=collection, uid=uid, data=data, parent=parent, *args, **kwargs
         )

--- a/signac/core/synced_collections/collection_mongodb.py
+++ b/signac/core/synced_collections/collection_mongodb.py
@@ -53,9 +53,10 @@ class MongoDBCollection(SyncedCollection):
 
         Returns
         -------
-        Collection
+        Collection or None
             An equivalent unsynced collection satisfying :meth:`is_base_type` that
-            contains the data in the MongoDB database.
+            contains the data in the MongoDB database. Will return None if no data
+            was found in the database.
 
         """
         blob = self._collection.find_one(self._uid)

--- a/signac/core/synced_collections/collection_redis.py
+++ b/signac/core/synced_collections/collection_redis.py
@@ -109,7 +109,6 @@ class RedisDict(RedisCollection, SyncedAttrDict):
     """
 
     def __init__(self, client=None, key=None, data=None, parent=None, *args, **kwargs):
-        self._validate_constructor_args({"client": client, "key": key}, data, parent)
         super().__init__(
             client=client, key=key, data=data, parent=parent, *args, **kwargs
         )
@@ -150,7 +149,6 @@ class RedisList(RedisCollection, SyncedList):
     """
 
     def __init__(self, client=None, key=None, data=None, parent=None, *args, **kwargs):
-        self._validate_constructor_args({"client": client, "key": key}, data, parent)
         super().__init__(
             client=client, key=key, data=data, parent=parent, *args, **kwargs
         )

--- a/signac/core/synced_collections/collection_redis.py
+++ b/signac/core/synced_collections/collection_redis.py
@@ -39,9 +39,10 @@ class RedisCollection(SyncedCollection):
 
         Returns
         -------
-        Collection
+        Collection or None
             An equivalent unsynced collection satisfying :meth:`is_base_type` that
-            contains the data in the Redis database.
+            contains the data in the Redis database. Will return None if no data
+            was found in the Redis database.
 
         """
         blob = self._client.get(self._key)

--- a/signac/core/synced_collections/collection_zarr.py
+++ b/signac/core/synced_collections/collection_zarr.py
@@ -150,7 +150,6 @@ class ZarrDict(ZarrCollection, SyncedAttrDict):
     """
 
     def __init__(self, group=None, name=None, data=None, parent=None, *args, **kwargs):
-        self._validate_constructor_args({"group": group, "name": name}, data, parent)
         super().__init__(
             group=group, name=name, data=data, parent=parent, *args, **kwargs
         )
@@ -191,7 +190,6 @@ class ZarrList(ZarrCollection, SyncedList):
     """
 
     def __init__(self, group=None, name=None, data=None, parent=None, *args, **kwargs):
-        self._validate_constructor_args({"group": group, "name": name}, data, parent)
         super().__init__(
             group=group, name=name, data=data, parent=parent, *args, **kwargs
         )

--- a/signac/core/synced_collections/collection_zarr.py
+++ b/signac/core/synced_collections/collection_zarr.py
@@ -48,9 +48,10 @@ class ZarrCollection(SyncedCollection):
 
         Returns
         -------
-        Collection
+        Collection or None
             An equivalent unsynced collection satisfying :meth:`is_base_type` that
-            contains the data in the Zarr group.
+            contains the data in the Zarr group. Will return None if associated
+            data is not found in the Zarr group.
 
         """
         try:

--- a/signac/core/synced_collections/serialized_file_buffered_collection.py
+++ b/signac/core/synced_collections/serialized_file_buffered_collection.py
@@ -13,7 +13,7 @@ import json
 
 from .errors import MetadataError
 from .file_buffered_collection import FileBufferedCollection
-from .utils import SCJSONEncoder
+from .utils import SyncedCollectionJSONEncoder
 
 
 class SerializedFileBufferedCollection(FileBufferedCollection):
@@ -168,7 +168,7 @@ class SerializedFileBufferedCollection(FileBufferedCollection):
             The underlying encoded data.
 
         """
-        return json.dumps(data, cls=SCJSONEncoder).encode()
+        return json.dumps(data, cls=SyncedCollectionJSONEncoder).encode()
 
     @staticmethod
     def _decode(blob):

--- a/signac/core/synced_collections/synced_attr_dict.py
+++ b/signac/core/synced_collections/synced_attr_dict.py
@@ -180,29 +180,22 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
             for key, value in data.items():
                 self._data[key] = self._from_base(value, parent=self)
 
-    def reset(self, data=None):
+    def reset(self, data):
         """Update the instance with new data.
 
         Parameters
         ----------
         data : mapping
-            Data to update the instance (Default value = None).
+            Data to update the instance.
 
         Raises
         ------
         ValueError
-            If the data is not instance of mapping
+            If the data is not a mapping.
 
         """
-        if data is None:
-            data = {}
         if _mapping_resolver.get_type(data) == "MAPPING":
-            self._validate(data)
-            with self._suspend_sync:
-                self._data = {
-                    key: self._from_base(data=value, parent=self)
-                    for key, value in data.items()
-                }
+            self._update(data)
             with self._thread_lock:
                 self._save()
         else:

--- a/signac/core/synced_collections/synced_attr_dict.py
+++ b/signac/core/synced_collections/synced_attr_dict.py
@@ -185,7 +185,7 @@ class SyncedAttrDict(SyncedCollection, MutableMapping):
 
         Parameters
         ----------
-        data: mapping
+        data : mapping
             Data to update the instance (Default value = None).
 
         Raises

--- a/signac/core/synced_collections/synced_collection.py
+++ b/signac/core/synced_collections/synced_collection.py
@@ -340,11 +340,15 @@ class SyncedCollection(Collection):
     def _load_from_resource(self):
         """Load data from underlying backend.
 
-        This method must be implemented for each backend.
+        This method must be implemented for each backend. Backends may choose
+        to return ``None``, signaling that no modification should be performed
+        on the data in memory. This mode is useful for backends where the underlying
+        resource (e.g. a file) may not initially exist, but can be transparently
+        created on save.
 
         Returns
         -------
-        Collection
+        Collection or None
             An equivalent unsynced collection satisfying :meth:`is_base_type` that
             contains the data in the underlying resource (e.g. a file).
 

--- a/signac/core/synced_collections/synced_list.py
+++ b/signac/core/synced_collections/synced_list.py
@@ -150,30 +150,24 @@ class SyncedList(SyncedCollection, MutableSequence):
                 )
             )
 
-    def reset(self, data=None):
+    def reset(self, data):
         """Update the instance with new data.
 
         Parameters
         ----------
-        data: non-string Sequence, optional
-            Data to update the instance (Default value = None).
+        data: non-string Sequence
+            Data to update the instance.
 
         Raises
         ------
         ValueError
-            If the data is not instance of non-string seqeuence
+            If the data is not a non-string sequence.
 
         """
-        if data is None:
-            data = []
-        elif NUMPY and isinstance(data, numpy.ndarray):
+        if NUMPY and isinstance(data, numpy.ndarray):
             data = data.tolist()
-        self._validate(data)
         if _sequence_resolver.get_type(data) == "SEQUENCE":
-            with self._suspend_sync:
-                self._data = [
-                    self._from_base(data=value, parent=self) for value in data
-                ]
+            self._update(data)
             with self._thread_lock:
                 self._save()
         else:

--- a/signac/core/synced_collections/utils.py
+++ b/signac/core/synced_collections/utils.py
@@ -114,7 +114,7 @@ def default(o: Any) -> Dict[str, Any]:  # noqa: D102
         raise TypeError from e
 
 
-class SCJSONEncoder(JSONEncoder):
+class SyncedCollectionJSONEncoder(JSONEncoder):
     """A JSONEncoder capable of encoding SyncedCollections and other supported types.
 
     This encoder will attempt to obtain a JSON-serializable representation of

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -72,6 +72,9 @@ class TestBufferedMode(TestProjectBase):
             assert job.doc.a == 2
         assert job.doc.a == 2
 
+    @pytest.mark.xfail(
+        reason="The new SyncedCollection does not implement force_write."
+    )
     def test_buffered_mode_force_write(self):
         with signac.buffered(force_write=False):
             with signac.buffered(force_write=False):
@@ -88,6 +91,9 @@ class TestBufferedMode(TestProjectBase):
                     pass
         assert not signac.is_buffered()
 
+    @pytest.mark.xfail(
+        reason="The new SyncedCollection does not implement force_write."
+    )
     def test_buffered_mode_force_write_with_file_modification(self):
         job = self.project.open_job(dict(a=0))
         job.init()
@@ -114,8 +120,8 @@ class TestBufferedMode(TestProjectBase):
                 file.write(json.dumps({"a": x}).encode())
         assert job.doc.a == (not x)
 
-    @pytest.mark.skipif(
-        not ABLE_TO_PREVENT_WRITE, reason="unable to trigger permission error"
+    @pytest.mark.xfail(
+        reason="The new SyncedCollection does not implement force_write."
     )
     def test_force_write_mode_with_permission_error(self):
         job = self.project.open_job(dict(a=0))
@@ -138,6 +144,7 @@ class TestBufferedMode(TestProjectBase):
             os.chmod(path, mode)
         assert job.doc.a == x
 
+    @pytest.mark.xfail(reason="This API for setting the buffer size is deprecated.")
     def test_buffered_mode_change_buffer_size(self):
         assert not signac.is_buffered()
         with signac.buffered(buffer_size=12):
@@ -165,6 +172,7 @@ class TestBufferedMode(TestProjectBase):
                 with signac.buffered(buffer_size=14):
                     pass
 
+    @pytest.mark.xfail(reason="This test uses various deprecated APIs.")
     def test_integration(self):
         def routine():
             for i in range(1, 4):

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -73,6 +73,7 @@ class TestBufferedMode(TestProjectBase):
             assert job.doc.a == 2
         assert job.doc.a == 2
 
+    # Remove this test in signac 2.0.
     @pytest.mark.xfail(
         reason="The new SyncedCollection does not implement force_write."
     )
@@ -92,6 +93,7 @@ class TestBufferedMode(TestProjectBase):
                     pass
         assert not signac.is_buffered()
 
+    # Remove this test in signac 2.0.
     @pytest.mark.xfail(
         reason="The new SyncedCollection does not implement force_write."
     )
@@ -121,6 +123,7 @@ class TestBufferedMode(TestProjectBase):
                 file.write(json.dumps({"a": x}).encode())
         assert job.doc.a == (not x)
 
+    # Remove this test in signac 2.0.
     @pytest.mark.xfail(
         reason="The new SyncedCollection does not implement force_write."
     )

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -146,23 +146,27 @@ class TestBufferedMode(TestProjectBase):
         assert job.doc.a == x
 
     def test_buffered_mode_change_buffer_size(self):
-        assert not signac.is_buffered()
-        signac.set_buffer_size(12)
-        with signac.buffered():
-            assert signac.buffered()
-            assert signac.get_buffer_size() == 12
-
-        assert not signac.is_buffered()
-
-        assert not signac.is_buffered()
-        with signac.buffered():
-            assert signac.buffered()
-            assert signac.get_buffer_size() == 12
+        original_buffer_size = signac.get_buffer_size()
+        try:
+            assert not signac.is_buffered()
+            signac.set_buffer_size(12)
             with signac.buffered():
                 assert signac.buffered()
                 assert signac.get_buffer_size() == 12
 
-        assert not signac.is_buffered()
+            assert not signac.is_buffered()
+
+            assert not signac.is_buffered()
+            with signac.buffered():
+                assert signac.buffered()
+                assert signac.get_buffer_size() == 12
+                with signac.buffered():
+                    assert signac.buffered()
+                    assert signac.get_buffer_size() == 12
+
+            assert not signac.is_buffered()
+        finally:
+            signac.set_buffer_size(original_buffer_size)
 
     def test_integration(self):
         def routine():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -537,6 +537,9 @@ class TestJobOpenAndClosing(TestJobBase):
         assert os.path.exists(os.path.join(job.workspace(), job.FN_MANIFEST))
 
     def test_construction(self):
+        from signac import Project  # noqa: F401
+
+        # The eval statement needs to have Project available
         job = self.open_job(test_token)
         job2 = eval(repr(job))
         assert job == job2

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -446,10 +446,13 @@ class TestJobSpInterface(TestJobBase):
             assert str(key) in job.sp
 
     def test_invalid_sp_key_types(self):
-        job = self.open_job(dict(invalid_key=True)).init()
-
         class A:
             pass
+
+        with pytest.raises(KeyTypeError):
+            self.open_job({A(): True}).init()
+
+        job = self.open_job(dict(invalid_key=True)).init()
 
         for key in (0.0, A(), (1, 2, 3)):
             with pytest.raises(KeyTypeError):

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -208,8 +208,6 @@ class SyncedDictTest(SyncedCollectionTest):
         synced_collection[key] = testdata
         assert len(synced_collection) == 1
         assert synced_collection[key] == testdata
-        synced_collection.reset()
-        assert len(synced_collection) == 0
         synced_collection.reset({"reset": "abc"})
         assert len(synced_collection) == 1
         assert synced_collection[key] == "abc"
@@ -544,8 +542,6 @@ class SyncedListTest(SyncedCollectionTest):
         synced_collection.reset([1, 2, 3])
         assert len(synced_collection) == 3
         assert synced_collection == [1, 2, 3]
-        synced_collection.reset()
-        assert len(synced_collection) == 0
         synced_collection.reset([3, 4])
         assert len(synced_collection) == 2
         assert synced_collection == [3, 4]

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -44,11 +44,6 @@ class SyncedDictTest(SyncedCollectionTest):
     def test_init_positional(self, synced_collection_positional):
         assert len(synced_collection_positional) == 0
 
-    def test_invalid_kwargs(self, synced_collection):
-        # JSONDict raise an error when neither filename nor parent is passed.
-        with pytest.raises(ValueError):
-            return type(synced_collection)()
-
     def test_isinstance(self, synced_collection):
         assert isinstance(synced_collection, SyncedCollection)
         assert isinstance(synced_collection, MutableMapping)
@@ -456,11 +451,6 @@ class SyncedListTest(SyncedCollectionTest):
 
     def test_init(self, synced_collection):
         assert len(synced_collection) == 0
-
-    def test_invalid_kwargs(self, synced_collection):
-        # JSONList raise an error when neither filename nor parent is passed.
-        with pytest.raises(ValueError):
-            return type(synced_collection)()
 
     def test_isinstance(self, synced_collection):
         assert isinstance(synced_collection, MutableSequence)

--- a/tests/test_synced_collections/test_utils.py
+++ b/tests/test_synced_collections/test_utils.py
@@ -10,7 +10,10 @@ import pytest
 
 from signac.core.synced_collections.collection_json import JSONDict
 from signac.core.synced_collections.synced_list import SyncedList
-from signac.core.synced_collections.utils import AbstractTypeResolver, SCJSONEncoder
+from signac.core.synced_collections.utils import (
+    AbstractTypeResolver,
+    SyncedCollectionJSONEncoder,
+)
 
 try:
     import numpy
@@ -52,7 +55,7 @@ def test_json_encoder():
     # Raw dictionaries should be encoded transparently.
     data = {"foo": 1, "bar": 2, "baz": 3}
     assert json.dumps(data) == encode_flat_dict(data)
-    assert json.dumps(data, cls=SCJSONEncoder) == json.dumps(data)
+    assert json.dumps(data, cls=SyncedCollectionJSONEncoder) == json.dumps(data)
 
     with TemporaryDirectory() as tmp_dir:
         fn = os.path.join(tmp_dir, "test_json_encoding.json")
@@ -60,14 +63,15 @@ def test_json_encoder():
         synced_data.update(data)
         with pytest.raises(TypeError):
             json.dumps(synced_data)
-        assert json.dumps(synced_data, cls=SCJSONEncoder) == encode_flat_dict(
-            synced_data
-        )
+        assert json.dumps(
+            synced_data, cls=SyncedCollectionJSONEncoder
+        ) == encode_flat_dict(synced_data)
 
         if NUMPY:
             array = numpy.random.rand(3)
             synced_data["foo"] = array
             assert isinstance(synced_data["foo"], SyncedList)
             assert (
-                json.loads(json.dumps(synced_data, cls=SCJSONEncoder)) == synced_data()
+                json.loads(json.dumps(synced_data, cls=SyncedCollectionJSONEncoder))
+                == synced_data()
             )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

This PR integrates the new synced collections into the core of signac. The job and project documents as well as the job statepoint now use the new classes. As part of the change, I also cleaned up parts of the Job class and removed basically all of the internal methods, many of which were quite small or only called once. The new classes are seamless fits for the job and project documents, I was able to perform basically a drop-in replacement. The statepoint is a little bit trickier, because it violates some of the core assumptions of how you'd expect SyncedCollections to typically work. A list (not necessarily exhaustive) of relevant points:

1. Statepoints almost never load from disk because they rely on data provided at initialization whenever possible (possibly from the project cache)
2. There are multiple ways in which a statepoint can be saved to disk, and depending on the context the in-memory representation may or may not be valid (because we intercept the normal saving process and instead call `Job.reset_statepoint`). Moreover, in some of these cases the Job can actually move the underlying file itself, which leaves the statepoint in pseudo-invalid states (not really invalid, since the file of a JSONDict need not exist, but it's something of an antipattern to be intentionally moving the file prior to having in-memory changes reflected).
3. Shallow copies of a job should reflect modifications, in particular the `id` of all copies should be synchronously updated when the statepoint is modified, so the typical approaches to make modifications thread safe go out the window.

These issues were already partly reflected by the necessarily slightly awkward design of the `_sp_save_hook`, in particular the need to store many jobs in a single hook to trigger updates of shallow copies. I'm not 100% happy with the results, in large part because there are 5 or 6 places where the Job is calling internal methods or modifying attributes of the statepoint. I think it's still a significant improvement over the old code, though, and I think integrating it will help us identify possible improvements. I'm very open to suggestions on ways that this can be improved.

One other note: as discussed with multiple other committers, the new JSON collections do not implement a force write mode comparable to the old JSONDict. I've added enough of a backwards compatibility layer that it won't affect the API, but of course the behavior will be no longer be the same. Aside from this very minor change, however, the new classes don't introduce any API breakage, so (looking forward a bit) I would feel comfortable making a minor release or two with the new classes as internal APIs only while we iron out any kinks. This would also give us a little bit of time to finish up the remaining items on the signac 2.0 checklist.

**Edit**

I've made some edits and am now much happier with the design. Much of the logic from the old `reset_statepoint` method has now been moved to the `_save` method of the `_StatepointDict` class, which helps resolve the majority of the concerns. The old `reset_statepoint` method is now a one-liner requesting that the statepoint reset itself. Since the migration logic is now contained within the `_StatepointDict`, there are no longer issues with the `_StatepointDict` being in an invalid state in the middle of `Job` functions. Moreover, thread locks can now be transparently migrated by the dict itself, allowing thread-safe modification of these objects. These changes largely remove the need for most complicated logic in the Job class.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Next step in #249.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
