### PR TITLE
"State point" instead of "manifest."

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -68,7 +68,7 @@ def calc_project_metadata_size(project):
     sp_size = []
     doc_size = []
     for job in tqdm(project, "determine metadata size"):
-        sp_size.append(size(job.fn(job.FN_MANIFEST)))
+        sp_size.append(size(job.fn(job.FN_STATE_POINT)))
         doc_size.append(size(job.fn(job.FN_DOCUMENT)))
     return sp_size, doc_size
 

--- a/signac/contrib/errors.py
+++ b/signac/contrib/errors.py
@@ -38,7 +38,7 @@ class DestinationExistsError(Error, RuntimeError):
 
 
 class JobsCorruptedError(Error, RuntimeError):
-    """The state point manifest file of one or more jobs cannot be opened or is corrupted.
+    """The state point file of one or more jobs cannot be opened or is corrupted.
 
     Parameters
     ----------

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -615,15 +615,15 @@ def _make_path_based_schema_function(schema_path):
     return parse_path
 
 
-def _with_consistency_check(schema_function, read_sp_manifest_file):
+def _with_consistency_check(schema_function, read_statepoint_file):
     """Return a function to check schema consistency.
 
     Parameters
     ----------
     schema_function : callable
         Schema function.
-    read_sp_manifest_file : callable
-        Function to read state point manifest.
+    read_statepoint_file : callable
+        Function to read state point file.
 
     Returns
     -------
@@ -633,7 +633,7 @@ def _with_consistency_check(schema_function, read_sp_manifest_file):
     """
 
     def _check(path):
-        """Check if the schema-detected state point matches the manifest file.
+        """Check if the schema-detected state point matches the state point file.
 
         Parameters
         ----------
@@ -648,54 +648,54 @@ def _with_consistency_check(schema_function, read_sp_manifest_file):
         Raises
         ------
         :class:`~signac.errors.StatepointParsingError`
-            If identified state point conflicts with state point in job manifest file.
+            If identified state point conflicts with state point in job state point file.
 
         """
-        if schema_function is read_sp_manifest_file:
+        if schema_function is read_statepoint_file:
             return schema_function(path)
         else:
             sp = schema_function(path)
-            sp_default = read_sp_manifest_file(path)
+            sp_default = read_statepoint_file(path)
             if sp and sp_default and sp_default != sp:
                 raise StatepointParsingError(
-                    "Identified state point conflicts with state point in job manifest file!"
+                    "Identified state point conflicts with state point in job state point file!"
                 )
             return sp
 
     return _check
 
 
-def _parse_workspaces(fn_manifest):
-    """Generate a schema function based on parsing state point manifest files.
+def _parse_workspaces(fn_statepoint):
+    """Generate a schema function based on parsing state point files.
 
     Parameters
     ----------
-    fn_manifest : str
-        Manifest file name.
+    fn_statepoint : str
+        State point file name.
 
     Returns
     -------
     callable
-        Function to parse a manifest, given a path.
+        Function to parse a state point, given a path.
 
     """
 
     def _parse_workspace(path):
-        """Parse a manifest, given a path.
+        """Parse a state point, given a path.
 
         Parameters
         ----------
         path : str
-            Path containing manifest file.
+            Path containing state point file.
 
         Returns
         -------
         dict
-            Parsed manifest contents.
+            Parsed state point contents.
 
         """
         try:
-            with open(os.path.join(path, fn_manifest), "rb") as file:
+            with open(os.path.join(path, fn_statepoint), "rb") as file:
                 return json.loads(file.read().decode())
         except OSError as error:
             if error.errno != errno.ENOENT:
@@ -823,16 +823,16 @@ def _analyze_directory_for_import(root, project, schema):
 
     """
     # Determine schema function
-    read_sp_manifest_file = _parse_workspaces(project.Job.FN_MANIFEST)
+    read_statepoint_file = _parse_workspaces(project.Job.FN_STATE_POINT)
     if schema is None:
-        schema_function = read_sp_manifest_file
+        schema_function = read_statepoint_file
     elif callable(schema):
-        schema_function = _with_consistency_check(schema, read_sp_manifest_file)
+        schema_function = _with_consistency_check(schema, read_statepoint_file)
     elif isinstance(schema, str):
         if not schema.startswith(root):
             schema = os.path.normpath(os.path.join(root, schema))
         schema_function = _with_consistency_check(
-            _make_path_based_schema_function(schema), read_sp_manifest_file
+            _make_path_based_schema_function(schema), read_statepoint_file
         )
     else:
         raise TypeError("The schema variable must be None, callable, or a string.")
