### PR TITLE
Avoid AssertionError.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,11 @@ Version 2
 [2.0.0] -- 2021-xx-xx
 ---------------------
 
+Changed
++++++++
+
+ - Functions raising ``AssertionError`` now raise ``RuntimeError`` (#612).
+
 Removed
 +++++++
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -1060,7 +1060,7 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
         If a job is already initialized.
     :class:`~signac.errors.StatepointParsingError`
         If the jobs identified with the given schema function are not unique.
-    AssertionError
+    RuntimeError
         If ``tmpdir`` given is not a directory.
 
     """
@@ -1125,9 +1125,11 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
 
     tarfile.extractall(path=tmpdir)
     for path, job in mappings.items():
-        assert os.path.isdir(tmpdir)
+        if not os.path.isdir(tmpdir):
+            raise RuntimeError(f"The provided tmpdir {tmpdir} is not a directory.")
         src = os.path.join(tmpdir, path)
-        assert os.path.isdir(src)
+        if not os.path.isdir(src):
+            raise RuntimeError(f"The path {src} is not a directory.")
         copy_executor = _CopyFromTarFileExecutor(src, job)
         yield src, copy_executor
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1632,20 +1632,17 @@ class Project:
             assert project.id == str(name)
             return project
         else:
-            try:
-                assert project.id == str(name)
-                if workspace is not None:
-                    assert os.path.realpath(workspace) == os.path.realpath(
-                        project.workspace()
-                    )
-                return project
-            except AssertionError:
+            if project.id != str(name) or (
+                workspace is not None
+                and os.path.realpath(workspace) != os.path.realpath(project.workspace())
+            ):
                 raise RuntimeError(
                     "Failed to initialize project '{}'. Path '{}' already "
                     "contains a conflicting project configuration.".format(
                         name, os.path.abspath(root)
                     )
                 )
+            return project
 
     @classmethod
     def get_project(cls, root=None, search=True, **kwargs):

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -125,13 +125,14 @@ def _split_and_print_progress(iterable, num_chunks=10, write=None, desc="Progres
 
     Raises
     ------
-    AssertionError
+    ValueError
         If num_chunks <= 0.
 
     """
+    if num_chunks <= 0:
+        raise ValueError("num_chunks must be a positive integer.")
     if write is None:
         write = print
-    assert num_chunks > 0
     if num_chunks > 1:
         N = len(iterable)
         len_chunk = int(N / num_chunks)

--- a/signac/synced_collections/_caching.py
+++ b/signac/synced_collections/_caching.py
@@ -37,11 +37,12 @@ def get_cache():
             cache = redis.Redis()
             test_key = str(uuid.uuid4())
             cache.set(test_key, 0)
-            assert cache.get(test_key) == b"0"  # Redis stores data as bytes
+            if cache.get(test_key) == b"0":  # Redis stores data as bytes
+                raise RuntimeError("Cache access check failed.")
             cache.delete(test_key)
             logger.info("Using Redis cache.")
             return _RedisCache(cache)
-        except (redis.exceptions.ConnectionError, AssertionError) as error:
+        except (redis.exceptions.ConnectionError, RuntimeError) as error:
             logger.debug(str(error))
     logger.info("Redis not available.")
     return {}

--- a/signac/synced_collections/_caching.py
+++ b/signac/synced_collections/_caching.py
@@ -37,7 +37,7 @@ def get_cache():
             cache = redis.Redis()
             test_key = str(uuid.uuid4())
             cache.set(test_key, 0)
-            if cache.get(test_key) == b"0":  # Redis stores data as bytes
+            if cache.get(test_key) != b"0":  # Redis stores data as bytes
                 raise RuntimeError("Cache access check failed.")
             cache.delete(test_key)
             logger.info("Using Redis cache.")

--- a/tests/test_synced_collections/test_mongodb_collection.py
+++ b/tests/test_synced_collections/test_mongodb_collection.py
@@ -19,10 +19,11 @@ try:
         tmp_collection = mongo_client["test_db"]["test"]
         tmp_collection.insert_one({"test": "0"})
         ret = tmp_collection.find_one({"test": "0"})
-        assert ret["test"] == "0"
+        if ret["test"] != "0":
+            raise RuntimeError("MongoDB access check failed.")
         tmp_collection.drop()
         PYMONGO = True
-    except (pymongo.errors.ServerSelectionTimeoutError, AssertionError):
+    except (pymongo.errors.ServerSelectionTimeoutError, RuntimeError):
         PYMONGO = False
 except ImportError:
     PYMONGO = False

--- a/tests/test_synced_collections/test_redis_collection.py
+++ b/tests/test_synced_collections/test_redis_collection.py
@@ -13,14 +13,15 @@ try:
     import redis
 
     try:
-        # try to connect to server
+        # Try to connect to server
         redis_client = redis.Redis()
         test_key = str(uuid.uuid4())
         redis_client.set(test_key, 0)
-        assert redis_client.get(test_key) == b"0"  # redis stores data as bytes
+        if redis_client.get(test_key) == b"0":  # Redis stores data as bytes
+            raise RuntimeError("Cache access check failed.")
         redis_client.delete(test_key)
         REDIS = True
-    except (redis.exceptions.ConnectionError, AssertionError):
+    except (redis.exceptions.ConnectionError, RuntimeError):
         REDIS = False
 except ImportError:
     REDIS = False


### PR DESCRIPTION
## Description
There are a few places where signac raises `AssertionError` as a way to validate program state via `assert` statements. This is not a good practice, because "optimized" execution of Python will ignore these assertions, potentially leading to unwanted or invalid program states. See also: https://stackoverflow.com/questions/9929456/keeping-assert-despite-the-o-optimize-flag

## Motivation and Context
Makes some internal logic more resilient if executing Python with optimization flags.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
