### PR TITLE
Skip pre-checks in favor of pre-commit CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,31 +268,15 @@ workflows:
   version: 2
   test:
     jobs:
-      - pre-checks
-      - linux-python-39:
-          requires:
-            - pre-checks
-      - linux-python-39-minimal:
-          requires:
-            - pre-checks
-      - linux-python-38:
-          requires:
-            - pre-checks
-      - linux-python-37:
-          requires:
-            - pre-checks
-      - linux-python-36-oldest:
-          requires:
-            - pre-checks
-      - linux-pypy-37:
-          requires:
-            - pre-checks
-      - windows-python-38:
-          requires:
-            - pre-checks
-      - macos-python-3:
-          requires:
-            - pre-checks
+#     - pre-checks
+      - linux-python-39
+      - linux-python-39-minimal
+      - linux-python-38
+      - linux-python-37
+      - linux-python-36-oldest
+      - linux-pypy-37
+      - windows-python-38
+      - macos-python-3
       - check-metadata:
           filters:
             branches:


### PR DESCRIPTION
## Description
I recently enabled pre-commit CI. This can replace the pre-checks currently being run on CircleCI.

## Motivation and Context
Removes redundancy and potentially speeds up CI.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