@@ -919,32 +919,32 @@ def _analyze_zipfile_for_import(zipfile, project, schema):
     """
     names = zipfile.namelist()
 
-    def read_sp_manifest_file(path):
-        """Read a state point manifest file.
+    def read_statepoint_file(path):
+        """Read a state point file.
 
         Parameters
         ----------
         path : str
-            Path to manifest file.
+            Path to state point file.
 
         Returns
         -------
         dict
-            Parsed manifest contents.
+            Parsed state point contents.
 
         """
         # Must use forward slashes, not os.path.sep.
-        fn_manifest = path + "/" + project.Job.FN_MANIFEST
-        if fn_manifest in names:
-            return json.loads(zipfile.read(fn_manifest).decode())
+        fn_statepoint = path + "/" + project.Job.FN_STATE_POINT
+        if fn_statepoint in names:
+            return json.loads(zipfile.read(fn_statepoint).decode())
 
     if schema is None:
-        schema_function = read_sp_manifest_file
+        schema_function = read_statepoint_file
     elif callable(schema):
-        schema_function = _with_consistency_check(schema, read_sp_manifest_file)
+        schema_function = _with_consistency_check(schema, read_statepoint_file)
     elif isinstance(schema, str):
         schema_function = _with_consistency_check(
-            _make_path_based_schema_function(schema), read_sp_manifest_file
+            _make_path_based_schema_function(schema), read_statepoint_file
         )
     else:
         raise TypeError("The schema variable must be None, callable, or a string.")
@@ -1065,35 +1065,35 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
 
     """
 
-    def read_sp_manifest_file(path):
-        """Read state point from the manifest file.
+    def read_statepoint_file(path):
+        """Read a state point file.
 
         Parameters
         ----------
         path : str
-            Path to manifest file.
+            Path to state point file.
 
         Returns
         -------
         dict
-            state point.
+            Parsed state point contents.
 
         """
         # Must use forward slashes, not os.path.sep.
-        fn_manifest = _tarfile_path_join(path, project.Job.FN_MANIFEST)
+        fn_statepoint = _tarfile_path_join(path, project.Job.FN_STATE_POINT)
         try:
-            with closing(tarfile.extractfile(fn_manifest)) as file:
+            with closing(tarfile.extractfile(fn_statepoint)) as file:
                 return json.loads(file.read())
         except KeyError:
             pass
 
     if schema is None:
-        schema_function = read_sp_manifest_file
+        schema_function = read_statepoint_file
     elif callable(schema):
-        schema_function = _with_consistency_check(schema, read_sp_manifest_file)
+        schema_function = _with_consistency_check(schema, read_statepoint_file)
     elif isinstance(schema, str):
         schema_function = _with_consistency_check(
-            _make_path_based_schema_function(schema), read_sp_manifest_file
+            _make_path_based_schema_function(schema), read_statepoint_file
         )
     else:
         raise TypeError("The schema variable must be None, callable, or a string.")
@@ -1184,9 +1184,9 @@ def import_into_project(origin, project, schema=None, copytree=None):
     This function will walk through the data space located at origin and try to identify
     data space paths that can be imported as a job workspace into project.
 
-    The default schema function will simply look for state point manifest files -- usually named
+    The default schema function will simply look for state point files -- usually named
     ``signac_statepoint.json`` -- and then import all data located within that path into the job
-    workspace corresponding to the state point specified in the manifest file.
+    workspace corresponding to the specified state point.
 
     Alternatively the schema argument may be a string, that is converted into a schema function,
     for example: Providing ``foo/{foo:int}`` as schema argument means that all directories under

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -239,7 +239,7 @@ class Job:
 
     """
 
-    FN_MANIFEST = "signac_statepoint.json"
+    FN_STATE_POINT = "signac_statepoint.json"
     """The job's state point filename.
 
     The job state point is a human-readable file containing the job's state
@@ -337,7 +337,7 @@ class Job:
         """Get the path of the state point file for this job."""
         # We can rely on the job workspace to be well-formed, so just
         # use str.join with os.sep instead of os.path.join for speed.
-        return os.sep.join((self.workspace(), self.FN_MANIFEST))
+        return os.sep.join((self.workspace(), self.FN_STATE_POINT))
 
     @property
     def ws(self):
