### PR TITLE
Lock lazy properties

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ next
 Added
 +++++
 
- - New ``SyncedCollection`` class and subclasses to replace ``JSONDict`` with more general support for different types of resources (such as MongoDB collections or Redis databases) and more complete support for different data types synchronized with files (#196, #234, #249, #316, #383, #397, #465, #484). This change introduces a minor-backwards incompatible change; for users making direct use of signac buffering, the ``force_write`` parameter is no longer respected. If the argument is passed, a warning will now be raised to indicate that it is ignored and will be removed in signac 2.0.
+ - New ``SyncedCollection`` class and subclasses to replace ``JSONDict`` with more general support for different types of resources (such as MongoDB collections or Redis databases) and more complete support for different data types synchronized with files (#196, #234, #249, #316, #383, #397, #465, #484, #529). This change introduces a minor-backwards incompatible change; for users making direct use of signac buffering, the ``force_write`` parameter is no longer respected. If the argument is passed, a warning will now be raised to indicate that it is ignored and will be removed in signac 2.0.
  - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332, #514). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac. Indexing APIs will be removed in signac 2.0.
 
 Changed

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ next
 Added
 +++++
 
- - New ``SyncedCollection`` class and subclasses to replace ``JSONDict`` with more general support for different types of resources (such as MongoDB collections or Redis databases) and more complete support for different data types synchronized with files (#196, #234, #249, #316, #383, #397, #465, #484, #529). This change introduces a minor-backwards incompatible change; for users making direct use of signac buffering, the ``force_write`` parameter is no longer respected. If the argument is passed, a warning will now be raised to indicate that it is ignored and will be removed in signac 2.0.
+ - New ``SyncedCollection`` class and subclasses to replace ``JSONDict`` with more general support for different types of resources (such as MongoDB collections or Redis databases) and more complete support for different data types synchronized with files (#196, #234, #249, #316, #383, #397, #465, #484, #529, #530). This change introduces a minor-backwards incompatible change; for users making direct use of signac buffering, the ``force_write`` parameter is no longer respected. If the argument is passed, a warning will now be raised to indicate that it is ignored and will be removed in signac 2.0.
  - Unified querying for state point and document filters using 'sp' and 'doc' as prefixes (#332, #514). This change introduces a minor backwards-incompatible change to the ``Collection`` index schema ('statepoint'->'sp'), but this does not affect any APIs, only indexes saved to file using a previous version of signac. Indexing APIs will be removed in signac 2.0.
 
 Changed

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -281,10 +281,11 @@ class Job:
 
     def _initialize_lazy_properties(self):
         """Initialize all properties that are designed to be loaded lazily."""
-        self._wd = None
-        self._document = None
-        self._stores = None
-        self._cwd = []
+        with self._lock:
+            self._wd = None
+            self._document = None
+            self._stores = None
+            self._cwd = []
 
     @deprecated(
         deprecated_in="1.3",

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -281,11 +281,10 @@ class Job:
 
     def _initialize_lazy_properties(self):
         """Initialize all properties that are designed to be loaded lazily."""
-        with self._lock:
-            self._wd = None
-            self._document = None
-            self._stores = None
-            self._cwd = []
+        self._wd = None
+        self._document = None
+        self._stores = None
+        self._cwd = []
 
     @deprecated(
         deprecated_in="1.3",
@@ -395,7 +394,6 @@ class Job:
                 self._statepoint_requires_init = False
             self.statepoint.reset(new_statepoint)
 
-        # Update the project's state point cache when loaded lazily
         self._project._register(self.id, new_statepoint)
 
     def update_statepoint(self, update, overwrite=False):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -2396,6 +2396,17 @@ class Project:
         # Return the matched job id from the found project
         return project.open_job(id=job_id)
 
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        # Locks are not pickleable and must be removed from the state
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state):
+        # Locks are not pickleable and must be added back to the state
+        state["_lock"] = RLock()
+        self.__dict__.update(state)
+
 
 @contextmanager
 def TemporaryProject(name=None, cls=None, **kwargs):


### PR DESCRIPTION
## Description

While debugging #528, we identified two sets of changes that are needed for correctness.

This PR adds thread locks around Job and Project methods that lazily instantiate synced collections and HDF5 data stores.

## Motivation and Context

Fixes thread safety in Job and Project classes.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
