### PR TITLE
Remove index arguments and state point backups

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,7 +25,6 @@ The Project
     Project.data
     Project.doc
     Project.document
-    Project.dump_statepoints
     Project.export_to
     Project.find_jobs
     Project.fn
@@ -38,7 +37,6 @@ The Project
     Project.min_len_unique_id
     Project.num_jobs
     Project.open_job
-    Project.read_statepoints
     Project.repair
     Project.root_directory
     Project.stores
@@ -46,7 +44,6 @@ The Project
     Project.update_cache
     Project.update_statepoint
     Project.workspace
-    Project.write_statepoints
 
 .. autoclass:: Project
     :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -28,7 +28,6 @@ The Project
     Project.export_to
     Project.find_jobs
     Project.fn
-    Project.get_statepoint
     Project.groupby
     Project.groupbydoc
     Project.import_from

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ omit =
 
 [tool:pytest]
 filterwarnings = 
-	ignore: .*[get_statepoint | Use of.+as key] is deprecated.*: DeprecationWarning
+	ignore: .*[Use of.+as key] is deprecated.*: DeprecationWarning
 
 [bumpversion:file:setup.py]
 

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -113,13 +113,6 @@ def _fmt_bytes(nbytes, suffix="B"):
     return "{:.1f} {}{}".format(nbytes, "Yi", suffix)
 
 
-def _read_index(project, fn_index=None):
-    if fn_index is not None:
-        _print_err(f"Reading index from file '{fn_index}'...")
-        with open(fn_index) as file_descriptor:
-            return [json.loads(line) for line in file_descriptor]
-
-
 def _open_job_by_id(project, job_id):
     """Attempt to open a job by id and provide user feedback on error."""
     try:
@@ -160,23 +153,14 @@ def find_with_filter(args):
             return args.job_id
 
     project = get_project()
-    if hasattr(args, "index"):
-        index = _read_index(project, args.index)
-    else:
-        index = None
-
     f = parse_filter_arg(args.filter)
     df = parse_filter_arg(args.doc_filter)
-    return get_project()._find_job_ids(index=index, filter=f, doc_filter=df)
+    return project._find_job_ids(filter=f, doc_filter=df)
 
 
 def main_project(args):
     """Handle project subcommand."""
     project = get_project()
-    if args.index:
-        for doc in project._index():
-            print(json.dumps(doc))
-        return
     if args.workspace:
         print(project.workspace())
     else:
@@ -350,7 +334,6 @@ def main_view(args):
         prefix=args.prefix,
         path=args.path,
         job_ids=find_with_filter(args),
-        index=_read_index(args.index),
     )
 
 
@@ -973,12 +956,6 @@ def main():
         action="store_true",
         help="Print the project's workspace path instead of the project id.",
     )
-    parser_project.add_argument(
-        "-i",
-        "--index",
-        action="store_true",
-        help="Generate and print an index for the project.",
-    )
     parser_project.set_defaults(func=main_project)
 
     parser_job = subparsers.add_parser("job")
@@ -1130,9 +1107,6 @@ def main():
         nargs="+",
         help="Show documents of job matching this document filter.",
     )
-    parser_document.add_argument(
-        "--index", type=str, help="The filename of an index file."
-    )
     parser_document.set_defaults(func=main_document)
 
     parser_remove = subparsers.add_parser("rm")
@@ -1201,9 +1175,6 @@ def main():
     )
     parser_find.add_argument(
         "-d", "--doc-filter", type=str, nargs="+", help="A document filter."
-    )
-    parser_find.add_argument(
-        "-i", "--index", type=str, help="The filename of an index file."
     )
     parser_find.add_argument(
         "-s",
@@ -1297,9 +1268,6 @@ def main():
         type=str,
         nargs="+",
         help="Limit the view to jobs with these job ids.",
-    )
-    selection_group.add_argument(
-        "-i", "--index", type=str, help="The filename of an index file."
     )
     parser_view.set_defaults(func=main_view)
 

--- a/signac/contrib/filterparse.py
+++ b/signac/contrib/filterparse.py
@@ -40,28 +40,6 @@ def _with_message(query, file):
     return query
 
 
