### PR TITLE
Disallow Project.config mutation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,17 @@ Changelog
 
 The **signac** package follows `semantic versioning <https://semver.org/>`_.
 
+Version 2
+=========
+
+[2.0.0] -- 2021-xx-xx
+---------------------
+
+Removed
++++++++
+
+ - ``Project.config`` is no longer mutable. Use the command line ``$ signac config`` to modify configuration (#608, #246, #244).
+
 Version 1
 =========
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -327,16 +327,18 @@ class Job:
 
         """
         if self._wd is None:
-            # We can rely on the project workspace to be well-formed, so just
-            # use str.join with os.sep instead of os.path.join for speed.
+            # Performance-critical path. We can rely on the project workspace
+            # and job id to be well-formed, so just use str.join with os.sep
+            # instead of os.path.join for speed.
             self._wd = os.sep.join((self._project.workspace(), self.id))
         return self._wd
 
     @property
     def _statepoint_filename(self):
         """Get the path of the state point file for this job."""
-        # We can rely on the job workspace to be well-formed, so just
-        # use str.join with os.sep instead of os.path.join for speed.
+        # Performance-critical path. We can rely on the job workspace and state
+        # point file name to be well-formed, so just use str.join with os.sep
+        # instead of os.path.join for speed.
         return os.sep.join((self.workspace(), self.FN_MANIFEST))
 
     @property

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -207,6 +207,12 @@ class Project:
     def config(self):
         """Get project's configuration.
 
+        The configuration is immutable once the Project is constructed. To
+        modify a project configuration, use the command line or edit the
+        configuration file directly.
+
+        See :ref:`signac config <signac-cli-config>` for related command line tools.
+
         Returns
         -------
         :class:`~signac.contrib.project._ProjectConfig`

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -130,6 +130,7 @@ class Project:
             )
 
         # Prepare root directory and workspace paths.
