### PR TITLE
Update buffer capacity methods for consistency with synced collections

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,4 +3,5 @@ IPython
 jupyter_client
 nbconvert
 nbsphinx>=0.3
+sphinx>=4
 sphinxcontrib-programoutput

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,5 +3,5 @@ IPython
 jupyter_client
 nbconvert
 nbsphinx>=0.3
-sphinx>=4
+sphinx>=3
 sphinxcontrib-programoutput

--- a/signac/__init__.py
+++ b/signac/__init__.py
@@ -28,9 +28,9 @@ from .version import __version__
 # Alias some properties related to buffering into the signac namespace.
 buffered = JSONDict.buffer_backend
 is_buffered = JSONDict.backend_is_buffered
-get_buffer_load = JSONDict.get_current_buffer_size
-get_buffer_size = JSONDict.get_buffer_capacity
-set_buffer_size = JSONDict.set_buffer_capacity
+get_current_buffer_size = JSONDict.get_current_buffer_size
+get_buffer_capacity = JSONDict.get_buffer_capacity
+set_buffer_capacity = JSONDict.set_buffer_capacity
 
 __all__ = [
     "__version__",
@@ -47,9 +47,9 @@ __all__ = [
     "Collection",
     "buffered",
     "is_buffered",
-    "get_buffer_size",
-    "get_buffer_load",
-    "set_buffer_size",
+    "get_buffer_capacity",
+    "get_current_buffer_size",
+    "set_buffer_capacity",
     "JSONDict",
     "H5Store",
     "H5StoreManager",

--- a/signac/synced_collections/buffers/buffered_collection.py
+++ b/signac/synced_collections/buffers/buffered_collection.py
@@ -97,7 +97,7 @@ class BufferedCollection(SyncedCollection):
             cls._buffer_context = _CounterFuncContext(cls._flush_buffer)
 
     @classmethod
-    def buffer_backend(cls, *args, **kwargs):
+    def buffer_backend(cls):
         """Enter context to buffer all operations for this backend."""
         return cls._buffer_context
 

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -11,7 +11,6 @@ specific components are abstract and must be implemented by child classes.
 
 import errno
 import os
-import warnings
 from abc import abstractmethod
 from threading import RLock
 from typing import Dict, Tuple, Union
@@ -347,26 +346,14 @@ class FileBufferedCollection(BufferedCollection):
         else:
             raise BufferedError(issues)
 
-    # TODO: The buffer_size argument should be changed to buffer_capacity in
-    # signac 2.0 for consistency with the new names in synced collections.
     @classmethod
-    def buffer_backend(cls, buffer_size=None, force_write=None, *args, **kwargs):
+    def buffer_backend(cls, buffer_capacity=None):
         """Enter context to buffer all operations for this backend.
 
         Parameters
         ----------
-        buffer_size : int
+        buffer_capacity : int
             The capacity of the buffer to use within this context (resets after
             the context is exited).
-        force_write : bool
-            This argument does nothing and is only present for compatibility
-            with signac 1.x.
         """
-        if force_write is not None:
-            warnings.warn(
-                DeprecationWarning(
-                    "The force_write parameter is deprecated and will be removed in "
-                    "signac 2.0. This functionality is no longer supported."
-                )
-            )
-        return cls._buffer_context(buffer_size)
+        return cls._buffer_context(buffer_capacity)

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -71,21 +71,21 @@ class TestBufferedMode(TestProjectBase):
             assert job.doc.a == 2
         assert job.doc.a == 2
 
-    def test_buffered_mode_change_buffer_size(self):
+    def test_buffered_mode_change_buffer_capacity(self):
         assert not signac.is_buffered()
-        with signac.buffered(buffer_size=12):
+        with signac.buffered(buffer_capacity=12):
             assert signac.buffered()
-            assert signac.get_buffer_size() == 12
+            assert signac.get_buffer_capacity() == 12
 
         assert not signac.is_buffered()
 
         assert not signac.is_buffered()
-        with signac.buffered(buffer_size=12):
+        with signac.buffered(buffer_capacity=12):
             assert signac.buffered()
-            assert signac.get_buffer_size() == 12
+            assert signac.get_buffer_capacity() == 12
             with signac.buffered():
                 assert signac.buffered()
-                assert signac.get_buffer_size() == 12
+                assert signac.get_buffer_capacity() == 12
 
         assert not signac.is_buffered()
 
@@ -114,24 +114,24 @@ class TestBufferedMode(TestProjectBase):
                 assert job.doc.a
 
         routine()
-        assert signac.get_buffer_load() == 0
+        assert signac.get_current_buffer_size() == 0
         with signac.buffered():
             assert signac.is_buffered()
             routine()
-            assert signac.get_buffer_load() > 0
-        assert signac.get_buffer_load() == 0
+            assert signac.get_current_buffer_size() > 0
+        assert signac.get_current_buffer_size() == 0
 
         for job in self.project:
             x = job.doc.a
             with signac.buffered():
-                assert signac.get_buffer_load() == 0
+                assert signac.get_current_buffer_size() == 0
                 assert job.doc.a == x
-                assert signac.get_buffer_load() > 0
+                assert signac.get_current_buffer_size() > 0
                 job.doc.a = not job.doc.a
                 assert job.doc.a == (not x)
                 job2 = self.project.open_job(id=job.id)
                 assert job2.doc.a == (not x)
-            assert signac.get_buffer_load() == 0
+            assert signac.get_current_buffer_size() == 0
             assert job.doc.a == (not x)
             assert job2.doc.a == (not x)
 


### PR DESCRIPTION
## Description
This alters a couple method signatures and method names for buffering. These changes make signac's buffering consistent with the new names designed by @vyasr in the synced collections submodule.

## Motivation and Context
Executing planned API changes for signac 2.0.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