-def _read_index(project, fn_index=None):
-    """Read index from the file passed.
-
-    Parameters
-    ----------
-    project : :class:`~signac.Project`
-        Project handle.
-    fn_index : str
-        File name of the index (Default value = None).
-
-    Returns
-    -------
-    generator
-        Returns the file contents, parsed as JSON-encoded lines.
-
-    """
-    if fn_index is not None:
-        _print_err(f"Reading index from file '{fn_index}'...")
-        fd = open(fn_index)
-        return (json.loads(line) for line in fd)
-
-
 def _is_json(q):
     """Check if q is JSON.
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -63,8 +63,7 @@ def _make_schema_based_path_function(jobs, exclude_keys=None, delimiter_nested="
         return lambda job, sep=None: ""
 
     index = [{"_id": job.id, "sp": job.sp()} for job in jobs]
-    jsi = _build_job_statepoint_index(exclude_const=True, index=index)
-    sp_index = OrderedDict(jsi)
+    sp_index = OrderedDict(_build_job_statepoint_index(exclude_const=True, index=index))
 
     paths = {}
     for key_tokens, values in sp_index.items():

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -63,10 +63,12 @@ def _make_schema_based_path_function(jobs, exclude_keys=None, delimiter_nested="
         return lambda job, sep=None: ""
 
     index = [{"_id": job.id, "sp": job.sp()} for job in jobs]
-    sp_index = OrderedDict(_build_job_statepoint_index(exclude_const=True, index=index))
+    statepoint_index = OrderedDict(
+        _build_job_statepoint_index(exclude_const=True, index=index)
+    )
 
     paths = {}
-    for key_tokens, values in sp_index.items():
+    for key_tokens, values in statepoint_index.items():
         key = key_tokens.replace(".", delimiter_nested)
         if exclude_keys and key in exclude_keys:
             continue

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -14,7 +14,7 @@ from .utility import _mkdir_p
 logger = logging.getLogger(__name__)
 
 
-def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None):
+def create_linked_view(project, prefix=None, job_ids=None, path=None):
     """Create or update a persistent linked view of the selected data space.
 
     Parameters
@@ -26,8 +26,6 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     job_ids : iterable
         If None (the default), create the view for the complete data space,
         otherwise only for this iterable of job ids.
-    index :
-        A document index (Default value = None).
     path :
         The path (function) used to structure the linked data space (Default value = None).
 
@@ -42,8 +40,6 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     OSError
         Linked views cannot be created on Windows because
         symbolic links are not supported by the platform.
-    ValueError
-        When the selected data space is provided with an insufficient index.
     RuntimeError
         When state points contain one of ``[os.sep, " ", "*"]``.
 
@@ -60,23 +56,10 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     if prefix is None:
         prefix = "view"
 
-    if index is None:
-        if job_ids is None:
-            index = [{"_id": job.id, "sp": job.sp()} for job in project]
-            jobs = list(project)
-        else:
-            index = [
-                {"_id": job_id, "sp": project.open_job(id=job_id).sp()}
-                for job_id in job_ids
-            ]
-            jobs = list(project.open_job(id=job_id) for job_id in job_ids)
-    elif job_ids is not None:
-        if not isinstance(job_ids, set):
-            job_ids = set(job_ids)
-        index = [doc for doc in index if doc["_id"] in job_ids]
+    if job_ids is None:
+        jobs = list(project)
+    else:
         jobs = list(project.open_job(id=job_id) for job_id in job_ids)
-        if not job_ids.issubset({doc["_id"] for doc in index}):
-            raise ValueError("Insufficient index for selected data space.")
 
     key_list = [k for job in jobs for k in job.statepoint().keys()]
     value_list = [v for job in jobs for v in job.statepoint().values()]
@@ -92,7 +75,7 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
     if any(bad_items):
         err_msg = " ".join(
             [
-                f"In order to use view, statepoints should not contain {bad_chars}:",
+                f"In order to use view, state points should not contain {bad_chars}:",
                 *bad_items,
             ]
         )

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -823,17 +823,16 @@ class Project:
         ValueError
             If the filters are invalid.
         RuntimeError
-            If the filters are not supported by the index.
+            If the filters are not supported.
 
         Notes
         -----
-        If all arguments are ``None``, this method skips indexing the data
-        space and instead simply iterates over all job directories. This
-        code path can be much faster for certain use cases since it defers
-        all work that would be required to construct an index, so in
-        performance-critical applications where no filtering of the data space
-        is required, passing no arguments to this method (as opposed to empty
-        dict filters) is recommended.
+        If all arguments are ``None``, this method simply returns a list of all
+        job directories. This code path can be much faster for certain use cases
+        since it defers all work that would be required to construct an index,
+        so in performance-critical applications where no filtering of the data
+        space is required, passing no arguments to this method (as opposed to
+        empty dict filters) is recommended.
 
         """
         if not filter and not doc_filter:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -817,8 +817,6 @@ class Project:
             If the filters are not JSON serializable.
         ValueError
             If the filters are invalid.
-        RuntimeError
-            If the filters are not supported.
 
         Notes
         -----

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1290,7 +1290,7 @@ class Project:
         """
         return self._get_statepoint(job_id=jobid, fn=fn)
 