+        # os.path is used instead of pathlib.Path for performance.
         self._root_directory = self.config["project_dir"]
         self._workspace = os.path.expandvars(
             self.config.get("workspace_dir", "workspace")
@@ -625,8 +626,9 @@ class Project:
             True if the job id is initialized for this project.
 
         """
-        # We can rely on the project workspace to be well-formed, so just use
-        # str.join with os.sep instead of os.path.join for speed.
+        # Performance-critical path. We can rely on the project workspace and
+        # job id to be well-formed, so just use str.join with os.sep instead of
+        # os.path.join for speed.
         return os.path.exists(os.sep.join((self.workspace(), job_id)))
 
     def __contains__(self, job):
@@ -871,8 +873,9 @@ class Project:
             Identifier of the job.
 
         """
-        # We can rely on the project workspace to be well-formed, so just use
-        # str.join with os.sep instead of os.path.join for speed.
+        # Performance-critical path. We can rely on the project workspace, job
+        # id, and state point file name to be well-formed, so just use str.join
+        # with os.sep instead of os.path.join for speed.
         fn_manifest = os.sep.join((self.workspace(), job_id, self.Job.FN_MANIFEST))
         try:
             with open(fn_manifest, "rb") as manifest:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -236,9 +236,8 @@ class Project:
         """Return the project's workspace directory.
 
         The workspace defaults to `project_root/workspace`. Configure this
-        directory with the ``'workspace_dir'`` configuration option. If the
-        specified directory is a relative path, the absolute path is relative
-        from the project's root directory.
+        directory with the ``'workspace_dir'`` configuration option. A relative
+        path is assumed to be relative to the project's root directory.
 
         .. note::
             The configuration will respect environment variables,

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1053,7 +1053,7 @@ class Project:
             if error.errno == errno.EEXIST:
                 raise DestinationExistsError(dst)
             elif error.errno == errno.ENOENT:
-                raise ValueError("Source job not initalized.")
+                raise ValueError("Source job not initialized.")
             else:
                 raise
         return dst

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -81,14 +81,7 @@ class _ProjectConfig(Config):
 
     def __setitem__(self, key, value):
         if not self._mutable:
-            warnings.warn(
-                "Modifying the project configuration after project "
-                "initialization is deprecated as of version 1.3 and "
-                "will be removed in version 2.0.",
-                DeprecationWarning,
-            )
-
-            assert version.parse(__version__) < version.parse("2.0")
+            raise ValueError("The project configuration is immutable.")
         if self._mutate_hook is not None:
             self._mutate_hook()
         return super().__setitem__(key, value)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -497,41 +497,7 @@ class TestJobSpInterface(TestJobBase):
 
 
 class TestConfig(TestJobBase):
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
-    def test_set_get_delete(self):
-        key, value = list(test_token.items())[0]
-        key, value = "author_name", list(test_token.values())[0]
-        config = copy.deepcopy(self.project.config)
-        config[key] = value
-        assert config[key] == value
-        assert key in config
-        del config[key]
-        assert key not in config
-
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
-    def test_update(self):
-        key, value = "author_name", list(test_token.values())[0]
-        config = copy.deepcopy(self.project.config)
-        config.update({key: value})
-        assert config[key] == value
-        assert key in config
-
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
-    def test_set_and_retrieve_version(self):
-        fake_version = 0, 0, 0
-        self.project.config["signac_version"] = fake_version
-        assert self.project.config["signac_version"] == fake_version
-
-    def test_str(self):
+    def test_config_str(self):
         str(self.project.config)
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -571,7 +571,7 @@ class TestProject(TestProjectBase):
             os.replace(wd, wd_invalid)
             with pytest.raises(JobsCorruptedError):
                 self.project.check()
-            #  ... we reinitalize the initial job, ...
+            #  ... we reinitialize the initial job, ...
             job.init()
             with pytest.raises(JobsCorruptedError):
                 # ... which means the repair attempt must fail.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -105,25 +105,27 @@ class TestProject(TestProjectBase):
     def test_workspace_directory(self):
         assert self._tmp_wd == self.project.workspace()
 
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
     def test_config_modification(self):
         # In-memory modification of the project configuration is
         # deprecated as of 1.3, and will be removed in version 2.0.
         # This unit test should reflect that change beginning 2.0,
         # and check that the project configuration is immutable.
-        self.project.config["foo"] = "bar"
+        with pytest.raises(ValueError):
+            self.project.config["foo"] = "bar"
 
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
     def test_workspace_directory_with_env_variable(self):
-        os.environ["SIGNAC_ENV_DIR_TEST"] = self._tmp_wd
-        self.project.config["workspace_dir"] = "${SIGNAC_ENV_DIR_TEST}"
-        assert self._tmp_wd == self.project.workspace()
+        try:
+            with TemporaryDirectory() as tmp_dir:
+                os.environ["SIGNAC_ENV_DIR_TEST"] = os.path.join(tmp_dir, "work_here")
+                project = self.project_class.init_project(
+                    name="testing_test_project",
+                    root=tmp_dir,
+                    workspace="${SIGNAC_ENV_DIR_TEST}",
+                )
+                assert project.workspace() == os.environ["SIGNAC_ENV_DIR_TEST"]
+        finally:
+            if "SIGNAC_ENV_DIR_TEST" in os.environ:
+                del os.environ["SIGNAC_ENV_DIR_TEST"]
 
     def test_workspace_directory_exists(self):
         assert os.path.exists(self.project.workspace())
@@ -213,29 +215,27 @@ class TestProject(TestProjectBase):
         self.project.data = {"a": {"b": 45}}
         assert self.project.data == {"a": {"b": 45}}
 
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
     def test_workspace_path_normalization(self):
         def norm_path(p):
             return os.path.abspath(os.path.expandvars(p))
 
-        def root_path():
-            # Returns 'C:\\' on Windows, '/' on other platforms
-            return os.path.abspath(os.sep)
-
         assert self.project.workspace() == norm_path(self._tmp_wd)
 
-        abs_path = os.path.join(root_path(), "path", "to", "workspace")
-        self.project.config["workspace_dir"] = abs_path
-        assert self.project.workspace() == norm_path(abs_path)
+        with TemporaryDirectory() as tmp_dir:
+            abs_path = os.path.join(tmp_dir, "path", "to", "workspace")
+            project = self.project_class.init_project(
+                name="testing_test_project", root=tmp_dir, workspace=abs_path
+            )
+            assert project.workspace() == norm_path(abs_path)
 
-        rel_path = norm_path(os.path.join("path", "to", "workspace"))
-        self.project.config["workspace_dir"] = rel_path
-        assert self.project.workspace() == norm_path(
-            os.path.join(self.project.root_directory(), self.project.workspace())
-        )
+        with TemporaryDirectory() as tmp_dir:
+            rel_path = norm_path(os.path.join("path", "to", "workspace"))
+            project = self.project_class.init_project(
+                name="testing_test_project", root=tmp_dir, workspace=rel_path
+            )
+            assert project.workspace() == norm_path(
+                os.path.join(project.root_directory(), rel_path)
+            )
 
     def test_no_workspace_warn_on_find(self, caplog):
         if os.path.exists(self.project.workspace()):
@@ -249,16 +249,18 @@ class TestProject(TestProjectBase):
             assert len(caplog.records) in (2, 3)
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
-    )
     def test_workspace_broken_link_error_on_find(self):
-        wd = self.project.workspace()
-        os.symlink(wd + "~", self.project.fn("workspace-link"))
-        self.project.config["workspace_dir"] = "workspace-link"
-        with pytest.raises(WorkspaceError):
-            list(self.project.find_jobs())
+        with TemporaryDirectory() as tmp_dir:
+            project = self.project_class.init_project(
+                name="testing_test_project", root=tmp_dir, workspace="workspace-link"
+            )
+            os.rmdir(os.path.join(tmp_dir, "workspace-link"))
+            os.symlink(
+                os.path.join(tmp_dir, "workspace~"),
+                os.path.join(tmp_dir, "workspace-link"),
+            )
+            with pytest.raises(WorkspaceError):
+                list(project.find_jobs())
 
     def test_workspace_read_only_path(self):
         # Create file where workspace would be, thus preventing the creation
@@ -2373,9 +2375,8 @@ class TestProjectSchema(TestProjectBase):
                 name=str(self.project), root=self.project.root_directory()
             )
 
-    @pytest.mark.filterwarnings(
-        "ignore:Modifying the project configuration after project initialization "
-        "is deprecated"
+    @pytest.mark.xfail(
+        reason="Modifying the project configuration is not supported in signac 2.0."
     )
     def test_project_schema_version_migration(self):
         from signac.contrib.migration import apply_migrations

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2187,6 +2187,12 @@ class TestProjectInit:
         assert project.workspace() == os.path.join(root, "workspace")
         assert project.root_directory() == root
 
+    def test_project_no_id(self):
+        config = load_config(self.project.root_directory())
+        del config["project"]
+        with pytest.raises(LookupError):
+            self.project = self.project_class(config=config)
+
     def test_get_project_all_printable_characters(self):
         root = self._tmp_dir.name
         with pytest.raises(LookupError):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2188,10 +2188,12 @@ class TestProjectInit:
         assert project.root_directory() == root
 
     def test_project_no_id(self):
-        config = load_config(self.project.root_directory())
+        root = self._tmp_dir.name
+        signac.init_project(name="testproject", root=root)
+        config = load_config(root)
         del config["project"]
         with pytest.raises(LookupError):
-            self.project = self.project_class(config=config)
+            Project(config=config)
 
     def test_get_project_all_printable_characters(self):
         root = self._tmp_dir.name


### PR DESCRIPTION
## Description
This PR makes the `Project.config` immutable. Follows up on #246 with the planned changes for signac 2.0.

To-do:
- [x] Update tests to pass and ensure that the configuration is immutable.
- [x] Identify and apply optimizations that are now possible with the immutable configuration. There are some changes to make with caching the workspace / project root directories.
- [x] Revise the docs for the `Project.config` attribute.

## Motivation and Context
See #244 for a discussion where the decision was made to have an immutable Project configuration.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.