### PR TITLE
Fix incorrect docstring, resolve #506.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,11 @@ Deprecated
 
  - ``doc_filter`` arguments, which are replaced by namespaced filters. Due to their long history, ``doc_filter`` arguments will still be accepted in signac 2.0 and will only be removed in 3.0.
 
+Fixed
++++++
+
+ - Corrected docstrings for ``Job.update_statepoint`` and ``Project.update_statepoint`` (#506, #563).
+
 
 [1.6.0] -- 2020-01-24
 ---------------------

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -410,25 +410,25 @@ class Job:
 
         .. warning::
 
-            While appending to a job's state point is generally safe,
-            modifying existing parameters may lead to data
-            inconsistency. Use the overwrite argument with caution!
+            While appending to a job's state point is generally safe, modifying
+            existing parameters may lead to data inconsistency. Use the
+            ``overwrite`` argument with caution!
 
         Parameters
         ----------
         update : dict
             A mapping used for the state point update.
         overwrite : bool, optional
-            If True, this method will set all existing and new parameters
-            to a job's statepoint, making it equivalent to
-            :meth:`~.reset_statepoint`. Use with caution!
-            (Default value = False).
+            If False, an error will be raised if the update modifies the values
+            of existing keys in the state point. If True, any existing keys will
+            be overwritten in the same way as :meth:`dict.update`. Use with
+            caution! (Default value = False).
 
         Raises
         ------
         KeyError
-            If the update contains keys, which are already part of the job's
-            state point and overwrite is False.
+            If the update contains keys which are already part of the job's
+            state point and ``overwrite`` is False.
         :class:`~signac.errors.DestinationExistsError`
             If a job associated with the new state point is already initialized.
         OSError

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1545,9 +1545,9 @@ class Project:
 
         .. warning::
 
-            While appending to a job's state point is generally safe,
-            modifying existing parameters may lead to data
-            inconsistency. Use the overwrite argument with caution!
+            While appending to a job's state point is generally safe, modifying
+            existing parameters may lead to data inconsistency. Use the
+            ``overwrite`` argument with caution!
 
         Parameters
         ----------
@@ -1556,16 +1556,16 @@ class Project:
         update : mapping
             A mapping used for the state point update.
         overwrite : bool, optional
-            If True, this method will set all existing and new parameters
-            to a job's statepoint, making it equivalent to
-            :meth:`~.reset_statepoint`. Use with caution!
-            (Default value = False).
+            If False, an error will be raised if the update modifies the values
+            of existing keys in the state point. If True, any existing keys will
+            be overwritten in the same way as :meth:`dict.update`. Use with
+            caution! (Default value = False).
 
         Raises
         ------
         KeyError
-            If the update contains keys, which are already part of the job's
-            state point and overwrite is False.
+            If the update contains keys which are already part of the job's
+            state point and ``overwrite`` is False.
         :class:`~signac.errors.DestinationExistsError`
             If a job associated with the new state point is already initialized.
         OSError


### PR DESCRIPTION
## Description
See #506 for issue description. This alters a docstring whose described behavior doesn't match the implementation.

## Motivation and Context
Resolves #506.

## Types of Changes
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
