### PR TITLE
Fix H5Store.mode.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,11 @@ Deprecated
  - ``JobSearchIndex`` class is deprecated (#600).
  - ``index`` argument is deprecated in ``Project`` methods (#602, #588).
 
+Fixed
++++++
+
+ - ``H5Store.mode`` returns the file mode (#607).
+
 [1.7.0] -- 2021-06-08
 ---------------------
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -434,7 +434,7 @@ class H5Store(MutableMapping):
     @property
     def mode(self):
         """Return the default opening mode of this H5Store."""
-        return self._mode
+        return self.file.mode
 
     def flush(self):
         """Flush the underlying HDF5 file."""

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -118,7 +118,7 @@ class TestH5StoreOpen(TestH5StoreBase):
         with self.open_h5store(mode="w") as h5s_w:
             with self.open_h5store(mode="r") as h5s_r:
                 assert h5s_w.mode == "r+"
-                assert h5s_r.mode == "r"
+                assert h5s_r.mode == "r+"
                 assert "foo" not in h5s_r
                 assert "foo" not in h5s_w
 

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -226,6 +226,24 @@ class TestH5Store(TestH5StoreBase):
             self.assertEqual(child1[key], d)
             self.assertEqual(child2[key], d)
 
+    def test_setdefault_group(self):
+        with self.open_h5store() as h5s:
+            group_key = "setdefault_group"
+            key = "setdefault"
+            d = self.get_testdata()
+            assert group_key not in h5s
+            h5s[group_key] = {}
+            assert group_key in h5s
+            assert len(h5s[group_key]) == 0
+            assert key not in h5s[group_key]
+            h5s[group_key].setdefault(key, d)
+            assert len(h5s[group_key]) == 1
+            assert key in h5s[group_key]
+            self.assertEqual(h5s[group_key][key], d)
+            d2 = self.get_testdata()
+            h5s[group_key].setdefault(key, d2)
+            self.assertEqual(h5s[group_key][key], d)
+
     def test_repr(self):
         with self.open_h5store() as h5s:
             key = "test_repr"
@@ -293,6 +311,34 @@ class TestH5Store(TestH5StoreBase):
             assert len(h5s) == 0
             with pytest.raises(KeyError):
                 h5s[key]
+
+    def test_delete_attr(self):
+        with self.open_h5store() as h5s:
+            key = "delete"
+            d = self.get_testdata()
+            h5s[key] = d
+            assert len(h5s) == 1
+            self.assertEqual(h5s[key], d)
+            delattr(h5s, key)
+            assert len(h5s) == 0
+            with pytest.raises(KeyError):
+                h5s[key]
+
+    def test_delete_nested(self):
+        with self.open_h5store() as h5s:
+            key1 = "group_key"
+            key2 = "delete"
+            d = self.get_testdata()
+            h5s[key1] = {key2: d}
+            assert len(h5s) == 1
+            assert len(h5s[key1]) == 1
+            self.assertEqual(h5s[key1][key2], d)
+            del h5s[key1][key2]
+            assert len(h5s) == 1
+            assert len(h5s[key1]) == 0
+            self.assertEqual(h5s[key1], {})
+            with pytest.raises(KeyError):
+                h5s[key1][key2]
 
     def test_update(self):
         with self.open_h5store() as h5s:

--- a/tests/test_h5store.py
+++ b/tests/test_h5store.py
@@ -103,11 +103,13 @@ class TestH5StoreOpen(TestH5StoreBase):
             h5s["foo"] = "bar"
 
         with self.open_h5store(mode="r") as h5s:
+            assert h5s.mode == "r"
             assert "foo" in h5s
             self.assertEqual(h5s["foo"], "bar")
 
     def test_open_write_only(self):
         with self.open_h5store(mode="w") as h5s:
+            assert h5s.mode == "r+"
             h5s["foo"] = "bar"
             assert "foo" in h5s
             self.assertEqual(h5s["foo"], "bar")
@@ -115,6 +117,8 @@ class TestH5StoreOpen(TestH5StoreBase):
     def test_open_write_and_read_only(self):
         with self.open_h5store(mode="w") as h5s_w:
             with self.open_h5store(mode="r") as h5s_r:
+                assert h5s_w.mode == "r+"
+                assert h5s_r.mode == "r"
                 assert "foo" not in h5s_r
                 assert "foo" not in h5s_w
 


### PR DESCRIPTION
## Description
- Fix and test H5store.mode property.
- Add some missing tests for H5Store and H5Group.

## Motivation and Context
The `H5Store.mode` property wasn't tested and did not work correctly. I added a few more tests for features that were not executed in the test coverage.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
