### PR TITLE
Revert modifications to global configuration file after test completes.

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -788,15 +788,25 @@ class TestBasicShell:
         assert "[x]" in cfg
         assert "y = z" in cfg
 
+        backup_config = os.path.exists(config.FN_CONFIG)
         global_config_path_backup = config.FN_CONFIG + ".tmp"
         try:
-            shutil.copy2(config.FN_CONFIG, global_config_path_backup)
+            # Make a backup of the global config if it exists
+            if backup_config:
+                shutil.copy2(config.FN_CONFIG, global_config_path_backup)
+
+            # Test the global config CLI
             self.call("python -m signac config --global set b c".split())
             cfg = self.call("python -m signac config --global show".split())
             assert "b" in cfg
             assert "b = c" in cfg.split(os.linesep)
         finally:
-            shutil.move(global_config_path_backup, config.FN_CONFIG)
+            # Revert the global config to its previous state (or remove it if
+            # it did not exist)
+            if backup_config:
+                shutil.move(global_config_path_backup, config.FN_CONFIG)
+            else:
+                os.remove(config.FN_CONFIG)
 
         # setting password with config set should fail
         with pytest.raises(ExitCodeError):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -3,6 +3,7 @@
 # This software is licensed under the BSD 3-Clause License.
 import json
 import os
+import shutil
 import subprocess
 import sys
 from tempfile import TemporaryDirectory
@@ -787,10 +788,15 @@ class TestBasicShell:
         assert "[x]" in cfg
         assert "y = z" in cfg
 
-        self.call("python -m signac config --global set b c".split())
-        cfg = self.call("python -m signac config --global show".split())
-        assert "b" in cfg
-        assert "b = c" in cfg.split(os.linesep)
+        global_config_path_backup = config.FN_CONFIG + ".tmp"
+        try:
+            shutil.copy2(config.FN_CONFIG, global_config_path_backup)
+            self.call("python -m signac config --global set b c".split())
+            cfg = self.call("python -m signac config --global show".split())
+            assert "b" in cfg
+            assert "b = c" in cfg.split(os.linesep)
+        finally:
+            shutil.move(global_config_path_backup, config.FN_CONFIG)
 
         # setting password with config set should fail
         with pytest.raises(ExitCodeError):


### PR DESCRIPTION
## Description
This fixes a minor annoyance: after the signac tests run, there is a key `b = c` in the global configuration `$HOME/.signacrc`. This is from a test of the CLI. I modified the test to make a backup of the global configuration and revert changes to the configuration file after the test completes.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
