### PR TITLE
Deprecate cite module.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Deprecated
  - ``Project.index`` method is deprecated (#591, #588).
  - ``JobSearchIndex`` class is deprecated (#600).
  - ``index`` argument is deprecated in ``Project`` methods (#602, #588).
+ - ``signac.cite`` module is deprecated (#611, #592).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/signac/cite.py
+++ b/signac/cite.py
@@ -4,6 +4,10 @@
 """Functions to support citing this software."""
 import sys
 
+from deprecation import deprecated
+
+from .version import __version__
+
 ARXIV_BIBTEX = """@online{signac,
     author      = {Carl S. Adorf and Paul M. Dodd and Sharon C. Glotzer},
     title       = {signac - A Simple Data Management Framework},
@@ -22,6 +26,12 @@ ARXIV_REFERENCE = (
 )
 
 
+@deprecated(
+    deprecated_in="1.8",
+    removed_in="2.0",
+    current_version=__version__,
+    details="The cite module is deprecated.",
+)
 def bibtex(file=None):
     """Generate bibtex entries for signac.
 
@@ -45,6 +55,12 @@ def bibtex(file=None):
     file.write(ARXIV_BIBTEX)
 
 
+@deprecated(
+    deprecated_in="1.8",
+    removed_in="2.0",
+    current_version=__version__,
+    details="The cite module is deprecated.",
+)
 def reference(file=None):
     """Generate formatted reference entries for signac.
 


### PR DESCRIPTION
## Description
We are deprecating and removing the `cite` module in signac 2.0. Resolves #592.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.