### PR TITLE
Deprecate state point backup files.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac** package follows `semantic versioning <https://semver.org/>`_.
 Version 1
 =========
 
+[1.8.0] -- 2021-xx-xx
+---------------------
+
+Deprecated
+++++++++++
+
+ - ``Project`` methods ``read_statepoints``, ``write_statepoints``, and ``dump_statepoints`` are deprecated (#579, #197).
+
 [1.7.0] -- 2021-06-08
 ---------------------
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1195,6 +1195,12 @@ class Project:
         """
         return self.find_jobs().to_dataframe(*args, **kwargs)
 
+    @deprecated(
+        deprecated_in="1.8",
+        removed_in="2.0",
+        current_version=__version__,
+        details="State point backup files are being removed in favor of Project.update_cache().",
+    )
     def read_statepoints(self, fn=None):
         """Read all state points from a file.
 
@@ -1221,6 +1227,12 @@ class Project:
         with open(fn) as file:
             return json.loads(file.read())
 
+    @deprecated(
+        deprecated_in="1.8",
+        removed_in="2.0",
+        current_version=__version__,
+        details="State point backup files are being removed in favor of Project.update_cache().",
+    )
     def dump_statepoints(self, statepoints):
         """Dump the state points and associated job ids.
 
@@ -1244,6 +1256,12 @@ class Project:
         """
         return {calc_id(sp): sp for sp in statepoints}
 
+    @deprecated(
+        deprecated_in="1.8",
+        removed_in="2.0",
+        current_version=__version__,
+        details="State point backup files are being removed in favor of Project.update_cache().",
+    )
     def write_statepoints(self, statepoints=None, fn=None, indent=2):
         """Dump state points to a file.
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -233,6 +233,8 @@ class Project:
     KEY_DATA = "signac_data"
     "The project's datastore key."
 
+    # Remove in signac 2.0.
+    # State point backup files are being removed in favor of Project.update_cache().
     FN_STATEPOINTS = "signac_statepoints.json"
     "The default filename to read from and write state points to."
 
@@ -1394,6 +1396,10 @@ class Project:
             except KeyError as error:
                 # Fall back to a file containing all state points because the state
                 # point could not be read from the job workspace.
+                #
+                # In signac 2.0, Project.read_statepoints will be removed.
+                # Update this code path to "raise error" and update the method
+                # documentation accordingly.
                 try:
                     statepoints = self.read_statepoints(fn=fn)
                     # Update the project's state point cache
@@ -1865,6 +1871,9 @@ class Project:
             )
             raise JobsCorruptedError(corrupted)
 
+    # State point backup files are being removed in favor of Project.update_cache().
+    # Change this method in signac 2.0 to use the state point cache by default
+    # instead of FN_STATEPOINTS.
     def repair(self, fn_statepoints=None, index=None, job_ids=None):
         """Attempt to repair the workspace after it got corrupted.
 
@@ -1894,6 +1903,10 @@ class Project:
         self._read_cache()
         try:
             # Updates the state point cache from the provided file
+            #
+            # In signac 2.0, Project.read_statepoints will be removed.
+            # Remove this code path (only use "self._read_cache()" above) and
+            # update the method signature and docs to remove "fn_statepoints."
             self._sp_cache.update(self.read_statepoints(fn=fn_statepoints))
         except OSError as error:
             if error.errno != errno.ENOENT or fn_statepoints is not None:


### PR DESCRIPTION
## Description

Following conversation on #197, I am creating this PR to deprecate methods for state point backup files.

https://github.com/glotzerlab/signac/issues/197#issuecomment-786925614

Once this PR is merged into `master`, we should merge `master` into `next`. Then we can tackle changes from this PR (removing `read_statepoints`, `write_statepoints`, `dump_statepoints` and some corresponding changes in behavior) in a new PR to `next`.

## Motivation and Context
Reducing the API to core features for signac 2.0 in alignment with discussion on #197.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
