### PR TITLE
Feature: Measuring the airspeed velocity of an unladen signac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__
 pip-log.txt
 
 # Unit test / coverage reports
+.asv
 .noseids
 .coverage
 .tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: check-builtin-literals
       - id: check-executables-have-shebangs
       - id: check-json
+        exclude: 'asv.conf.json'
       - id: check-yaml
       - id: debug-statements
       - id: requirements-txt-fixer

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ python -m pytest tests/
 ## Acknowledgment
 
 When using **signac** as part of your work towards a publication, we would really appreciate that you acknowledge **signac** appropriately.
-We have prepared examples on how to do that [here](http://docs.signac.io/en/latest/acknowledge.html).
+We have prepared examples on how to do that [here](https://docs.signac.io/en/latest/acknowledge.html).
 **Thank you very much!**
 
 The signac framework is a [NumFOCUS Affiliated Project](https://numfocus.org/sponsored-projects/affiliated-projects).

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,160 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "signac",
+
+    // The project's homepage
+    "project_url": "https://signac.io/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/glotzerlab/signac/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.9"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // "matrix": {
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    // },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/benchmark.py
+++ b/benchmark.py
@@ -18,6 +18,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+"""Benchmarks for use in CI testing.
+
+This script defines benchmarks of common signac operations, used to assess the
+performance of the framework over time. Most developers will want to make use of
+the asv (airspeed velocity) tools for benchmarking, located in
+``benchmarks/benchmarks.py``. This script is used by CI tests to identify any
+significant performance regressions introduced by new features.
+"""
+
+
 import argparse
 import base64
 import json

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -4,6 +4,7 @@ import random
 import string
 from itertools import islice
 from multiprocessing import Pool
+from tempfile import TemporaryDirectory
 
 from tqdm import tqdm
 
@@ -59,9 +60,10 @@ def setup_random_project(
     if not isinstance(N, int):
         raise TypeError("N must be an integer!")
 
-    project = signac.init_project(f"benchmark-N={N}")
+    temp_dir = TemporaryDirectory()
+    project = signac.init_project(f"benchmark-N={N}", root=temp_dir.name)
     generate_random_data(project, N, num_keys, num_doc_keys, data_size, data_std)
-    return project
+    return project, temp_dir
 
 
 PARAMETERS = {"N": [100, 1_000]}
@@ -73,7 +75,10 @@ class _ProjectBenchBase:
 
     def setup(self, *params):
         (N,) = params
-        self.project = setup_random_project(N)
+        self.project, self.temp_dir = setup_random_project(N)
+
+    def teardown(self, *params):
+        self.temp_dir.cleanup()
 
 
 class ProjectBench(_ProjectBenchBase):

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,109 @@
+# Copyright 2021 The Regents of the University of Michigan
+
+import random
+import string
+from itertools import islice
+from multiprocessing import Pool
+from tempfile import TemporaryDirectory
+
+from tqdm import tqdm
+
+import signac
+
+
+def _random_str(size):
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(size))
+
+
+def _make_doc(i, num_keys=1, data_size=0):
+    assert num_keys >= 1
+    assert data_size >= 0
+
+    doc = {f"b_{j}": _random_str(data_size) for j in range(num_keys - 1)}
+    doc["a"] = f"{i}{_random_str(max(0, data_size - len(str(i))))}"
+    return doc
+
+
+def _make_job(project, num_keys, num_doc_keys, data_size, data_std, i):
+    size = max(0, int(random.gauss(data_size, data_std)))
+    job = project.open_job(_make_doc(i, num_keys, size))
+    if num_doc_keys > 0:
+        size = max(0, int(random.gauss(data_size, data_std)))
+        job.document.update(_make_doc(i, num_doc_keys, size))
+    else:
+        job.init()
+
+
+def generate_random_data(
+    project, N_sp, num_keys=1, num_doc_keys=0, data_size=0, data_std=0, parallel=True
+):
+    assert len(project) == 0
+
+    if parallel:
+        with Pool() as pool:
+            p = [
+                (project, num_keys, num_doc_keys, data_size, data_std, i)
+                for i in range(N_sp)
+            ]
+            list(pool.starmap(_make_job, tqdm(p, desc="init random project data")))
+    else:
+        from functools import partial
+
+        make = partial(_make_job, project, num_keys, num_doc_keys, data_size, data_std)
+        list(map(make, tqdm(range(N_sp), desc="init random project data")))
+
+
+def setup_random_project(
+    N, num_keys=1, num_doc_keys=0, data_size=0, data_std=0, seed=0, root=None
+):
+    random.seed(seed)
+    if not isinstance(N, int):
+        raise TypeError("N must be an integer!")
+
+    temp_dir = TemporaryDirectory()
+    project = signac.init_project(f"benchmark-N={N}", root=temp_dir.name)
+    generate_random_data(project, N, num_keys, num_doc_keys, data_size, data_std)
+    return project, temp_dir
+
+
+class ProjectBench:
+    def setup(self):
+        self.project, self.temp_dir = setup_random_project(100)
+
+    def teardown(self):
+        self.temp_dir.cleanup()
+
+    def time_determine_len(self):
+        len(self.project)
+
+    def time_iterate_single_pass(self):
+        list(self.project)
+
+    def time_iterate(self):
+        for _ in range(10):
+            list(self.project)
+
+    def time_iterate_load_sp(self):
+        for _ in range(10):
+            [job.sp() for job in self.project]
+
+
+class ProjectRandomJobBench:
+    def setup(self):
+        self.project, self.temp_dir = setup_random_project(100)
+        self.random_job = random.choice(list(self.project))
+        self.random_job_sp = self.random_job.statepoint()
+        self.random_job_id = self.random_job.id
+        self.lean_filter = {k: v for k, v in islice(self.random_job_sp.items(), 1)}
+
+    def teardown(self):
+        self.temp_dir.cleanup()
+
+    def time_select_by_id(self):
+        self.project.open_job(id=self.random_job_id)
+
+    def time_search_lean_filter(self):
+        len(self.project.find_jobs(self.lean_filter))
+
+    def time_search_rich_filter(self):
+        len(self.project.find_jobs(self.random_job_sp))

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,4 +1,14 @@
 # Copyright 2021 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Benchmarks for use with asv (airspeed velocity).
+
+This script defines benchmarks of common signac operations, used to assess the
+performance of the framework over time. The asv tools allow for profiling,
+comparison, and visualization of benchmark results. This complements the file
+``benchmark.py`` in the root directory of the repository, which is primarily
+intended for CI tests.
+"""
 
 import random
 import string

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -15,21 +15,21 @@ def _random_str(size):
     return "".join(random.choice(string.ascii_lowercase) for _ in range(size))
 
 
-def _make_doc(i, num_keys=1, data_size=0):
+def _make_json_data(i, num_keys=1, data_size=0):
     assert num_keys >= 1
     assert data_size >= 0
 
-    doc = {f"b_{j}": _random_str(data_size) for j in range(num_keys - 1)}
-    doc["a"] = f"{i}{_random_str(max(0, data_size - len(str(i))))}"
-    return doc
+    data = {f"b_{j}": _random_str(data_size) for j in range(num_keys - 1)}
+    data["a"] = f"{i}{_random_str(max(0, data_size - len(str(i))))}"
+    return data
 
 
 def _make_job(project, num_keys, num_doc_keys, data_size, data_std, i):
     size = max(0, int(random.gauss(data_size, data_std)))
-    job = project.open_job(_make_doc(i, num_keys, size))
+    job = project.open_job(_make_json_data(i, num_keys, size))
     if num_doc_keys > 0:
         size = max(0, int(random.gauss(data_size, data_std)))
-        job.document.update(_make_doc(i, num_doc_keys, size))
+        job.document.update(_make_json_data(i, num_doc_keys, size))
     else:
         job.init()
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,11 @@ Version 1
 [1.8.0] -- 2021-xx-xx
 ---------------------
 
+Added
++++++
+
+ - Benchmarks can be run using the ``asv`` (airspeed velocity) tool (#629).
+
 Deprecated
 ++++++++++
 

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -97,7 +97,7 @@ To run tests, execute:
 Benchmarking
 ------------
 
-This repository includes support for the `asv (airspeed velocity) <https://asv.readthedocs.io/>`__ benchmarking tool.
+Benchmarks can be run using the `asv (airspeed velocity) <https://asv.readthedocs.io/>`__ tool.
 To install the tool, execute:
 
 .. code-block:: bash

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -94,6 +94,26 @@ To run tests, execute:
 
     (signac-dev) signac $ python -m pytest tests/
 
+Benchmarking
+------------
+
+This repository includes support for the `asv (airspeed velocity) <https://asv.readthedocs.io/>`__ benchmarking tool.
+To install the tool, execute:
+
+.. code-block:: bash
+
+   (signac-dev) signac $ pip install asv
+
+The ``asv run`` command installs signac into an isolated virtual environment that is used for benchmarking.
+Below is a quick reference with some helpful commands:
+
+  * ``asv run master..mybranch`` benchmarks every commit from ``master`` to ``mybranch``.
+  * ``asv publish`` generates a static HTML site showing benchmark results.
+  * ``asv preview`` hosts a local preview of the generated HTML site.
+  * ``asv dev`` runs benchmarks that are in development.
+  * ``asv profile 'benchmarks.ProjectBench.time_iterate_load_sp(.*)' --gui=snakeviz`` will profile a specific test and visualize results with `snakeviz <https://jiffyclub.github.io/snakeviz/>`__.
+
+For more information on how to use asv, refer to `Using airspeed velocity <https://asv.readthedocs.io/en/stable/using.html>`__.
 
 Building documentation
 ----------------------

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -15,7 +15,7 @@ Code contributions
 
 This project is open-source.
 Users are highly encouraged to contribute directly by implementing new features and fixing issues.
-Development for packages as part of the **signac** framework should follow the general development guidelines outlined `here <http://docs.signac.io/en/latest/community.html#contributions>`__.
+Development for packages as part of the **signac** framework should follow the general development guidelines outlined `here <https://docs.signac.io/en/latest/community.html#contributions>`__.
 
 A brief summary of contributing guidelines are outlined in the `CONTRIBUTING.md <https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md>`_ file as part of the repository.
 All contributors must agree to the `Contributor Agreement <https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md>`_ before their pull request can be merged.
@@ -98,7 +98,7 @@ To run tests, execute:
 Building documentation
 ----------------------
 
-Building documentation requires the `sphinx <http://www.sphinx-doc.org/en/master/>`_ package which you will need to install into your development environment.
+Building documentation requires the `sphinx <https://www.sphinx-doc.org/>`__ package which you will need to install into your development environment.
 
 .. code-block:: bash
 

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -104,14 +104,14 @@ To install the tool, execute:
 
    (signac-dev) signac $ pip install asv
 
-The ``asv run`` command installs signac into an isolated virtual environment that is used for benchmarking.
+The ``asv`` tool will install signac into an isolated virtual environment that is used for benchmarking.
 Below is a quick reference with some helpful commands:
 
-  * ``asv run master..mybranch`` benchmarks every commit from ``master`` to ``mybranch``.
-  * ``asv publish`` generates a static HTML site showing benchmark results.
-  * ``asv preview`` hosts a local preview of the generated HTML site.
-  * ``asv dev`` runs benchmarks that are in development.
-  * ``asv profile 'benchmarks.ProjectBench.time_iterate_load_sp(.*)' --gui=snakeviz`` will profile a specific test and visualize results with `snakeviz <https://jiffyclub.github.io/snakeviz/>`__.
+  * ``$ asv run master..mybranch`` benchmarks every commit from ``master`` to ``mybranch``.
+  * ``$ asv publish`` generates a static HTML site showing benchmark results.
+  * ``$ asv preview`` hosts a local preview of the generated HTML site.
+  * ``$ asv dev`` runs benchmarks that are in development.
+  * ``$ asv profile 'benchmarks.ProjectBench.time_iterate_load_sp(.*)' --gui=snakeviz`` will profile a specific test and visualize results with `snakeviz <https://jiffyclub.github.io/snakeviz/>`__.
 
 For more information on how to use asv, refer to `Using airspeed velocity <https://asv.readthedocs.io/en/stable/using.html>`__.
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -316,7 +316,7 @@ class H5Store(MutableMapping):
     \*\*kwargs
         Additional keyword arguments to be forwarded to the ``h5py.File``
         constructor. See the documentation for the `h5py.File constructor
-        <http://docs.h5py.org/en/latest/high/file.html#File>`_ for more
+        <https://docs.h5py.org/en/latest/high/file.html#File>`_ for more
         information.
 
     """


### PR DESCRIPTION
## Description
This PR uses [asv (airspeed velocity)](https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown) to measure performance of the signac package. It could replace our existing `benchmark.py` script. I haven't yet tried all the features of asv, but it does a lot of things we care about and is a very powerful / helpful tool:
- isolated testing of each commit in a virtual environment (which it handles for you)
- automated testing from git ranges: running `asv run v1.3.0..master` tests every commit from v1.3.0 to master (with the current commit's set of benchmarks, so it doesn't require any git trickery!)
- publishing results into a static HTML site that can be hosted/shared: `asv publish`
- local preview of the HTML site: `asv preview`
- checking that the benchmark suite runs correctly during development: `asv dev`
- profiling+visualization with snakeviz: e.g. `asv profile 'benchmarks.ProjectBench.time_iterate_load_sp(.*)' --gui=snakeviz`
- direct comparison of two commits with `asv compare`
- automatic detection of performance regressions 👀

Preview of asv results from v1.3.0 to master (this link may be removed in the future): https://glotzerlab.github.io/signac/

To-do:
- [x] Decide what to do with `benchmark.py` (see below)
- [x] Update changelog
- [ ] Update docs
- [ ] Port this feature over to signac-flow and close https://github.com/glotzerlab/signac-flow/pull/399

## Motivation and Context
I have always wanted to try asv and I think this is a great tool for understanding the project's longitudinal improvements. From a reporting/visualization/profiling perspective, asv seems like a massive step forward. Especially since releases 1.6.0 and 1.7.0 were very carefully tested for performance, it would be nice to add this tool to ensure that we keep high performance into signac 2.0 and beyond.

We can separately discuss whether to remove `benchmark.py`. For now, I'm happy to keep both. To get rid of `benchmark.py` we'll want to decide how to incorporate all the flags from `benchmark.py`, like those controlling document sizes, number of state point keys, etc. I think I would recommend that we just add those as parameters, and then let users alter the settings of the benchmark file if they need to test particular configurations (e.g. large documents).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.