### PR TITLE
Remove deprecated job.get_id() 

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -204,7 +204,7 @@ def benchmark_project(project, keys=None):
         "select_by_id",
         Timer(
             stmt="project.open_job(id=job_id)",
-            setup=setup + "job_id = random.choice(list(islice(project, 100))).get_id()",
+            setup=setup + "job_id = random.choice(list(islice(project, 100))).id",
         ),
     )
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -94,7 +94,6 @@ The Job class
     Job.doc
     Job.document
     Job.fn
-    Job.get_id
     Job.id
     Job.init
     Job.isfile

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -12,8 +12,6 @@ from json import JSONDecodeError
 from threading import RLock
 from typing import FrozenSet
 
-from deprecation import deprecated
-
 from ..core.h5store import H5StoreManager
 from ..sync import sync_jobs
 from ..synced_collections.backends.collection_json import (
@@ -22,7 +20,6 @@ from ..synced_collections.backends.collection_json import (
     json_attr_dict_validator,
 )
 from ..synced_collections.errors import KeyTypeError
-from ..version import __version__
 from .errors import DestinationExistsError, JobsCorruptedError
 from .hashing import calc_id
 from .utility import _mkdir_p
@@ -286,23 +283,6 @@ class Job:
             self._document = None
             self._stores = None
             self._cwd = []
-
-    @deprecated(
-        deprecated_in="1.3",
-        removed_in="2.0",
-        current_version=__version__,
-        details="Use job.id instead.",
-    )
-    def get_id(self):
-        """Job's state point unique identifier.
-
-        Returns
-        -------
-        str
-            The job id.
-
-        """
-        return self._id
 
     @property
     def id(self):

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -99,13 +99,11 @@ class TestBufferedMode(TestProjectBase):
                 assert job.sp.a > 0
                 job.sp.a = -job.sp.a
                 assert job.sp.a < 0
-                with pytest.deprecated_call():
-                    job2 = self.project.open_job(id=job.get_id())
+                job2 = self.project.open_job(id=job.id)
                 assert job2.sp.a < 0
                 job.sp.a = -job.sp.a
                 assert job.sp.a > 0
-                with pytest.deprecated_call():
-                    job2 = self.project.open_job(id=job.get_id())
+                job2 = self.project.open_job(id=job.id)
                 assert job2.sp.a > 0
 
             for job in self.project:
@@ -131,8 +129,7 @@ class TestBufferedMode(TestProjectBase):
                 assert signac.get_buffer_load() > 0
                 job.doc.a = not job.doc.a
                 assert job.doc.a == (not x)
-                with pytest.deprecated_call():
-                    job2 = self.project.open_job(id=job.get_id())
+                job2 = self.project.open_job(id=job.id)
                 assert job2.doc.a == (not x)
             assert signac.get_buffer_load() == 0
             assert job.doc.a == (not x)


### PR DESCRIPTION
Part of removing deprecated code for v2.0

## Description
get_id() was the only deprecated function in job.py and was easy to pull out/ replace.


## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
