### PR TITLE
Feature/synced collection/fix buffer reload

### DIFF
--- a/signac/synced_collections/buffers/serialized_file_buffered_collection.py
+++ b/signac/synced_collections/buffers/serialized_file_buffered_collection.py
@@ -121,7 +121,7 @@ class SerializedFileBufferedCollection(FileBufferedCollection):
                                 raise MetadataError(
                                     self._filename, cached_data["contents"]
                                 )
-                            self._data = self._decode(cached_data["contents"])
+                            self._update(self._decode(cached_data["contents"]))
                             self._save_to_resource()
                     finally:
                         # Whether or not an error was raised, the cache must be

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -521,6 +521,14 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         assert "bar" in sc
 
+    def test_data_type_with_buffered(self, synced_collection):
+        """Make sure that the _data attribute has the right types after buffering."""
+        with self._collection_type.buffer_backend():
+            synced_collection["foo"] = {"bar": "baz"}
+
+        # This will fail if synced_collection['foo'] is a raw dict.
+        synced_collection["foo"]()
+
 
 class TestBufferedJSONList(BufferedJSONCollectionTest, TestJSONList):
     """Tests of buffering JSONLists."""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Make sure that nested collections don't lose type information when leaving buffered mode.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #485 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
