### PR TITLE
Clean up utility functions.

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -1665,8 +1665,7 @@ job documents."
 
     parser_update_cache = subparsers.add_parser(
         "update-cache",
-        description="""Use this command to update the project's persistent state point cache.
-This feature is still experimental and may be removed in future versions.""",
+        description="Use this command to update the project's persistent state point cache.",
     )
     parser_update_cache.set_defaults(func=main_update_cache)
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -41,7 +41,7 @@ from .hashing import calc_id
 from .indexing import _SignacProjectCrawler
 from .job import Job
 from .schema import ProjectSchema
-from .utility import _mkdir_p, _nested_dicts_to_dotted_keys, split_and_print_progress
+from .utility import _mkdir_p, _nested_dicts_to_dotted_keys, _split_and_print_progress
 
 logger = logging.getLogger(__name__)
 
@@ -1767,7 +1767,7 @@ class Project:
             def _add(_id):
                 self._sp_cache[_id] = self._get_statepoint_from_workspace(_id)
 
-            to_add_chunks = split_and_print_progress(
+            to_add_chunks = _split_and_print_progress(
                 iterable=list(to_add),
                 num_chunks=max(1, min(100, int(len(to_add) / 1000))),
                 write=logger.info,

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -6,18 +6,14 @@
 import logging
 import os
 import sys
-import tarfile
-import zipfile
 from collections.abc import Mapping
-from contextlib import contextmanager
 from datetime import timedelta
-from tempfile import TemporaryDirectory
 from time import time
 
 logger = logging.getLogger(__name__)
 
 
-def query_yes_no(question, default="yes"):
+def query_yes_no(question, default="yes"):  # pragma: no cover
     """Ask a yes/no question via input() and return their answer.
 
     "question" is a string that is presented to the user.
@@ -150,7 +146,7 @@ def _mkdir_p(path):
         os.makedirs(path, exist_ok=True)
 
 
-def split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progress: "):
+def _split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progress: "):
     """Split the progress and prints it.
 
     Parameters
@@ -199,39 +195,6 @@ def split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progress
         write(f"{desc}100%")
     else:
         yield iterable
-
-
-@contextmanager
-def _extract(filename):
-    """Extract zipfile and tarfile.
-
-    Parameters
-    ----------
-    filename : str
-        Name of zipfile/tarfile to extract.
-
-    Yields
-    ------
-    str
-        Path to the extracted directory.
-
-    Raises
-    ------
-    RuntimeError
-        When the provided file is neither a zipfile nor a tarfile.
-
-    """
-    with TemporaryDirectory() as tmpdir:
-        if zipfile.is_zipfile(filename):
-            with zipfile.ZipFile(filename) as file:
-                file.extractall(tmpdir)
-                yield tmpdir
-        elif tarfile.is_tarfile(filename):
-            with tarfile.open(filename) as file:
-                file.extractall(path=tmpdir)
-                yield tmpdir
-        else:
-            raise RuntimeError(f"Unknown file type: '{filename}'.")
 
 
 def _dotted_dict_to_nested_dicts(dotted_dict, delimiter_nested="."):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -805,8 +805,9 @@ class TestProject(TestProjectBase):
         for i in range(10):
             self.project.open_job(
                 {
-                    "const": 0,
+                    "const1": 0,
                     "const2": {"const3": 0},
+                    "const4": {},
                     "a": i,
                     "b": {"b2": i},
                     "c": [i if i % 2 else None, 0, 0],
@@ -817,8 +818,18 @@ class TestProject(TestProjectBase):
             ).init()
 
         s = self.project.detect_schema()
-        assert len(s) == 9
-        for k in "const", "const2.const3", "a", "b.b2", "c", "d", "e.e2", "f.f2":
+        assert len(s) == 10
+        for k in (
+            "const1",
+            "const2.const3",
+            "const4",
+            "a",
+            "b.b2",
+            "c",
+            "d",
+            "e.e2",
+            "f.f2",
+        ):
             assert k in s
             assert k.split(".") in s
             # The following calls should not error out.
@@ -828,9 +839,10 @@ class TestProject(TestProjectBase):
         assert s.format() == str(s)
         s = self.project.detect_schema(exclude_const=True)
         assert len(s) == 7
-        assert "const" not in s
+        assert "const1" not in s
         assert ("const2", "const3") not in s
         assert "const2.const3" not in s
+        assert "const4" not in s
         assert type not in s["e"]
 
     def test_schema_subset(self):


### PR DESCRIPTION
## Description
This PR removes unused utility functions and cleans up test coverage of the `utility.py` module.

Notes:
- The `_query_yes_no` function doesn't need test coverage (it's strictly for interactive use on the terminal).
- The `_split_and_print_progress` function can probably be simplified and replaced with tqdm, if it is needed at all. The function is used only once, to print info-level logging for updates to the in-memory state point cache. This should be investigated further, but I've made the function private for now.
- There was an important edge case of `_nested_dicts_to_dotted_keys` that wasn't being tested, when a value is an empty dict. I added a test that covers that edge case.

## Motivation and Context
Cleanup for signac 2.0.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.