### PR TITLE
Add configuration for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ exemptLabels:
   - security
   - blocked
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - blocked
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
## Description

Adds configuration for the [stale bot](https://github.com/apps/stale).

I increased the default stale time from 60 days to 90 days to be a bit more conservative.
We can consider to make it more aggressive after some testing time.

Issues labeled 'pinned', 'security', or 'blocked' are ignored.

## Motivation and Context

There are many, many open issues that have become stale that clutter up the issue list and also waste the maintainers time. Using a bot will help de-clutter and make sure that issues that appear to not be as important as originally thought get closed over time.