### PR TITLE
Update deprecated Xcode image from 11.3.0 to 13.2.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
 
   macos-python-3:
     macos:  # executor type
-      xcode: 11.3.0
+      xcode: 13.2.0
     steps:
       - checkout
       - run:

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,11 @@ Fixed
 
  - ``H5Store.mode`` returns the file mode (#607).
 
+Removed
++++++++
+
+ - Tests for storing ``pandas`` objects in ``H5Store`` via ``tables`` have been removed from continuous integration because wheels are not broadly available for ``tables``.
+
 [1.7.0] -- 2021-06-08
 ---------------------
 

--- a/requirements/requirements-test-optional.txt
+++ b/requirements/requirements-test-optional.txt
@@ -4,5 +4,4 @@ pandas==1.3.4; implementation_name=='cpython'
 pymongo==4.0; implementation_name=='cpython'
 redis==4.0.2
 ruamel.yaml==0.17.17
-tables==3.6.1; implementation_name=='cpython'
 zarr==2.10.3; platform_system!='Windows'


### PR DESCRIPTION
## Description
I received a notification from CircleCI that this project depends on a deprecated Xcode image. See https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions for currently supported versions. This PR updates to the latest supported version so that we may continue testing on macOS.

## Motivation and Context
Fixes deprecated CI configuration. No changelog entry required.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.