-    def create_linked_view(self, prefix=None, job_ids=None, index=None, path=None):
+    def create_linked_view(self, prefix=None, job_ids=None, path=None):
         """Create or update a persistent linked view of the selected data space.
 
         Similar to :meth:`~signac.Project.export_to`, this function expands the data space
@@ -1335,8 +1335,6 @@ class Project:
         job_ids : iterable
             If None (the default), create the view for the complete data space,
             otherwise only for this iterable of job ids.
-        index :
-            A document index (Default value = None).
         path :
             The path (function) used to structure the linked data space (Default value = None).
 
@@ -1347,18 +1345,9 @@ class Project:
             directory paths.
 
         """
-        if index is not None:
-            warnings.warn(
-                (
-                    "The `index` argument is deprecated as of version 1.3 and will be "
-                    "removed in version 2.0."
-                ),
-                DeprecationWarning,
-            )
-
         from .linked_view import create_linked_view
 
-        return create_linked_view(self, prefix, job_ids, index, path)
+        return create_linked_view(self, prefix, job_ids, path)
 
     def clone(self, job, copytree=shutil.copytree):
         """Clone job into this project.

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1605,7 +1605,7 @@ class Project:
     # State point backup files are being removed in favor of Project.update_cache().
     # Change this method in signac 2.0 to use the state point cache by default
     # instead of FN_STATEPOINTS.
-    def repair(self, fn_statepoints=None, index=None, job_ids=None):
+    def repair(self, fn_statepoints=None, job_ids=None):
         """Attempt to repair the workspace after it got corrupted.
 
         This method will attempt to repair lost or corrupted job state point
@@ -1616,8 +1616,6 @@ class Project:
         fn_statepoints : str
             The filename of the file containing the state points, defaults
             to :attr:`~signac.Project.FN_STATEPOINTS`.
-        index :
-            A document index (Default value = None).
         job_ids :
             An iterable of job ids that should get repaired. Defaults to all jobs.
 
@@ -1642,9 +1640,6 @@ class Project:
         except OSError as error:
             if error.errno != errno.ENOENT or fn_statepoints is not None:
                 raise
-        if index is not None:
-            for doc in index:
-                self._sp_cache[doc["signac_id"]] = doc["sp"]
 
         corrupted = []
         for job_id in job_ids:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -853,8 +853,8 @@ class Project:
         """Find all jobs in the project's workspace.
 
         The optional filter arguments must be a Mapping of key-value pairs and
-        JSON serializable. The `filter` argument is used to search against job
-        state points, whereas the `doc_filter` argument compares against job
+        JSON serializable. The ``filter`` argument is used to search against job
+        state points, whereas the ``doc_filter`` argument compares against job
         document keys.
 
         See :ref:`signac find <signac-cli-find>` for the command line equivalent.
@@ -862,10 +862,10 @@ class Project:
         Parameters
         ----------
         filter : Mapping
-            A mapping of key-value pairs that all indexed job state points are
+            A mapping of key-value pairs that job state points are
             compared against (Default value = None).
         doc_filter : Mapping
-            A mapping of key-value pairs that all indexed job documents are
+            A mapping of key-value pairs that job documents are
             compared against (Default value = None).
 
         Returns
@@ -1720,7 +1720,7 @@ class Project:
 
         Parameters
         ----------
-        include_job_document :
+        include_job_document : bool
             Whether to include the job document in the index (Default value =
             False).
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -46,24 +46,6 @@ logger = logging.getLogger(__name__)
 
 JOB_ID_REGEX = re.compile("[a-f0-9]{32}")
 
-ACCESS_MODULE_MINIMAL = """import signac
-
-def get_indexes(root):
-    yield signac.get_project(root).index()
-"""
-
-ACCESS_MODULE_MAIN = """#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-import signac
-
-def get_indexes(root):
-    yield signac.get_project(root).index()
-
-if __name__ == '__main__':
-    with signac.Collection.open('index.txt') as index:
-        signac.export(signac.index(), index, update=True)
-"""
-
 # The warning used for doc filter deprecation everywhere. Don't use
 # triple-quoted multi-line string to avoid inserting newlines.
 # TODO: In signac 2.0, remove all docstrings for doc_filter parameters. The

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -762,7 +762,7 @@ class Project:
         """
         return self._contains_job_id(job.id)
 
