### PR TITLE
Revert "Revert "Implement feature to search jobs with a sp- and doc-integrated filter ""

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,15 @@ The **signac** package follows `semantic versioning <https://semver.org/>`_.
 Version 1
 =========
 
+next
+----
+
+Added
++++++
+
+ - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac, and indexing APIs will be removed in signac 2.0.
+
+
 [1.6.0] -- 2020-01-24
 ---------------------
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -62,7 +62,7 @@ def _make_schema_based_path_function(jobs, exclude_keys=None, delimiter_nested="
         # signature of the path function below.
         return lambda job, sep=None: ""
 
-    index = [{"_id": job.id, "statepoint": job.statepoint()} for job in jobs]
+    index = [{"_id": job.id, "sp": job.sp()} for job in jobs]
     jsi = _build_job_statepoint_index(exclude_const=True, index=index)
     sp_index = OrderedDict(jsi)
 

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -62,11 +62,11 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
 
     if index is None:
         if job_ids is None:
-            index = [{"_id": job.id, "statepoint": job.statepoint()} for job in project]
+            index = [{"_id": job.id, "sp": job.sp()} for job in project]
             jobs = list(project)
         else:
             index = [
-                {"_id": job_id, "statepoint": project.open_job(id=job_id).statepoint()}
+                {"_id": job_id, "sp": project.open_job(id=job_id).sp()}
                 for job_id in job_ids
             ]
             jobs = list(project.open_job(id=job_id) for job_id in job_ids)

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -36,6 +36,7 @@ from .errors import (
     JobsCorruptedError,
     WorkspaceError,
 )
+from .filterparse import _add_prefix, _root_keys, parse_filter
 from .hashing import calc_id
 from .indexing import MainCrawler, SignacProjectCrawler
 from .job import Job
@@ -128,6 +129,16 @@ class JobSearchIndex:
         -------
         list
             List of job ids matching the provided filter(s).
+
+        Raises
+        ------
+        TypeError
+            If the filters are not JSON serializable.
+        ValueError
+            If the filters are invalid.
+        RuntimeError
+            If the filters are not supported
+            by the index.
 
         """
         if filter:
@@ -841,7 +852,7 @@ class Project:
         from .schema import _build_job_statepoint_index
 
         if index is None:
-            index = [{"_id": job.id, "statepoint": job.statepoint()} for job in self]
+            index = [{"_id": job.id, "sp": job.sp()} for job in self]
         for x, y in _build_job_statepoint_index(
             exclude_const=exclude_const, index=index
         ):
@@ -968,14 +979,15 @@ class Project:
         if filter is None and doc_filter is None and index is None:
             return list(self._job_dirs())
         if index is None:
-            if doc_filter is None:
-                index = self._sp_index()
-            else:
+            filter = dict(parse_filter(_add_prefix("sp.", filter)))
+            if doc_filter:
+                filter.update(parse_filter(_add_prefix("doc.", doc_filter)))
                 index = self.index(include_job_document=True)
-            search_index = JobSearchIndex(index, _trust=True)
-        else:
-            search_index = JobSearchIndex(index)
-        return search_index.find_job_ids(filter=filter, doc_filter=doc_filter)
+            elif "doc" in _root_keys(filter):
+                index = self.index(include_job_document=True)
+            else:
+                index = self._sp_index()
+        return Collection(index, _trust=True)._find(filter)
 
     def find_jobs(self, filter=None, doc_filter=None):
         """Find all jobs in the project's workspace.
@@ -1011,7 +1023,10 @@ class Project:
             If the filters are not supported by the index.
 
         """
-        return JobsCursor(self, filter, doc_filter)
+        filter = dict(parse_filter(_add_prefix("sp.", filter)))
+        if doc_filter:
+            filter.update(parse_filter(_add_prefix("doc.", doc_filter)))
+        return JobsCursor(self, filter)
 
     def __iter__(self):
         return iter(self.find_jobs())
@@ -1029,6 +1044,14 @@ class Project:
 
             # Group jobs by state point parameter 'a'.
             for key, group in project.groupby('a'):
+                print(key, list(group))
+
+            # Group jobs by document value 'a'.
+            for key, group in project.groupby('doc.a'):
+                print(key, list(group))
+
+            # Group jobs by jobs.sp['a'] and job.document['b']
+            for key, group in project.groupby('a', 'doc.b'):
                 print(key, list(group))
 
             # Find jobs where job.sp['a'] is 1 and group them
@@ -1811,7 +1834,7 @@ class Project:
                 raise
         if index is not None:
             for doc in index:
-                self._sp_cache[doc["signac_id"]] = doc["statepoint"]
+                self._sp_cache[doc["signac_id"]] = doc["sp"]
 
         corrupted = []
         for job_id in job_ids:
@@ -1879,7 +1902,7 @@ class Project:
         for _id in to_remove:
             del self._index_cache[_id]
         for _id in to_add:
-            self._index_cache[_id] = dict(statepoint=self._get_statepoint(_id), _id=_id)
+            self._index_cache[_id] = dict(sp=self._get_statepoint(_id), _id=_id)
         return self._index_cache.values()
 
     def _build_index(self, include_job_document=False):
@@ -1894,16 +1917,16 @@ class Project:
         """
         wd = self.workspace() if self.Job is Job else None
         for _id in self._find_job_ids():
-            doc = dict(_id=_id, statepoint=self._get_statepoint(_id))
+            doc = dict(_id=_id, sp=self._get_statepoint(_id))
             if include_job_document:
                 if wd is None:
-                    doc.update(self.open_job(id=_id).document)
+                    doc["doc"] = self.open_job(id=_id).document
                 else:  # use optimized path
                     try:
                         with open(
                             os.path.join(wd, _id, self.Job.FN_DOCUMENT), "rb"
                         ) as file:
-                            doc.update(json.loads(file.read().decode()))
+                            doc["doc"] = json.loads(file.read().decode())
                     except OSError as error:
                         if error.errno != errno.ENOENT:
                             raise
@@ -2416,36 +2439,28 @@ class JobsCursor:
     filter : dict
         A mapping of key-value pairs that all indexed job state points are
         compared against (Default value = None).
-    doc_filter : dict
-        A mapping of key-value pairs that all indexed job documents are
-        compared against (Default value = None).
 
     """
 
     _use_pandas_for_html_repr = True  # toggle use of pandas for html repr
 
-    def __init__(self, project, filter, doc_filter):
+    def __init__(self, project, filter):
         self._project = project
         self._filter = filter
-        self._doc_filter = doc_filter
 
         # This private attribute allows us to implement the deprecated
         # next() method for this class.
         self._next_iter = None
 
     def __eq__(self, other):
-        return (
-            self._project == other._project
-            and self._filter == other._filter
-            and self._doc_filter == other._doc_filter
-        )
+        return self._project == other._project and self._filter == other._filter
 
     def __len__(self):
         # Highly performance critical code path!!
-        if self._filter or self._doc_filter:
-            # We use the standard function for determining job ids if a filter
-            # is provided.
-            return len(self._project._find_job_ids(self._filter, self._doc_filter))
+        if self._filter:
+            # We use the standard function for determining job ids if and only if
+            # any of the two filter is provided.
+            return len(self._project._find_job_ids(self._filter))
         else:
             # Without filters, we can simply return the length of the whole project.
             return len(self._project)
@@ -2467,13 +2482,13 @@ class JobsCursor:
         if job not in self._project:
             # Exit early if the job is not in the project. This is O(1).
             return False
-        if self._filter or self._doc_filter:
+        if self._filter:
             # We use the standard function for determining job ids if a filter
             # is provided. This is O(N) and could be optimized by caching the
             # ids of state points that match a state point filter. Caching the
             # matches for a document filter is not safe because the document
             # can change.
-            return job.id in self._project._find_job_ids(self._filter, self._doc_filter)
+            return job.id in self._project._find_job_ids(self._filter)
         # Without filters, we can simply check if the job is in the project.
         # By the early-exit condition, we know the job must be contained.
         return True
@@ -2481,8 +2496,7 @@ class JobsCursor:
     def __iter__(self):
         # Code duplication here for improved performance.
         return _JobsCursorIterator(
-            self._project,
-            self._project._find_job_ids(self._filter, self._doc_filter),
+            self._project, self._project._find_job_ids(self._filter)
         )
 
     def next(self):
@@ -2519,6 +2533,14 @@ class JobsCursor:
             for key, group in project.groupby('a'):
                 print(key, list(group))
 
+            # Group jobs by document value 'a'.
+            for key, group in project.groupby('doc.a'):
+                print(key, list(group))
+
+            # Group jobs by jobs.sp['a'] and job.document['b']
+            for key, group in project.groupby('a', 'doc.b'):
+                print(key, list(group))
+
             # Find jobs where job.sp['a'] is 1 and group them
             # by job.sp['b'] and job.sp['c'].
             for key, group in project.find_jobs({'a': 1}).groupby(('b', 'c')):
@@ -2545,49 +2567,64 @@ class JobsCursor:
 
         """
         _filter = self._filter
+
+        if default is not None and not isinstance(key, (str, Iterable)):
+            warnings.warn(
+                "The default parameter is ignored for grouping except "
+                "when grouping by a (list of) string key(s)."
+            )
+
+        def _strip_prefix(key):
+            """Strip the prefix, if it is present.
+
+            Implicit and explicit sp prefixes are equivalent and can be treated
+            identically for this purpose.
+            """
+            return key.split(".", 1)[-1]
+
+        def _is_doc_key(key):
+            """Check if a key is a document key."""
+            return "." in key and key.split(".", 1)[0] == "doc"
+
         if isinstance(key, str):
+            stripped_key = _strip_prefix(key)
+
             if default is None:
                 if _filter is None:
                     _filter = {key: {"$exists": True}}
                 else:
                     _filter = {"$and": [{key: {"$exists": True}}, _filter]}
 
-                def keyfunction(job):
-                    """Return job's state point value corresponding to the key.
+                if _is_doc_key(key):
 
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
+                    def keyfunction(job):
+                        return job.document[stripped_key]
 
-                    Returns
-                    -------
-                    State point value corresponding to the key.
+                else:
 
-                    """
-                    return job.statepoint[key]
+                    def keyfunction(job):
+                        return job.sp[stripped_key]
 
             else:
+                if _is_doc_key(key):
 
-                def keyfunction(job):
-                    """Return job's state point value corresponding to the key.
+                    def keyfunction(job):
+                        return job.document.get(stripped_key, default)
 
-                    Return default if key is not present.
+                else:
 
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    State point value corresponding to the key.
-                    Default if key is not present.
-
-                    """
-                    return job.statepoint.get(key, default)
+                    def keyfunction(job):
+                        return job.sp.get(stripped_key, default)
 
         elif isinstance(key, Iterable):
+            sp_keys = []
+            doc_keys = []
+            for k in key:
+                if _is_doc_key(k):
+                    doc_keys.append(_strip_prefix(k))
+                else:
+                    sp_keys.append(_strip_prefix(k))
+
             if default is None:
                 if _filter is None:
                     _filter = {k: {"$exists": True} for k in key}
@@ -2595,57 +2632,22 @@ class JobsCursor:
                     _filter = {"$and": [{k: {"$exists": True} for k in key}, _filter]}
 
                 def keyfunction(job):
-                    """Return job's state point value corresponding to the key.
-
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    tuple
-                        State point values.
-
-                    """
-                    return tuple(job.statepoint[k] for k in key)
+                    return tuple(
+                        [job.sp[k] for k in sp_keys]
+                        + [job.document[k] for k in doc_keys]
+                    )
 
             else:
 
                 def keyfunction(job):
-                    """Return job's state point value corresponding to the key.
-
-                    Return default if key is not present.
-
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    tuple
-                        State point values.
-
-                    """
-                    return tuple(job.statepoint.get(k, default) for k in key)
+                    return tuple(
+                        [job.sp.get(k, default) for k in sp_keys]
+                        + [job.document.get(k, default) for k in doc_keys]
+                    )
 
         elif key is None:
             # Must return a type that can be ordered with <, >
             def keyfunction(job):
-                """Return the job's id.
-
-                Parameters
-                ----------
-                job : :class:`~signac.contrib.job.Job`
-                    The job instance.
-
-                Returns
-                -------
-                str
-                    The job's id.
-
-                """
                 return str(job)
 
         else:
@@ -2654,7 +2656,7 @@ class JobsCursor:
 
         return groupby(
             sorted(
-                iter(JobsCursor(self._project, _filter, self._doc_filter)),
+                iter(JobsCursor(self._project, _filter)),
                 key=keyfunction,
             ),
             key=keyfunction,
@@ -2702,112 +2704,32 @@ class JobsCursor:
             if default is None:
 
                 def keyfunction(job):
-                    """Return job's document value corresponding to the key.
-
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    Document value corresponding to the key.
-
-                    """
                     return job.document[key]
 
             else:
 
                 def keyfunction(job):
-                    """Return job's document value corresponding to the key.
-
-                    Return default if key is not present.
-
-                    Parameters
-                    ----------
-                    job : class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    Document value corresponding to the key.
-                    Default if key is not present.
-
-                    """
                     return job.document.get(key, default)
 
         elif isinstance(key, Iterable):
             if default is None:
 
                 def keyfunction(job):
-                    """Return job's document value corresponding to the key.
-
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    tuple
-                        Document values.
-
-                    """
                     return tuple(job.document[k] for k in key)
 
             else:
 
                 def keyfunction(job):
-                    """Return job's document value corresponding to the key.
-
-                    Return default if key is not present.
-
-                    Parameters
-                    ----------
-                    job : :class:`~signac.contrib.job.Job`
-                        The job instance.
-
-                    Returns
-                    -------
-                    tuple
-                        Document values.
-
-                    """
                     return tuple(job.document.get(k, default) for k in key)
 
         elif key is None:
             # Must return a type that can be ordered with <, >
             def keyfunction(job):
-                """Return the job's id.
-
-                Parameters
-                ----------
-                job : :class:`~signac.contrib.job.Job`
-                    The job instance.
-
-                Returns
-                -------
-                str
-                    The job's id.
-
-                """
                 return str(job)
 
         else:
             # Pass the job document to a callable
             def keyfunction(job):
-                """Return job's document value corresponding to the key.
-
-                Parameters
-                ----------
-                job : :class:`~signac.contrib.job.Job`
-                    The job instance.
-
-                Returns
-                -------
-                Document values.
-
-                """
                 return key(job.document)
 
         return groupby(sorted(iter(self), key=keyfunction), key=keyfunction)
@@ -2925,11 +2847,10 @@ class JobsCursor:
         ).infer_objects()
 
     def __repr__(self):
-        return "{type}(project={project}, filter={filter}, doc_filter={doc_filter})".format(
+        return "{type}(project={project}, filter={filter})".format(
             type=self.__class__.__name__,
             project=repr(self._project),
             filter=repr(self._filter),
-            doc_filter=repr(self._doc_filter),
         )
 
     def _repr_html_jobs(self):

--- a/signac/contrib/schema.py
+++ b/signac/contrib/schema.py
@@ -67,13 +67,13 @@ def _build_job_statepoint_index(exclude_const, index):
     collection = Collection(index, _trust=True)
     for doc in collection.find():
         for key, _ in _nested_dicts_to_dotted_keys(doc):
-            if key == "_id" or key.split(".")[0] != "statepoint":
+            if key == "_id" or key.split(".")[0] != "sp":
                 continue
             collection.index(key, build=True)
     indexes = collection._indexes
 
     def strip_prefix(key):
-        return key[len("statepoint.") :]
+        return key[len("sp.") :]
 
     def remove_dict_placeholder(x):
         """Remove _DictPlaceholder elements from a mapping.

--- a/tests/test_find_command_line_interface.py
+++ b/tests/test_find_command_line_interface.py
@@ -10,7 +10,7 @@ from itertools import chain
 
 import pytest
 
-from signac.contrib.filterparse import parse_filter_arg
+from signac.contrib.filterparse import parse_filter_arg, parse_simple
 from signac.core.json import JSONDecodeError
 
 FILTERS = [
@@ -38,6 +38,7 @@ FILTERS = [
     {"d": {"$type": "list"}},
     {"a.b": {"$where": "lambda x: x < 10"}},
     {"a.b": {"$where": "lambda x: isinstance(x, int)"}},
+    {"a": {"$regex": "[a][b][c]"}},
 ]
 
 
@@ -90,6 +91,9 @@ class TestFindCommandLineInterface:
             _assert_equal(f)
 
     def test_interpret_simple(self):
+        assert self._parse(["a"]) == {"a": {"$exists": True}}
+        assert next(parse_simple(["a"])) == ("a", {"$exists": True})
+
         for s, v in VALUES.items():
             assert self._parse(["a", s]) == {"a": v}
         for f in FILTERS:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -160,6 +160,8 @@ class TestBasicShell:
         assert "{'a': 0}" in sp
         assert len(project) == 1
 
+    # Index schema is changed
+    @pytest.mark.xfail()
     def test_index(self):
         self.call("python -m signac init my_project".split())
         self.call("python -m signac project --access".split())
@@ -269,6 +271,7 @@ class TestBasicShell:
         # Test the doc_filter
         for job in project.find_jobs():
             job.document["a"] = job.statepoint()["a"]
+            job.document["b"] = job.statepoint()["a"] + 1
 
         for i in range(3):
             assert (
@@ -278,6 +281,24 @@ class TestBasicShell:
                 ).strip()
                 == next(iter(project.find_jobs({"a": i}))).id
             )
+
+        with pytest.deprecated_call():
+            for i in range(3):
+                assert (
+                    self.call(
+                        "python -m signac find ".split() + ['{"doc.a": ' + str(i) + "}"]
+                    ).strip()
+                    == list(project.find_job_ids(doc_filter={"a": i}))[0]
+                )
+
+        with pytest.deprecated_call():
+            for i in range(1, 4):
+                assert (
+                    self.call(
+                        "python -m signac find ".split() + ['{"doc.b": ' + str(i) + "}"]
+                    ).strip()
+                    == list(project.find_job_ids(doc_filter={"b": i}))[0]
+                )
 
     def test_diff(self):
         self.call("python -m signac init ProjectA".split())


### PR DESCRIPTION
This PR undoes the reversion in #499, which reverts #332. The `JobsCursor` constructor is _not_ public API, so breaking it should be acceptable and no additional tests are necessary. Unfortunately, the most recent release of signac-flow makes use of this API internally, which is why this problem was identified. I'll make a subsequent PR to add a compatibility layer for this, and a separate PR in signac-flow to resolve the improper API usage for future versions of signac-flow.