### PR TITLE
Add support for zero-dimensional numpy arrays.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,12 @@ Deprecated
 
  - Deprecate ``syncutil.copytree`` method (#439).
 
+Fixed
++++++
+
+ - Zero-dimensional NumPy arrays can be used in state points and documents (#449).
+
+
 [1.5.1] -- 2020-12-19
 ---------------------
 

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -128,10 +128,13 @@ class _SyncedDict(MutableMapping):
         elif type(root) in (list, tuple):
             return _SyncedList(root, parent=self)
         elif NUMPY:
-            if isinstance(root, numpy.number):
+            if isinstance(root, numpy.ndarray):
+                if root.shape == ():
+                    return root.item()
+                else:
+                    return _SyncedList(root.tolist(), parent=self)
+            elif isinstance(root, numpy.number):
                 return root.item()
-            elif isinstance(root, numpy.ndarray):
-                return _SyncedList(root.tolist(), parent=self)
         return root
 
     @classmethod

--- a/tests/test_numpy_integration.py
+++ b/tests/test_numpy_integration.py
@@ -33,6 +33,13 @@ class TestNumpyIntegration(TestProjectBase):
             assert [i] == job.sp.a
             assert numpy.array([i]) == job.sp.a
 
+    def test_store_zero_dim_array_in_sp(self):
+        # Zero-dimensional array
+        value = 1.0
+        job = self.project.open_job(dict(a=numpy.array(value))).init()
+        assert value == job.sp.a
+        assert numpy.array(value) == job.sp.a
+
     def test_store_array_in_doc(self):
         for i in range(10):
             job = self.project.open_job(dict(a=i))
@@ -42,3 +49,14 @@ class TestNumpyIntegration(TestProjectBase):
             assert i == job.sp.a
             assert (numpy.array([i, i, i]) == job.doc.array).all()
             assert [i] * 3 == job.doc.array
+
+    def test_store_zero_dim_array(self):
+        # Zero-dimensional array
+        value = 1.0
+        job = self.project.open_job(dict(a=numpy.array(value))).init()
+        assert value == job.sp.a
+        assert numpy.array(value) == job.sp.a
+        job.doc.array = numpy.array(value)
+        numpy.testing.assert_equal(job.doc.array, numpy.array(value))
+        assert value == job.doc.array
+        assert numpy.array(value) == job.doc.array

--- a/tests/test_numpy_integration.py
+++ b/tests/test_numpy_integration.py
@@ -33,13 +33,6 @@ class TestNumpyIntegration(TestProjectBase):
             assert [i] == job.sp.a
             assert numpy.array([i]) == job.sp.a
 
-    def test_store_zero_dim_array_in_sp(self):
-        # Zero-dimensional array
-        value = 1.0
-        job = self.project.open_job(dict(a=numpy.array(value))).init()
-        assert value == job.sp.a
-        assert numpy.array(value) == job.sp.a
-
     def test_store_array_in_doc(self):
         for i in range(10):
             job = self.project.open_job(dict(a=i))
@@ -50,12 +43,19 @@ class TestNumpyIntegration(TestProjectBase):
             assert (numpy.array([i, i, i]) == job.doc.array).all()
             assert [i] * 3 == job.doc.array
 
-    def test_store_zero_dim_array(self):
-        # Zero-dimensional array
+    def test_store_zero_dim_array_in_sp(self):
+        # Zero-dimensional arrays have size 1, and their tolist() method
+        # returns a single value.
         value = 1.0
         job = self.project.open_job(dict(a=numpy.array(value))).init()
         assert value == job.sp.a
         assert numpy.array(value) == job.sp.a
+
+    def test_store_zero_dim_array_in_doc(self):
+        # Zero-dimensional arrays have size 1, and their tolist() method
+        # returns a single value.
+        value = 1.0
+        job = self.project.open_job(dict(a=1)).init()
         job.doc.array = numpy.array(value)
         numpy.testing.assert_equal(job.doc.array, numpy.array(value))
         assert value == job.doc.array


### PR DESCRIPTION
## Description
Adds support for zero-dimensional NumPy arrays like `numpy.array(1.0)`.

I note that this is _not_ a problem in our JSON encoder, only in `_dfs_convert` because it assumes that all NumPy arrays can be used to construct a SyncedList (which is not true for 0-d arrays, since SyncedLists must be 1-d or higher).

## Motivation and Context
Resolves #476.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
