### PR TITLE
Deprecate JobSearchIndex class.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@ Deprecated
 
  - ``Project`` methods ``read_statepoints``, ``write_statepoints``, and ``dump_statepoints`` are deprecated (#579, #197).
  - ``Project.index`` method is deprecated (#591, #588).
- - ``JobSearchIndex`` class is deprecated.
+ - ``JobSearchIndex`` class is deprecated (#600).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Deprecated
 
  - ``Project`` methods ``read_statepoints``, ``write_statepoints``, and ``dump_statepoints`` are deprecated (#579, #197).
  - ``Project.index`` method is deprecated (#591, #588).
+ - ``JobSearchIndex`` class is deprecated.
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -97,6 +97,12 @@ class JobSearchIndex:
 
     """
 
+    @deprecated(
+        deprecated_in="1.8",
+        removed_in="2.0",
+        current_version=__version__,
+        details="The JobSearchIndex class is deprecated.",
+    )
     def __init__(self, index, _trust=False):
         self._collection = Collection(index, _trust=_trust)
 


### PR DESCRIPTION
## Description
Deprecates `JobSearchIndex` class. This class is unused. See #587. I will merge once tests pass.

## Motivation and Context
signac 2.0 API cleanup.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
