### PR TITLE
Optimize path joins with os.sep.join(...).

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,11 @@ Added
  - New ``SyncedCollection`` class and subclasses to replace ``JSONDict`` with more general support for different types of resources (such as MongoDB collections or Redis databases) and more complete support for different data types synchronized with files (#196, #234, #249, #316, #383, #397, #465, #484). This change introduces a minor-backwards incompatible change; for users making direct use of signac buffering, the ``force_write`` parameter is no longer respected. If the argument is passed, a warning will now be raised to indicate that it is ignored and will be removed in signac 2.0.
  - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332, #514). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac. Indexing APIs will be removed in signac 2.0.
 
+Changed
++++++++
+
+ - Optimized internal path joins to speed up project iteration (#515).
+
 
 [1.6.0] -- 2020-01-24
 ---------------------

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -345,14 +345,16 @@ class Job:
         """
         if self._wd is None:
             # We can rely on the project workspace to be well-formed, so just
-            # use string-concatenation with os.sep instead of os.path.join for speed.
-            self._wd = self._project.workspace() + os.sep + self.id
+            # use str.join with os.sep instead of os.path.join for speed.
+            self._wd = os.sep.join((self._project.workspace(), self.id))
         return self._wd
 
     @property
     def _statepoint_filename(self):
         """Get the path of the state point file for this job."""
-        return self.workspace() + os.sep + self.FN_MANIFEST
+        # We can rely on the job workspace to be well-formed, so just
+        # use str.join with os.sep instead of os.path.join for speed.
+        return os.sep.join((self.workspace(), self.FN_MANIFEST))
 
     @property
     def ws(self):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -757,7 +757,9 @@ class Project:
             True if the job id is initialized for this project.
 
         """
-        return os.path.exists(os.path.join(self.workspace(), job_id))
+        # We can rely on the project workspace to be well-formed, so just use
+        # str.join with os.sep instead of os.path.join for speed.
+        return os.path.exists(os.sep.join((self.workspace(), job_id)))
 
     def __contains__(self, job):
         """Determine whether a job is in the project's data space.
@@ -1274,12 +1276,14 @@ class Project:
             Identifier of the job.
 
         """
-        fn_manifest = os.path.join(self.workspace(), job_id, self.Job.FN_MANIFEST)
+        # We can rely on the project workspace to be well-formed, so just use
+        # str.join with os.sep instead of os.path.join for speed.
+        fn_manifest = os.sep.join((self.workspace(), job_id, self.Job.FN_MANIFEST))
         try:
             with open(fn_manifest, "rb") as manifest:
                 return json.loads(manifest.read().decode())
         except (OSError, ValueError) as error:
-            if os.path.isdir(os.path.join(self.workspace(), job_id)):
+            if os.path.isdir(os.sep.join((self.workspace(), job_id))):
                 logger.error(
                     "Error while trying to access state "
                     "point manifest file of job '{}': '{}'.".format(job_id, error)


### PR DESCRIPTION
## Description
Extends on work started in #511. In a few performance-critical locations that use internal paths (not user-provided paths), we can sacrifice the safety benefits of `os.path.join(*paths)` in favor of the speedier `os.sep.join(paths)`.

This yields about a 20-25% speedup when iterating over a project without accessing job state points.

We can only apply this optimization in places that deal with _internal paths_, like "project_workspace / job_id" but not like `job.fn(some_user_path)`. User paths must be accessed through `os.path.join`, which includes the project workspace (which is configurable). Regardless, we are able to safely handle the most important cases (the job workspace and the job state point filename) that are called O(N) times.

## Benchmarks

Below I have benchmarks of the following script, which just iterates over the project without accessing any job properties. There are 1000 jobs in the workspace.

```python
import signac

project = signac.get_project()

def no_load_data():
    data = [job for job in project]

no_load_data()
```

### Before

The call to `os.path.join` (displayed as `posixpath.py:71(join)`) takes a chunk of time, which is eliminated in the "After".
![image](https://user-images.githubusercontent.com/3943761/108604395-4f12d680-7373-11eb-80ab-65c45456687c.png)

### After
The bulk of the iteration is `stat` calls, which cannot be further optimized. 👍 
![image](https://user-images.githubusercontent.com/3943761/108604406-589c3e80-7373-11eb-8b97-417ac3f762a0.png)


## Motivation and Context
Seeking some final obvious optimizations for synced collections (#484).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