-    def detect_schema(self, exclude_const=False, subset=None, index=None):
+    def detect_schema(self, exclude_const=False, subset=None):
         """Detect the project's state point schema.
 
         See :ref:`signac schema <signac-cli-schema>` for the command line equivalent.
@@ -775,8 +775,6 @@ class Project:
         subset :
             A sequence of jobs or job ids specifying a subset over which the state point
             schema should be detected (Default value = None).
-        index :
-            A document index (Default value = None).
 
         Returns
         -------
@@ -786,8 +784,7 @@ class Project:
         """
         from .schema import _build_job_statepoint_index
 
-        if index is None:
-            index = self._index(include_job_document=False)
+        index = self._index(include_job_document=False)
         if subset is not None:
             subset = {str(s) for s in subset}
             index = [doc for doc in index if doc["_id"] in subset]

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -814,34 +814,27 @@ class Project:
         )
         return ProjectSchema.detect(statepoint_index)
 
-    def _find_job_ids(self, filter=None, doc_filter=None, index=None):
+    def _find_job_ids(self, filter=None, doc_filter=None):
         """Find the job_ids of all jobs matching the filters.
 
         The optional filter arguments must be a JSON serializable mapping of
         key-value pairs.
 
-        .. note::
-            Providing a pre-calculated index may vastly increase the
-            performance of this function.
-
         Parameters
         ----------
         filter : Mapping
-            A mapping of key-value pairs that all indexed job state points
-            are compared against (Default value = None).
-        doc_filter : Mapping
-            A mapping of key-value pairs that all indexed job documents are
+            A mapping of key-value pairs that all job state points are
             compared against (Default value = None).
-        index :
-            A document index. If not provided, an index will be computed
-            (Default value = None).
+        doc_filter : Mapping
+            A mapping of key-value pairs that all job documents are compared
+            against (Default value = None).
 
         Returns
         -------
         Collection or list
-            The ids of all indexed jobs matching both filters. If no arguments
-            are provided to this method, the ids are returned as a list. If
-            any of the arguments are provided, a :class:`Collection` containing
+            The ids of all jobs matching both filters. If no arguments are
+            provided to this method, the ids are returned as a list. If any
+            of the arguments are provided, a :class:`Collection` containing
             all the ids is returned.
 
         Raises
@@ -864,18 +857,17 @@ class Project:
         dict filters) is recommended.
 
         """
-        if not filter and not doc_filter and index is None:
+        if not filter and not doc_filter:
             return list(self._job_dirs())
-        if index is None:
-            filter = dict(parse_filter(_add_prefix("sp.", filter)))
-            if doc_filter:
-                warnings.warn(DOC_FILTER_WARNING, DeprecationWarning)
-                filter.update(parse_filter(_add_prefix("doc.", doc_filter)))
-                index = self._index(include_job_document=True)
-            elif "doc" in _root_keys(filter):
-                index = self._index(include_job_document=True)
-            else:
-                index = self._sp_index()
+        filter = dict(parse_filter(_add_prefix("sp.", filter)))
+        if doc_filter:
+            warnings.warn(DOC_FILTER_WARNING, DeprecationWarning)
+            filter.update(parse_filter(_add_prefix("doc.", doc_filter)))
+            index = self._index(include_job_document=True)
+        elif "doc" in _root_keys(filter):
+            index = self._index(include_job_document=True)
+        else:
+            index = self._sp_index()
         return Collection(index, _trust=True)._find(filter)
 
     def find_jobs(self, filter=None, doc_filter=None):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1608,7 +1608,7 @@ class Project:
         """Attempt to repair the workspace after it got corrupted.
 
         This method will attempt to repair lost or corrupted job state point
-        manifest files using a state points file or a document index or both.
+        manifest files using a state points file.
 
         Parameters
         ----------

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -820,12 +820,12 @@ class Project:
 
         Notes
         -----
-        If all arguments are ``None``, this method simply returns a list of all
-        job directories. This code path can be much faster for certain use cases
-        since it defers all work that would be required to construct an index,
-        so in performance-critical applications where no filtering of the data
-        space is required, passing no arguments to this method (as opposed to
-        empty dict filters) is recommended.
+        If all filter arguments are empty or ``None``, this method simply
+        returns a list of all job directories. This code path can be much faster
+        for certain use cases since it defers all work that would be required to
+        construct an index. In performance-critical applications where no
+        filtering of the data space is required, passing empty filters (or
+        ``None``) to this method is recommended.
 
         """
         if not filter and not doc_filter:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1049,7 +1049,7 @@ class Project:
                 raise JobsCorruptedError([job_id])
             raise KeyError(job_id)
 
