### PR TITLE
Update filelock pinning to >= instead of ~=.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 deprecation>=2
-filelock~=3.0
+filelock>=3.0
 packaging>=15.0
 tqdm>=4.10.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     # Deprecation management
     "deprecation>=2",
     # Platform-independent file locking
-    "filelock~=3.0",
+    "filelock>=3.0",
     # Used for version parsing and comparison
     "packaging>=15.0",
     # Progress bars


### PR DESCRIPTION
## Description
Currently our pinning for `filelock` is `~=`, which differs from how we handle all other dependencies. I have changed it to `>=` to avoid Dependabot PRs like #623, which is not aligned with our intentions for the pinning.

## Motivation and Context
Maintenance.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.
