### PR TITLE
Fix deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,6 @@ source = signac
 omit = 
 	*/signac/common/configobj/*.py
 
-[tool:pytest]
-filterwarnings = 
-	ignore: .*[Use of.+as key] is deprecated.*: DeprecationWarning
-
 [bumpversion:file:setup.py]
 
 [bumpversion:file:signac/version.py]

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -52,7 +52,7 @@ JOB_ID_REGEX = re.compile("[a-f0-9]{32}")
 # doc_filter parameters will only be preserved for backwards compatibility but
 # not advertised as part of the API in signac 2.0.
 DOC_FILTER_WARNING = (
-    "The doc_filter argument is deprecated in version 1.7 and will be removed "
+    "The doc_filter argument is deprecated as of version 1.7 and will be removed "
     "in version 3.0. Users should instead use a filter with a 'doc.' prefix. For "
     "example, `doc_filter={'foo': 'bar'}` is equivalent to `filter={'doc.foo': 'bar'}`. "
     "See https://docs.signac.io/en/latest/query.html#query-namespaces for more "

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -52,7 +52,7 @@ JOB_ID_REGEX = re.compile("[a-f0-9]{32}")
 # doc_filter parameters will only be preserved for backwards compatibility but
 # not advertised as part of the API in signac 2.0.
 DOC_FILTER_WARNING = (
-    "The doc_filter argument was deprecated in version 1.7 and will be removed "
+    "The doc_filter argument is deprecated in version 1.7 and will be removed "
     "in version 3.0. Users should instead use a filter with a 'doc.' prefix. For "
     "example, `doc_filter={'foo': 'bar'}` is equivalent to `filter={'doc.foo': 'bar'}`. "
     "See https://docs.signac.io/en/latest/query.html#query-namespaces for more "

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -8,7 +8,6 @@ import logging
 import os
 import random
 import uuid
-import warnings
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -77,8 +76,6 @@ class TestJobBase:
         self.project = self.project_class.init_project(
             name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
         )
-
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="signac")
 
     def tearDown(self):
         pass
@@ -435,6 +432,9 @@ class TestJobSpInterface(TestJobBase):
             assert job.sp == job2.sp
             assert job.id == job2.id
 
+    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_valid_sp_key_types(self):
         job = self.open_job(dict(invalid_key=True)).init()
 
@@ -465,6 +465,9 @@ class TestJobSpInterface(TestJobBase):
             with pytest.raises(TypeError):
                 job.sp = {key: "test"}
 
+    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_valid_doc_key_types(self):
         job = self.open_job(dict(invalid_key=True)).init()
 
@@ -494,6 +497,10 @@ class TestJobSpInterface(TestJobBase):
 
 
 class TestConfig(TestJobBase):
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_set_get_delete(self):
         key, value = list(test_token.items())[0]
         key, value = "author_name", list(test_token.values())[0]
@@ -504,6 +511,10 @@ class TestConfig(TestJobBase):
         del config[key]
         assert key not in config
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_update(self):
         key, value = "author_name", list(test_token.values())[0]
         config = copy.deepcopy(self.project.config)
@@ -511,6 +522,10 @@ class TestConfig(TestJobBase):
         assert config[key] == value
         assert key in config
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_set_and_retrieve_version(self):
         fake_version = 0, 0, 0
         self.project.config["signac_version"] = fake_version

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -219,6 +219,9 @@ class TestJSONDict(TestJSONDictBase):
         with pytest.raises(InvalidKeyError):
             jsd["a.b"] = None
 
+    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
+    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_keys_valid_type(self):
         jsd = self.get_json_dict()
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -307,6 +307,7 @@ class TestProject(TestProjectBase):
         for job in self.project.find_jobs():
             assert self.project.open_job(id=job.id).id == job.id
 
+    @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find_jobs_JobsCursor_contains(self):
         statepoints = [{"a": i} for i in range(5)]
         for sp in statepoints:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -11,7 +11,6 @@ import re
 import string
 import sys
 import uuid
-import warnings
 from contextlib import contextmanager, redirect_stderr
 from tarfile import TarFile
 from tempfile import TemporaryDirectory
@@ -106,6 +105,10 @@ class TestProject(TestProjectBase):
     def test_workspace_directory(self):
         assert self._tmp_wd == self.project.workspace()
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_config_modification(self):
         # In-memory modification of the project configuration is
         # deprecated as of 1.3, and will be removed in version 2.0.
@@ -113,6 +116,10 @@ class TestProject(TestProjectBase):
         # and check that the project configuration is immutable.
         self.project.config["foo"] = "bar"
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_workspace_directory_with_env_variable(self):
         os.environ["SIGNAC_ENV_DIR_TEST"] = self._tmp_wd
         self.project.config["workspace_dir"] = "${SIGNAC_ENV_DIR_TEST}"
@@ -206,6 +213,10 @@ class TestProject(TestProjectBase):
         self.project.data = {"a": {"b": 45}}
         assert self.project.data == {"a": {"b": 45}}
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_workspace_path_normalization(self):
         def norm_path(p):
             return os.path.abspath(os.path.expandvars(p))
@@ -238,6 +249,10 @@ class TestProject(TestProjectBase):
             assert len(caplog.records) in (2, 3)
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_workspace_broken_link_error_on_find(self):
         wd = self.project.workspace()
         os.symlink(wd + "~", self.project.fn("workspace-link"))
@@ -268,6 +283,7 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(self._tmp_wd)
         assert not os.path.isdir(self.project.workspace())
 
+    @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find_jobs(self):
         statepoints = [{"a": i} for i in range(5)]
         for sp in statepoints:
@@ -308,6 +324,9 @@ class TestProject(TestProjectBase):
         for sp in statepoints:
             assert self.project.open_job(sp) in cursor_doc
 
+    @pytest.mark.filterwarnings(
+        r"ignore:Calling next\(\) directly on a JobsCursor is deprecated!"
+    )
     def test_find_jobs_next(self):
         statepoints = [{"a": i} for i in range(5)]
         for sp in statepoints:
@@ -961,6 +980,7 @@ class TestProject(TestProjectBase):
                 assert job.sp["b"] == k[0]
                 assert job.sp["c"] == k[1]
 
+    @pytest.mark.filterwarnings("ignore:groupbydoc is deprecated")
     def test_jobs_groupbydoc(self):
         def get_doc(i):
             return {"a": i, "b": i % 2, "c": i % 3}
@@ -2372,6 +2392,10 @@ class TestProjectSchema(TestProjectBase):
                 name=str(self.project), root=self.project.root_directory()
             )
 
+    @pytest.mark.filterwarnings(
+        "ignore:Modifying the project configuration after project initialization "
+        "is deprecated"
+    )
     def test_project_schema_version_migration(self):
         from signac.contrib.migration import apply_migrations
 
@@ -2455,7 +2479,6 @@ class TestProjectStoreBase(test_h5store.TestH5StoreBase):
             name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
         )
 
-        warnings.filterwarnings("ignore", category=DeprecationWarning, module="signac")
         self._fn_store = os.path.join(self._tmp_dir.name, "signac_data.h5")
         self._fn_store_other = os.path.join(self._tmp_dir.name, "other.h5")
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -202,6 +202,7 @@ class TestBasicShell:
                 "view/a/{}/job".format(sp["a"])
             ) == os.path.realpath(project.open_job(sp).workspace())
 
+    @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find(self):
         self.call("python -m signac init my_project".split())
         project = signac.Project()


### PR DESCRIPTION
## Description
I fixed the handling of warnings in signac's tests. Warnings were being globally ignored, which wasn't intended (the warning filters were declared in specific tests but were being applied globally by pytest during test collection). I fixed that by removing the global warning filters and replacing them with warning filters applied to each test. I made sure to include enough of the warning text so that the word "deprecated" was included, to make it easier to find and remove those filters when appropriate.

I separated these changes from PR #586.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
