### PR TITLE
Define job id length as a constant instead of a repeated magic number.

### DIFF
--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -55,8 +55,8 @@ _TYPES = {
     "null": type(None),
 }
 
-
-MAX_DEFAULT_ID = int("F" * 32, 16)
+MAX_DEFAULT_ID_LENGTH = 32
+MAX_DEFAULT_ID = int("F" * MAX_DEFAULT_ID_LENGTH, 16)
 
 
 class _DictPlaceholder:
@@ -464,7 +464,7 @@ class Collection:
             self._next_default_id_ = len(self)
         for i in range(len(self) + 1):
             assert self._next_default_id_ < MAX_DEFAULT_ID
-            _id = str(hex(self._next_default_id_))[2:].rjust(32, "0")
+            _id = str(hex(self._next_default_id_))[2:].rjust(MAX_DEFAULT_ID_LENGTH, "0")
             self._next_default_id_ += 1
             if _id not in self:
                 return _id

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -43,7 +43,8 @@ from .utility import _mkdir_p, _nested_dicts_to_dotted_keys, _split_and_print_pr
 
 logger = logging.getLogger(__name__)
 
-JOB_ID_REGEX = re.compile("[a-f0-9]{32}")
+JOB_ID_LENGTH = 32
+JOB_ID_REGEX = re.compile(f"[a-f0-9]{{{JOB_ID_LENGTH}}}")
 
 # The warning used for doc filter deprecation everywhere. Don't use
 # triple-quoted multi-line string to avoid inserting newlines.
@@ -336,7 +337,7 @@ class Project:
         """
         job_ids = list(self._find_job_ids())
         tmp = set()
-        for i in range(32):
+        for i in range(JOB_ID_LENGTH):
             tmp.clear()
             for _id in job_ids:
                 if _id[:i] in tmp:
@@ -567,7 +568,7 @@ class Project:
             # Worst case: no state point was provided and the state point cache
             # missed. The Job will register itself in self._sp_cache when the
             # state point is accessed.
-            if len(id) < 32:
+            if len(id) < JOB_ID_LENGTH:
                 # Resolve partial job ids (first few characters) into a full job id
                 job_ids = self._find_job_ids()
                 matches = [_id for _id in job_ids if _id.startswith(id)]


### PR DESCRIPTION
## Description
This PR defines the default job id length (32) as a constant instead of a repeated magic number.

## Motivation and Context
Reduces magic numbers in the code.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.