### PR TITLE
Feature/synced collection/simplify global buffering

### DIFF
--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -31,10 +31,11 @@ from .core.h5store import H5Store, H5StoreManager
 from .core.jsondict import flush_all as flush
 from .db import get_database
 from .diff import diff_jobs
-from .synced_collections.backends.collection_json import JSONDict
-from .synced_collections.buffers.buffered_collection import buffer_all as buffered
-from .synced_collections.buffers.buffered_collection import is_buffered
+from .synced_collections.backends.collection_json import BufferedJSONDict, JSONDict
 from .version import __version__
+
+buffered = BufferedJSONDict.buffer_backend
+is_buffered = BufferedJSONDict.backend_is_buffered
 
 __all__ = [
     "__version__",

--- a/signac/synced_collections/buffers/buffered_collection.py
+++ b/signac/synced_collections/buffers/buffered_collection.py
@@ -36,7 +36,6 @@ buffer flushes will occur when all such managers have been exited.
 """
 
 import logging
-import warnings
 from inspect import isabstract
 from typing import Any, List
 
@@ -201,7 +200,7 @@ class BufferedCollection(SyncedCollection):
     @property
     def _is_buffered(self):
         """Check if we should write to the buffer or not."""
-        return self.buffered or _BUFFER_ALL_CONTEXT or type(self)._buffer_context
+        return self.buffered or type(self)._buffer_context
 
     def _flush(self):
         """Flush data associated with this instance from the buffer."""
@@ -211,45 +210,3 @@ class BufferedCollection(SyncedCollection):
     def _flush_buffer(self):
         """Flush all data in this class's buffer."""
         pass
-
-
-# This module-scope variable is a context that can be accessed via the
-# buffer_all method for the purpose of buffering all subsequence read and write
-# operations.
-_BUFFER_ALL_CONTEXT = _CounterFuncContext(BufferedCollection._flush_all_backends)
-
-
-# This function provides a more familiar module-scope, function-based interface
-# for enabling buffering rather than calling the class's static method.
-def buffer_all(force_write=None, buffer_size=None):
-    """Return a global buffer context for all BufferedCollection instances.
-
-    All future operations use the buffer whenever possible. Write operations
-    are deferred until the context is exited, at which point all buffered
-    backends will flush their buffers. Individual backends may flush their
-    buffers within this context if the implementation requires it; this context
-    manager represents a promise to buffer whenever possible, but does not
-    guarantee that no writes will occur under all circumstances.
-    """
-    if force_write is not None:
-        warnings.warn(
-            DeprecationWarning(
-                "The force_write parameter is deprecated and will be removed in "
-                "signac 2.0. This functionality is no longer supported."
-            )
-        )
-    if buffer_size is not None:
-        warnings.warn(
-            DeprecationWarning(
-                "The buffer_size parameter is deprecated and will be removed in "
-                "signac 2.0. The buffer size should be set using the "
-                "set_buffer_capacity method of FileBufferedCollection or any of its "
-                "subclasses."
-            )
-        )
-    return _BUFFER_ALL_CONTEXT
-
-
-def is_buffered():
-    """Check the global buffered mode setting."""
-    return bool(_BUFFER_ALL_CONTEXT)

--- a/signac/synced_collections/buffers/buffered_collection.py
+++ b/signac/synced_collections/buffers/buffered_collection.py
@@ -105,7 +105,7 @@ class BufferedCollection(SyncedCollection):
             cls._buffer_context = _CounterFuncContext(cls._flush_buffer)
 
     @classmethod
-    def buffer_backend(cls):
+    def buffer_backend(cls, *args, **kwargs):
         """Enter context to buffer all operations for this backend."""
         return cls._buffer_context
 

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -16,7 +16,7 @@ from threading import RLock
 from typing import Dict, Tuple, Union
 
 from ..data_types.synced_collection import _LoadAndSave
-from ..errors import MetadataError
+from ..errors import BufferedError, MetadataError
 from ..utils import _NullContext
 from .buffered_collection import BufferedCollection
 
@@ -306,4 +306,5 @@ class FileBufferedCollection(BufferedCollection):
                 issues[collection._filename] = err
         if not issues:
             cls._buffered_collections = remaining_collections
-        return issues
+        else:
+            raise BufferedError(issues)

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -23,30 +23,36 @@ from .buffered_collection import BufferedCollection
 
 
 class _FileBufferedContext(_CounterFuncContext):
+    """Extend the usual buffering context to support setting the buffer size.
+
+    This context allows the buffer_backend method to temporarily set the buffer
+    size within the scope of this context.
+    """
+
     def __init__(self, cls):
         super().__init__(cls._flush_buffer)
-        self._buffer_size = None
-        self._original_buffer_sizes = []
+        self._buffer_capacity = None
+        self._original_buffer_capacitys = []
         self._cls = cls
 
-    def __call__(self, buffer_size=None):
-        self._buffer_size = buffer_size
+    def __call__(self, buffer_capacity=None):
+        self._buffer_capacity = buffer_capacity
         return self
 
     def __enter__(self):
         super().__enter__()
-        if self._buffer_size is not None:
-            self._original_buffer_sizes.append(self._cls.get_buffer_capacity())
-            self._cls.set_buffer_capacity(self._buffer_size)
+        if self._buffer_capacity is not None:
+            self._original_buffer_capacitys.append(self._cls.get_buffer_capacity())
+            self._cls.set_buffer_capacity(self._buffer_capacity)
         else:
-            self._original_buffer_sizes.append(None)
-        self._buffer_size = None
+            self._original_buffer_capacitys.append(None)
+        self._buffer_capacity = None
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         super().__exit__(exc_type, exc_val, exc_tb)
-        original_buffer_size = self._original_buffer_sizes.pop()
-        if original_buffer_size is not None:
-            self._cls.set_buffer_capacity(original_buffer_size)
+        original_buffer_capacity = self._original_buffer_capacitys.pop()
+        if original_buffer_capacity is not None:
+            self._cls.set_buffer_capacity(original_buffer_capacity)
 
 
 class _BufferedLoadAndSave(_LoadAndSave):
@@ -339,9 +345,21 @@ class FileBufferedCollection(BufferedCollection):
         else:
             raise BufferedError(issues)
 
+    # TODO: The buffer_size argument should be changed to buffer_capacity in
+    # signac 2.0 for consistency with the new names in synced collections.
     @classmethod
     def buffer_backend(cls, buffer_size=None, force_write=None, *args, **kwargs):
-        """Enter context to buffer all operations for this backend."""
+        """Enter context to buffer all operations for this backend.
+
+        Parameters
+        ----------
+        buffer_size : int
+            The capacity of the buffer to use within this context (resets after
+            the context is exited).
+        force_write : bool
+            This argument does nothing and is only present for compatibility
+            with signac 1.x.
+        """
         if force_write is not None:
             warnings.warn(
                 DeprecationWarning(

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -11,6 +11,7 @@ specific components are abstract and must be implemented by child classes.
 
 import errno
 import os
+import warnings
 from abc import abstractmethod
 from threading import RLock
 from typing import Dict, Tuple, Union
@@ -308,3 +309,26 @@ class FileBufferedCollection(BufferedCollection):
             cls._buffered_collections = remaining_collections
         else:
             raise BufferedError(issues)
+
+    @classmethod
+    def buffer_backend(cls, buffer_size=None, force_write=None, *args, **kwargs):
+        """Enter context to buffer all operations for this backend."""
+        if force_write is not None:
+            warnings.warn(
+                DeprecationWarning(
+                    "The force_write parameter is deprecated and will be removed in "
+                    "signac 2.0. This functionality is no longer supported."
+                )
+            )
+
+        if buffer_size is not None:
+            warnings.warn(
+                DeprecationWarning(
+                    "The buffer_size parameter is deprecated and will be removed in "
+                    "signac 2.0. The buffer size should be set using the "
+                    "set_buffer_capacity method of FileBufferedCollection or any of its "
+                    "subclasses."
+                )
+            )
+
+        return cls._buffer_context

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -149,27 +149,22 @@ class TestBufferedMode(TestProjectBase):
         assert job.doc.a == x
 
     def test_buffered_mode_change_buffer_size(self):
-        original_buffer_size = signac.get_buffer_size()
-        try:
-            assert not signac.is_buffered()
-            signac.set_buffer_size(12)
+        assert not signac.is_buffered()
+        with signac.buffered(buffer_size=12):
+            assert signac.buffered()
+            assert signac.get_buffer_size() == 12
+
+        assert not signac.is_buffered()
+
+        assert not signac.is_buffered()
+        with signac.buffered(buffer_size=12):
+            assert signac.buffered()
+            assert signac.get_buffer_size() == 12
             with signac.buffered():
                 assert signac.buffered()
                 assert signac.get_buffer_size() == 12
 
-            assert not signac.is_buffered()
-
-            assert not signac.is_buffered()
-            with signac.buffered():
-                assert signac.buffered()
-                assert signac.get_buffer_size() == 12
-                with signac.buffered():
-                    assert signac.buffered()
-                    assert signac.get_buffer_size() == 12
-
-            assert not signac.is_buffered()
-        finally:
-            signac.set_buffer_size(original_buffer_size)
+        assert not signac.is_buffered()
 
     def test_integration(self):
         def routine():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

Removes global buffering of synced collections in favor of class-specific buffering.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The current version of global buffering affects all backends simultaneously. This implementation doesn't really make sense; users should only be controlling buffering on a per-backend basis. The new approach also simplifies the process of introducing backend-specific buffering behavior, in this case for the purpose of reintroducing support for buffer size as a parameter for the buffering context.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
