### PR TITLE
Optionally skip validation in SyncedCollection _update.

### DIFF
--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -215,7 +215,7 @@ class _StatePointDict(JSONAttrDict):
             raise JobsCorruptedError([job_id])
 
         with self._suspend_sync:
-            self._update(data)
+            self._update(data, trust_source=True)
 
         return data
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -215,7 +215,7 @@ class _StatePointDict(JSONAttrDict):
             raise JobsCorruptedError([job_id])
 
         with self._suspend_sync:
-            self._update(data, _validate=True)
+            self._update(data, _validate=False)
 
         return data
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -215,7 +215,7 @@ class _StatePointDict(JSONAttrDict):
             raise JobsCorruptedError([job_id])
 
         with self._suspend_sync:
-            self._update(data, trust_source=True)
+            self._update(data, _validate=True)
 
         return data
 

--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -99,7 +99,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
         """
         return _mapping_resolver.get_type(data) == "MAPPING"
 
-    def _update(self, data=None):
+    def _update(self, data=None, trust_source=False):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -117,6 +117,8 @@ class SyncedDict(SyncedCollection, MutableMapping):
         data : collections.abc.Mapping
             The data to be assigned to this dict. If ``None``, the data is left
             unchanged (Default value = None).
+        trust_source : bool
+            If True, the data will not be validated (Default value = False).
 
         """
         if data is None:
@@ -135,7 +137,8 @@ class SyncedDict(SyncedCollection, MutableMapping):
                     except KeyError:
                         # If the item wasn't present at all, we can simply
                         # assign it.
-                        self._validate({key: new_value})
+                        if not trust_source:
+                            self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
                     else:
                         if new_value == existing:
@@ -153,7 +156,8 @@ class SyncedDict(SyncedCollection, MutableMapping):
                         #        (in which case we would have tried to update it), OR
                         #     2) The existing value is a SyncedCollection, but
                         #       the new value is not a compatible type for _update.
-                        self._validate({key: new_value})
+                        if not trust_source:
+                            self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
 
                 to_remove = [key for key in self._data if key not in data]

--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -99,7 +99,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
         """
         return _mapping_resolver.get_type(data) == "MAPPING"
 
-    def _update(self, data=None, trust_source=False):
+    def _update(self, data=None, _validate=False):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -117,7 +117,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
         data : collections.abc.Mapping
             The data to be assigned to this dict. If ``None``, the data is left
             unchanged (Default value = None).
-        trust_source : bool
+        _validate : bool
             If True, the data will not be validated (Default value = False).
 
         """
@@ -137,7 +137,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
                     except KeyError:
                         # If the item wasn't present at all, we can simply
                         # assign it.
-                        if not trust_source:
+                        if not _validate:
                             self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
                     else:
@@ -156,7 +156,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
                         #        (in which case we would have tried to update it), OR
                         #     2) The existing value is a SyncedCollection, but
                         #       the new value is not a compatible type for _update.
-                        if not trust_source:
+                        if not _validate:
                             self._validate({key: new_value})
                         self._data[key] = self._from_base(new_value, parent=self)
 

--- a/signac/synced_collections/data_types/synced_list.py
+++ b/signac/synced_collections/data_types/synced_list.py
@@ -109,7 +109,7 @@ class SyncedList(SyncedCollection, MutableSequence):
                 converted.append(value)
         return converted
 
-    def _update(self, data=None):
+    def _update(self, data=None, trust_source=False):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -127,6 +127,8 @@ class SyncedList(SyncedCollection, MutableSequence):
         data : collections.abc.Sequence
             The data to be assigned to this list. If ``None``, the data is left
             unchanged (Default value = None).
+        trust_source : bool
+            If True, the data will not be validated (Default value = False).
 
         """
         if data is None:
@@ -149,14 +151,16 @@ class SyncedList(SyncedCollection, MutableSequence):
                             continue
                         except ValueError:
                             pass
-                    self._validate(data[i])
+                    if not trust_source:
+                        self._validate(data[i])
                     self._data[i] = self._from_base(data[i], parent=self)
 
                 if len(self._data) > len(data):
                     self._data = self._data[: len(data)]
                 else:
-                    new_data = data[len(self) :]
-                    self._validate(new_data)
+                    new_data = data[len(self):]
+                    if not trust_source:
+                        self._validate(new_data)
                     self.extend(new_data)
         else:
             raise ValueError(

--- a/signac/synced_collections/data_types/synced_list.py
+++ b/signac/synced_collections/data_types/synced_list.py
@@ -158,7 +158,7 @@ class SyncedList(SyncedCollection, MutableSequence):
                 if len(self._data) > len(data):
                     self._data = self._data[: len(data)]
                 else:
-                    new_data = data[len(self):]
+                    new_data = data[len(self) :]
                     if not trust_source:
                         self._validate(new_data)
                     self.extend(new_data)

--- a/signac/synced_collections/data_types/synced_list.py
+++ b/signac/synced_collections/data_types/synced_list.py
@@ -109,7 +109,7 @@ class SyncedList(SyncedCollection, MutableSequence):
                 converted.append(value)
         return converted
 
-    def _update(self, data=None, trust_source=False):
+    def _update(self, data=None, _validate=False):
         """Update the in-memory representation to match the provided data.
 
         The purpose of this method is to update the SyncedCollection to match
@@ -127,7 +127,7 @@ class SyncedList(SyncedCollection, MutableSequence):
         data : collections.abc.Sequence
             The data to be assigned to this list. If ``None``, the data is left
             unchanged (Default value = None).
-        trust_source : bool
+        _validate : bool
             If True, the data will not be validated (Default value = False).
 
         """
@@ -151,7 +151,7 @@ class SyncedList(SyncedCollection, MutableSequence):
                             continue
                         except ValueError:
                             pass
-                    if not trust_source:
+                    if not _validate:
                         self._validate(data[i])
                     self._data[i] = self._from_base(data[i], parent=self)
 
@@ -159,7 +159,7 @@ class SyncedList(SyncedCollection, MutableSequence):
                     self._data = self._data[: len(data)]
                 else:
                     new_data = data[len(self) :]
-                    if not trust_source:
+                    if not _validate:
                         self._validate(new_data)
                     self.extend(new_data)
         else:


### PR DESCRIPTION
## Description
Split off from work started in #497. This PR allows data validation to be skipped on state point load, by adding an option `_validate=False` to the SyncedCollections' `_update` method.

## Motivation and Context
Trying to get SyncedCollection performance closer to the performance on `master` by shaving off checks that might not be necessary (based on the current balance of safety/performance in signac).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.