### PR TITLE
Remove JobsCursor.next.

### DIFF
--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1947,25 +1947,6 @@ class JobsCursor:
             self._project, self._project._find_job_ids(self._filter)
         )
 
-    def next(self):
-        """Return the next element.
-
-        This function is deprecated. Users should use ``next(iter(..))`` instead.
-        .. deprecated:: 0.9.6
-
-        """
-        warnings.warn(
-            "Calling next() directly on a JobsCursor is deprecated! Use next(iter(..)) instead.",
-            DeprecationWarning,
-        )
-        if self._next_iter is None:
-            self._next_iter = iter(self)
-        try:
-            return next(self._next_iter)
-        except StopIteration:
-            self._next_iter = None
-            raise
-
     def groupby(self, key=None, default=None):
         """Group jobs according to one or more state point parameters.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -325,24 +325,6 @@ class TestProject(TestProjectBase):
         for sp in statepoints:
             assert self.project.open_job(sp) in cursor_doc
 
-    @pytest.mark.filterwarnings(
-        r"ignore:Calling next\(\) directly on a JobsCursor is deprecated!"
-    )
-    def test_find_jobs_next(self):
-        statepoints = [{"a": i} for i in range(5)]
-        for sp in statepoints:
-            self.project.open_job(sp).init()
-        jobs = self.project.find_jobs()
-        for i in range(2):  # run this twice
-            jobs_ = set()
-            for i in range(len(self.project)):
-                job = jobs.next()
-                assert job in self.project
-                jobs_.add(job)
-            with pytest.raises(StopIteration):
-                job = jobs.next()
-            assert jobs_ == set(self.project)
-
     def test_find_jobs_arithmetic_operators(self):
         for i in range(10):
             self.project.open_job(dict(a=i)).init()


### PR DESCRIPTION
## Description
Removes the long-deprecated `JobsCursor.next` method (deprecated since before 1.0).

## Motivation and Context
signac 2.0 API cleanup.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.