### PR TITLE
Treat empty filters {} the same as None.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ next
 Added
 +++++
 
- - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac, and indexing APIs will be removed in signac 2.0.
+ - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332, #514). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac. Indexing APIs will be removed in signac 2.0.
 
 
 [1.6.0] -- 2020-01-24

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -914,19 +914,19 @@ class Project:
 
         Parameters
         ----------
-        filter : dict
-            A mapping of key-value pairs that all
-            indexed job state points are compared against (Default value = None).
-        doc_filter : dict
-            A mapping of key-value pairs that all
-            indexed job documents are compared against (Default value = None).
+        filter : Mapping
+            A mapping of key-value pairs that all indexed job state points
+            are compared against (Default value = None).
+        doc_filter : Mapping
+            A mapping of key-value pairs that all indexed job documents are
+            compared against (Default value = None).
         index :
-             A document index. If not provided, an index will be computed
+            A document index. If not provided, an index will be computed
             (Default value = None).
 
         Returns
         -------
-        The ids of all indexed jobs matching both filter(s).
+        The ids of all indexed jobs matching both filters.
 
         Raises
         ------
@@ -953,9 +953,9 @@ class Project:
         Parameters
         ----------
         filter : Mapping
-            A mapping of key-value pairs that all indexed job state points are
-            compared against (Default value = None).
-        doc_filter :
+            A mapping of key-value pairs that all indexed job state points
+            are compared against (Default value = None).
+        doc_filter : Mapping
             A mapping of key-value pairs that all indexed job documents are
             compared against (Default value = None).
         index :
@@ -976,7 +976,7 @@ class Project:
             If the filters are not supported by the index.
 
         """
-        if filter is None and doc_filter is None and index is None:
+        if not filter and not doc_filter and index is None:
             return list(self._job_dirs())
         if index is None:
             filter = dict(parse_filter(_add_prefix("sp.", filter)))
@@ -2436,7 +2436,7 @@ class JobsCursor:
     ----------
     project : :class:`~signac.Project`
         Project handle.
-    filter : dict
+    filter : Mapping
         A mapping of key-value pairs that all indexed job state points are
         compared against (Default value = None).
 
@@ -2444,7 +2444,7 @@ class JobsCursor:
 
     _use_pandas_for_html_repr = True  # toggle use of pandas for html repr
 
-    def __init__(self, project, filter, doc_filter=None):
+    def __init__(self, project, filter=None, doc_filter=None):
         self._project = project
         self._filter = filter
 
@@ -2452,7 +2452,15 @@ class JobsCursor:
         # removed after signac 2.0 is released and once signac-flow drops
         # support for signac < 2.0.
         if doc_filter:
-            filter.update(parse_filter(_add_prefix("doc.", doc_filter)))
+            doc_filter = parse_filter(_add_prefix("doc.", doc_filter))
+            if self._filter:
+                self._filter.update(doc_filter)
+            else:
+                self._filter = doc_filter
+
+        # Replace empty filters with None for performance
+        if self._filter == {}:
+            self._filter = None
 
         # This private attribute allows us to implement the deprecated
         # next() method for this class.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -964,7 +964,11 @@ class Project:
 
         Returns
         -------
-        The ids of all indexed jobs matching both filters.
+        Collection or list
+            The ids of all indexed jobs matching both filters. If no arguments
+            are provided to this method, the ids are returned as a list. If
+            any of the arguments are provided, a :class:`Collection` containing
+            all the ids is returned.
 
         Raises
         ------
@@ -974,6 +978,16 @@ class Project:
             If the filters are invalid.
         RuntimeError
             If the filters are not supported by the index.
+
+        Notes
+        -----
+        If all arguments are ``None``, this method skips indexing the data
+        space and instead simply iterates over all job directories. This
+        code path can be much faster for certain use cases since it defers
+        all work that would be required to construct an index, so in
+        performance-critical applications where no filtering of the data space
+        is required, passing no arguments to this method (as opposed to empty
+        dict filters) is recommended.
 
         """
         if not filter and not doc_filter and index is None:
@@ -2439,6 +2453,15 @@ class JobsCursor:
     filter : Mapping
         A mapping of key-value pairs that all indexed job state points are
         compared against (Default value = None).
+
+    Notes
+    -----
+    Iteration is performed by acquiring job ids from the project using
+    :meth:`Project._find_job_ids`. When no filter (``filter = None``) is
+    provided, that method can take a much faster execution path, so not passing
+    a filter (or passing ``None`` explicitly) to this constructor is strongly
+    recommended over passing an empty filter (``filter = {}``) when iterating
+    over the entire data space.
 
     """
 


### PR DESCRIPTION
## Description
I have been running benchmarks for synced collections (#484) and noticed that my project was loading state point data even when not requested.

I traced this down to the recent changes in #332 that changed the default `filter` behavior from `None` to `{}`. This prevented some of the "fast path" checks from triggering, and caused a full index for the project to be constructed.

## Motivation and Context
Bug fix.

I don't know how to test this effectively, because it only affects internal APIs and performance, not correctness.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
