### PR TITLE
Defer statepoint instantiation, unify reset_statepoint logic

### DIFF
--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -275,9 +275,6 @@ class Job:
         else:
             # Only an id was provided. State point will be loaded lazily.
             self._id = _id
-            self._statepoint = _StatePointDict(
-                jobs=[self], filename=self._statepoint_filename
-            )
             self._statepoint_requires_init = True
 
     def _initialize_lazy_properties(self):
@@ -383,7 +380,7 @@ class Job:
             The job's new state point.
 
         """
-        self._statepoint.reset(new_statepoint)
+        self.statepoint.reset(new_statepoint)
 
     def update_statepoint(self, update, overwrite=False):
         """Change the state point of this job while preserving job data.
@@ -429,7 +426,7 @@ class Job:
                 if statepoint.get(key, value) != value:
                     raise KeyError(key)
         statepoint.update(update)
-        self._statepoint.reset(statepoint)
+        self.statepoint.reset(statepoint)
 
     @property
     def statepoint(self):
@@ -456,6 +453,9 @@ class Job:
         """
         if self._statepoint_requires_init:
             # Load state point data lazily (on access).
+            self._statepoint = _StatePointDict(
+                jobs=[self], filename=self._statepoint_filename
+            )
             statepoint = self._statepoint.load(self.id)
 
             # Update the project's state point cache when loaded lazily
@@ -474,7 +474,7 @@ class Job:
             The new state point to be assigned.
 
         """
-        self._statepoint.reset(new_statepoint)
+        self.statepoint.reset(new_statepoint)
 
     @property
     def sp(self):
@@ -657,7 +657,7 @@ class Job:
         try:
             # Attempt early exit if the state point file exists and is valid.
             try:
-                statepoint = self._statepoint.load(self.id)
+                statepoint = self.statepoint.load(self.id)
             except Exception:
                 # Any exception means this method cannot exit early.
 
@@ -674,8 +674,8 @@ class Job:
                 # The state point save will not overwrite an existing file on
                 # disk unless force is True, so the subsequent load will catch
                 # when a preexisting invalid file was present.
-                self._statepoint.save(force=force)
-                statepoint = self._statepoint.load(self.id)
+                self.statepoint.save(force=force)
+                statepoint = self.statepoint.load(self.id)
 
                 # Update the project's state point cache if the saved file is valid.
                 self._project._register(self.id, statepoint)

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -215,7 +215,7 @@ class _StatePointDict(JSONAttrDict):
             raise JobsCorruptedError([job_id])
 
         with self._suspend_sync:
-            self._update(data)
+            self._update(data, validate=False)
 
         return data
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -215,7 +215,7 @@ class _StatePointDict(JSONAttrDict):
             raise JobsCorruptedError([job_id])
 
         with self._suspend_sync:
-            self._update(data, validate=False)
+            self._update(data)
 
         return data
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -384,14 +384,13 @@ class Job:
             # Instantiate state point data lazily - no load is required, since
             # we are provided with the new state point data.
             self._statepoint = _StatePointDict(
-                jobs=[self], filename=self._statepoint_filename, data=new_statepoint
+                jobs=[self], filename=self._statepoint_filename
             )
-
-            # Update the project's state point cache when loaded lazily
-            self._project._register(self.id, new_statepoint)
             self._statepoint_requires_init = False
-        else:
-            self.statepoint.reset(new_statepoint)
+        self.statepoint.reset(new_statepoint)
+
+        # Update the project's state point cache when loaded lazily
+        self._project._register(self.id, new_statepoint)
 
     def update_statepoint(self, update, overwrite=False):
         """Change the state point of this job while preserving job data.

--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -99,7 +99,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
         """
         return _mapping_resolver.get_type(data) == "MAPPING"
 
-    def _update(self, data=None):
+    def _update(self, data=None, validate=True):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -135,7 +135,8 @@ class SyncedDict(SyncedCollection, MutableMapping):
                     except KeyError:
                         # If the item wasn't present at all, we can simply
                         # assign it.
-                        self._validate({key: new_value})
+                        if validate:
+                            self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
                     else:
                         if new_value == existing:
@@ -153,7 +154,8 @@ class SyncedDict(SyncedCollection, MutableMapping):
                         #        (in which case we would have tried to update it), OR
                         #     2) The existing value is a SyncedCollection, but
                         #       the new value is not a compatible type for _update.
-                        self._validate({key: new_value})
+                        if validate:
+                            self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
 
                 to_remove = [key for key in self._data if key not in data]

--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -99,7 +99,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
         """
         return _mapping_resolver.get_type(data) == "MAPPING"
 
-    def _update(self, data=None, validate=True):
+    def _update(self, data=None):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -135,8 +135,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
                     except KeyError:
                         # If the item wasn't present at all, we can simply
                         # assign it.
-                        if validate:
-                            self._validate({key: new_value})
+                        self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
                     else:
                         if new_value == existing:
@@ -154,8 +153,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
                         #        (in which case we would have tried to update it), OR
                         #     2) The existing value is a SyncedCollection, but
                         #       the new value is not a compatible type for _update.
-                        if validate:
-                            self._validate({key: new_value})
+                        self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
 
                 to_remove = [key for key in self._data if key not in data]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1016,6 +1016,7 @@ class TestJobDocument(TestJobBase):
         with pytest.raises(DestinationExistsError):
             src_job.reset_statepoint(dst)
 
+    @pytest.mark.skipif(not H5PY, reason="test requires the h5py package")
     def test_reset_statepoint_job_lazy_access(self):
         key = "move_job"
         d = testdata()


### PR DESCRIPTION
## Description
@vyasr this is an attempt to defer instantiation of the `_StatePointDict` class. Related to https://github.com/glotzerlab/signac/pull/484#issuecomment-774398330.

~I also added an option to disable input data validation in `SyncedCollection._update`.~ I am moving the option to disable data validation into a separate PR.

## Motivation and Context
Speeds up `Project.open_job` by deferring `_StatePointDict.__init__` until `Job.statepoint` access.
This is a performance improvement for common access patterns (project iteration) for the same reasons as lazy loading, but benchmarks measuring "time to read statepoints" will see no change.

With deferred instantiation of the `_StatePointDict`, the profile of `open_job` looks identical for the current state of PR #484 and v1.6.0. As a consequence, we can conclude that the slowdown of `open_job` from v1.6.0 to the current state of PR #484 is _entirely_ due to the hierarchical access of `SyncedAttrDict.__setattr__`.

## Effect of the changes

With data validation disabled during `_StatePointDict.load`, the performance is closer to v1.6.0 but it won't match until we figure out how to improve `SyncedAttrDict.__setattr__`. Profiling a workspace of 1000 jobs, where I load the state point of every job:
- v1.6.0: 0.055 seconds
- PR #484 (currently): 0.113 seconds
- This PR: 0.081 seconds

The only other item causing slowdown relative to v1.6.0 is the call to `Job._statepoint_filename`, which appears to call `os.path.join` twice (once for the workspace, once for the state point filename) instead of once (directly computing the state point filename). Unless someone sees a way around that, I'm fine with ignoring that small impact.