### PR TITLE
Feature/synced collection/disable recursive validation

### DIFF
--- a/signac/synced_collections/data_types/synced_collection.py
+++ b/signac/synced_collections/data_types/synced_collection.py
@@ -300,6 +300,14 @@ class SyncedCollection(Collection):
     def _from_base(cls, data, **kwargs):
         r"""Dynamically resolve the type of object to the corresponding synced collection.
 
+        This method assumes that ``data`` has already been validated. This assumption
+        can always be met, since this method should only be called internally by
+        other methods that modify the internal collection data. While this requirement
+        does require that all calling methods be responsible for validation, it
+        confers significant performance benefits because it can instruct any invoked
+        class constructors not to validate, which is especially important for nested
+        collections.
+
         Parameters
         ----------
         data : Collection
@@ -325,7 +333,7 @@ class SyncedCollection(Collection):
         """
         for base_cls in SyncedCollection.registry[cls._backend]:
             if base_cls.is_base_type(data):
-                return base_cls(data=data, **kwargs)
+                return base_cls(data=data, _validate=False, **kwargs)
         return _convert_numpy(data)
 
     @abstractmethod

--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -49,12 +49,16 @@ class SyncedDict(SyncedCollection, MutableMapping):
     new :class:`SyncedDict`.
     """
 
-    def __init__(self, data=None, *args, **kwargs):
+    # The _validate parameter is an optimization for internal use only. This
+    # argument will be passed by _from_base whenever an unsynced collection is
+    # being recursively converted, ensuring that validation only happens once.
+    def __init__(self, data=None, _validate=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if data is None:
             self._data = {}
         else:
-            self._validate(data)
+            if _validate:
+                self._validate(data)
             with self._suspend_sync:
                 self._data = {
                     key: self._from_base(data=value, parent=self)

--- a/signac/synced_collections/data_types/synced_list.py
+++ b/signac/synced_collections/data_types/synced_list.py
@@ -55,12 +55,16 @@ class SyncedList(SyncedCollection, MutableSequence):
 
     """
 
-    def __init__(self, data=None, *args, **kwargs):
+    # The _validate parameter is an optimization for internal use only. This
+    # argument will be passed by _from_base whenever an unsynced collection is
+    # being recursively converted, ensuring that validation only happens once.
+    def __init__(self, data=None, _validate=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if data is None:
             self._data = []
         else:
-            self._validate(data)
+            if _validate:
+                self._validate(data)
             data = _convert_numpy(data)
             with self._suspend_sync:
                 self._data = [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Currently `_validate` is called on any container type, then again for each of its elements when `_from_base` is called on that element. This patch removes that extra call.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Optimization for synced collections.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
