### PR TITLE
Fix warning in synced collections tests with complex value.

### DIFF
--- a/tests/test_synced_collections/test_validators.py
+++ b/tests/test_synced_collections/test_validators.py
@@ -105,7 +105,7 @@ class TestJSONFormatValidator:
     @pytest.mark.skipif(not NUMPY, reason="test requires the numpy package")
     def test_numpy_invalid_data(self):
         # complex data
-        data = numpy.complex(1 + 2j)
+        data = numpy.complex128(1 + 2j)
         with pytest.raises(TypeError):
             json_format_validator(data)
         # complex data in ndarray


### PR DESCRIPTION
## Description
This is a minor fix for an issue in a test of synced collections with data types that cannot be serialized.

The current test uses `numpy.complex`, which is an alias for the built-in type `complex`. This test should instead use `numpy.complex128`, which is the scalar type that was intended for this test of unsupported NumPy types.

## Motivation and Context
Removes a warning from the output of `pytest`.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