-    def _get_statepoint(self, job_id, fn=None):
+    def _get_statepoint(self, job_id):
         """Get the state point associated with a job id.
 
         The state point is retrieved from the internal cache, from
@@ -1059,9 +1059,6 @@ class Project:
         ----------
         job_id : str
             A job id to get the state point for.
-        fn : str
-            The filename of the file containing the state points, defaults
-            to :attr:`~signac.Project.FN_STATEPOINTS`.
 
         Returns
         -------
@@ -1100,42 +1097,6 @@ class Project:
             # Update the project's state point cache from this cache miss
             self._sp_cache[job_id] = statepoint
         return statepoint
-
-    @deprecated(
-        deprecated_in="1.3",
-        removed_in="2.0",
-        current_version=__version__,
-        details="Use open_job(id=jobid).statepoint() function instead.",
-    )
-    def get_statepoint(self, jobid, fn=None):
-        """Get the state point associated with a job id.
-
-        The state point is retrieved from the internal cache, from
-        the workspace or from a state points file.
-
-        Parameters
-        ----------
-        jobid : str
-            A job id to get the state point for.
-        fn : str
-            The filename of the file containing the state points, defaults
-            to :attr:`~signac.Project.FN_STATEPOINTS`.
-
-        Returns
-        -------
-        dict
-            The state point corresponding to jobid.
-
-        Raises
-        ------
-        KeyError
-            If the state point associated with jobid could not be found.
-        :class:`signac.errors.JobsCorruptedError`
-            If the state point manifest file corresponding to jobid is
-            inaccessible or corrupted.
-
-        """
-        return self._get_statepoint(job_id=jobid, fn=fn)
 
     def create_linked_view(self, prefix=None, job_ids=None, path=None):
         """Create or update a persistent linked view of the selected data space.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1692,12 +1692,6 @@ class TestLinkedViewProject(TestProjectBase):
         job_subset = self.project.find_jobs({"b": 0})
         id_subset = [job.id for job in job_subset]
 
-        bad_index = [dict(_id=i) for i in range(3)]
-        with pytest.raises(ValueError):
-            self.project.create_linked_view(
-                prefix=view_prefix, job_ids=id_subset, index=bad_index
-            )
-
         self.project.create_linked_view(prefix=view_prefix, job_ids=id_subset)
         all_links = list(_find_all_links(view_prefix))
         assert len(all_links) == len(id_subset)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -596,18 +596,20 @@ class TestProject(TestProjectBase):
             # Iterating through the jobs should now result in an error.
             with pytest.raises(JobsCorruptedError):
                 for job in self.project:
-                    # Accessing the job state point triggers validation of the
-                    # state point manifest file
-                    job.statepoint()
+                    # Validate the state point.
+                    sp = job.statepoint()
+                    assert len(sp) == 1
+                    assert sp["a"] in range(5)
 
             self.project.repair()
 
             self.project._sp_cache.clear()
             self.project._remove_persistent_cache_file()
             for job in self.project:
-                # Accessing the job state point triggers validation of the
-                # state point manifest file
-                job.statepoint()
+                # Validate the state point.
+                sp = job.statepoint()
+                assert len(sp) == 1
+                assert sp["a"] in range(5)
         finally:
             logging.disable(logging.NOTSET)
 


### PR DESCRIPTION
## Description
Additional cleanup related to #588. This PR removes `index` arguments from a number of methods of `Project` and the CLI.

I also removed the public methods `read_statepoints`, `write_statepoints`, and `dump_statepoints` from the public API (see #579).

Finally, I removed the deprecated function `get_statepoint` from the public API because it used `FN_STATEPOINTS` which was removed as a part of the previously mentioned `read/write/dump_statepoints` changes. I would have split this into two pull requests but there would have been a couple annoying merge conflicts. Since this is a pure removal, I thought it would be fine to combine the two sets of changes to avoid having to deal with the conflicts.

Deprecations for the `index` argument will need to be added to signac 1.x.

## Motivation and Context
signac 2.0 API cleanup. There is no longer a public method for generating an index, so it no longer makes sense to allow users to supply one as an argument.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