@@ -701,7 +701,7 @@ class Job:
         """
         try:
             for fn in os.listdir(self.workspace()):
-                if fn in (self.FN_MANIFEST, self.FN_DOCUMENT):
+                if fn in (self.FN_STATE_POINT, self.FN_DOCUMENT):
                     continue
                 path = os.path.join(self.workspace(), fn)
                 if os.path.isfile(path):

--- a/signac/sync.py
+++ b/signac/sync.py
@@ -339,7 +339,7 @@ def sync_jobs(
         raise ValueError("Source and destination can't be the same!")
 
     # check src and dst compatiblity
-    assert src.FN_MANIFEST == dst.FN_MANIFEST
+    assert src.FN_STATE_POINT == dst.FN_STATE_POINT
     assert src.FN_DOCUMENT == dst.FN_DOCUMENT
 
     # Nothing to be done if the src is not initialized.
@@ -355,7 +355,7 @@ def sync_jobs(
         exclude = []
     elif not isinstance(exclude, list):
         exclude = [exclude]
-    exclude.append(src.FN_MANIFEST)
+    exclude.append(src.FN_STATE_POINT)
     if doc_sync != DocSync.COPY:
         exclude.append(src.FN_DOCUMENT)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -543,7 +543,7 @@ class TestJobOpenAndClosing(TestJobBase):
         assert job.workspace() == job.ws
         assert os.path.isdir(job.workspace())
         assert os.path.isdir(job.ws)
-        assert os.path.exists(os.path.join(job.workspace(), job.FN_MANIFEST))
+        assert os.path.exists(os.path.join(job.workspace(), job.FN_STATE_POINT))
 
     def test_chained_init(self):
         job = self.open_job(test_token)
@@ -552,7 +552,7 @@ class TestJobOpenAndClosing(TestJobBase):
         assert job.workspace() == job.ws
         assert os.path.isdir(job.workspace())
         assert os.path.isdir(job.ws)
-        assert os.path.exists(os.path.join(job.workspace(), job.FN_MANIFEST))
+        assert os.path.exists(os.path.join(job.workspace(), job.FN_STATE_POINT))
 
     def test_construction(self):
         from signac import Project  # noqa: F401
@@ -642,8 +642,8 @@ class TestJobOpenAndClosing(TestJobBase):
     def test_corrupt_workspace(self):
         job = self.open_job(test_token)
         job.init()
-        fn_manifest = os.path.join(job.workspace(), job.FN_MANIFEST)
-        with open(fn_manifest, "w") as file:
+        fn_statepoint = os.path.join(job.workspace(), job.FN_STATE_POINT)
+        with open(fn_statepoint, "w") as file:
             file.write("corrupted")
         job2 = self.open_job(test_token)
         try:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -511,7 +511,7 @@ class TestProject(TestProjectBase):
         job = self.project.open_job(dict(a=0))
         job.init()
 
-        os.remove(job.fn(job.FN_MANIFEST))
+        os.remove(job.fn(job.FN_STATE_POINT))
 
         self.project._sp_cache.clear()
         self.project._remove_persistent_cache_file()
@@ -526,8 +526,8 @@ class TestProject(TestProjectBase):
         job = self.project.open_job(dict(a=0))
         job.init()
 
-        # overwrite state point manifest file
-        with open(job.fn(job.FN_MANIFEST), "w"):
+        # Overwrite state point file.
+        with open(job.fn(job.FN_STATE_POINT), "w"):
             pass
 
         self.project._sp_cache.clear()
@@ -536,16 +536,16 @@ class TestProject(TestProjectBase):
             logging.disable(logging.CRITICAL)
             with pytest.raises(JobsCorruptedError):
                 # Accessing the job state point triggers validation of the
-                # state point manifest file
+                # state point file.
                 self.project.open_job(id=job.id).statepoint
             with pytest.raises(JobsCorruptedError):
                 # Initializing the job state point triggers validation of the
-                # state point manifest file
+                # state point file.
                 self.project.open_job(id=job.id).init()
         finally:
             logging.disable(logging.NOTSET)
-        # Ensure that the corrupted manifest still exists
-        assert os.path.exists(job.fn(job.FN_MANIFEST))
+        # Ensure that the corrupted state point file still exists.
+        assert os.path.exists(job.fn(job.FN_STATE_POINT))
 
     def test_rename_workspace(self):
         job = self.project.open_job(dict(a=0))
@@ -598,12 +598,13 @@ class TestProject(TestProjectBase):
 
         self.project.update_cache()
 
-        # no manifest file
+        # This job has no state point file.
         with self.project.open_job(statepoints[0]) as job:
-            os.remove(job.FN_MANIFEST)
-        # blank manifest file
+            os.remove(job.FN_STATE_POINT)
+
+        # This job has an empty state point file.
         with self.project.open_job(statepoints[1]) as job:
-            with open(job.FN_MANIFEST, "w"):
+            with open(job.FN_STATE_POINT, "w"):
                 pass
 
         # Need to clear internal cache to encounter error.


### PR DESCRIPTION
## Description
In an effort to reduce the number of terms and clarify definitions, I proposed using the term "state point" universally instead of "manifest" to describe the data file containing the state point information.

To-do:
- [ ] Decide whether `FN_STATE_POINT` and `FN_DOCUMENT` and related properties should be private or public.

## Motivation and Context
Resolves #478.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.