### PR TITLE
Fix typo in groupby docstring.

### DIFF
--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1106,7 +1106,7 @@ class Project:
                 print(key, list(group))
 
             # Group jobs by jobs.sp['a'] and job.document['b']
-            for key, group in project.groupby('a', 'doc.b'):
+            for key, group in project.groupby(('a', 'doc.b')):
                 print(key, list(group))
 
             # Find jobs where job.sp['a'] is 1 and group them
@@ -2667,7 +2667,7 @@ class JobsCursor:
                 print(key, list(group))
 
             # Group jobs by jobs.sp['a'] and job.document['b']
-            for key, group in project.groupby('a', 'doc.b'):
+            for key, group in project.groupby(('a', 'doc.b')):
                 print(key, list(group))
 
             # Find jobs where job.sp['a'] is 1 and group them


### PR DESCRIPTION
## Description
Fixes issue in the docs caught by @rskye144. The argument to `groupby` needs to be wrapped in a tuple if multiple keys are provided.

## Motivation and Context
Fixes docs.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
