### PR TITLE
Raise error on underspecified path for import/export and view

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Fixed
 +++++
 
  - ``H5Store.mode`` returns the file mode (#607).
+ - User-provided path functions now raise an error if not unique (#642).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ Fixed
 +++++
 
  - ``H5Store.mode`` returns the file mode (#607).
- - User-provided path functions now raise an error if not unique (#642).
+ - User-provided path functions now raise an error if not unique (#666).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -169,15 +169,16 @@ def _check_path_function_unique(jobs, path_spec, path_function):
 
     """
     job_paths = Counter(path_function(job) for job in jobs)
-    duplicates = {path for path, count in job_paths if count > 1}
+    duplicates = {path for path, count in job_paths.items() if count > 1}
     if len(duplicates) > 0:
         # Log paths generated more than once
         for path in duplicates:
             logger.debug(f"Generated path '{path}' is not unique.")
         raise RuntimeError(
-            f"The path specification {path_spec} would result in duplicate links. "
-            "See the debug log for the list. The easiest way to fix this is "
-            "to append the job id to the path specification like "
+            f"The path specification '{path_spec}' would result in duplicate "
+            "paths. See the debug log for the list of duplicate paths. The "
+            "easiest way to fix this is to append the job id to the path "
+            "specification like "
             f"'{os.path.join(str(path_spec), 'id', '{job.id}')}'."
         )
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -168,13 +168,13 @@ def _check_path_function(jobs, path_spec, path_function):
 
     """
     # quick check first
-    job_paths = Counter((path_function(job) for job in jobs))
+    job_paths = Counter(path_function(job) for job in jobs)
     common_paths = job_paths.most_common()
     if common_paths[0][1] > 1:
         # log paths generated more than once
-        duplicates = [c[0] for c in common_paths if c[1]>1]
+        duplicates = [c[0] for c in common_paths if c[1] > 1]
         for dup in duplicates:
-                logger.debug(f"Generated path '{dup}' is not unique.")
+            logger.debug(f"Generated path '{dup}' is not unique.")
         raise RuntimeError(
             f"The path specification {path_spec} would result in duplicate links. "
             "See the debug log for the list. The easiest way to fix "

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -168,16 +168,13 @@ def _check_path_function(jobs, path_spec, path_function):
 
     """
     # quick check first
-    job_paths = Counter({job: path_function(job) for job in jobs})
-    if len(set(job_paths.values())) != len(jobs):
-        # report all mismatches
-        links = set()
-        for job in jobs:
-            job_path = job_paths[job]
-            if job_path in links:
-                logger.debug(f"Generated path '{job_path}' is not unique.")
-            else:
-                links.add(job_path)
+    job_paths = Counter((path_function(job) for job in jobs))
+    common_paths = job_paths.most_common()
+    if common_paths[0][1] > 1:
+        # log paths generated more than once
+        duplicates = [c[0] for c in common_paths if c[1]>1]
+        for dup in duplicates:
+                logger.debug(f"Generated path '{dup}' is not unique.")
         raise RuntimeError(
             f"The path specification {path_spec} would result in duplicate links. "
             "See the debug log for the list. The easiest way to fix "

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -194,7 +194,7 @@ def _make_path_function(jobs, path):
             return str(job.id)
 
     elif isinstance(path, str):
-        # Detect keys that are already provided as part of the path specifier and
+        # Detect keys that are already provided as part of the path specifier
         # and should therefore be excluded from the 'auto'-part.
         exclude_keys = [x[1] for x in Formatter().parse(path)]
 
@@ -240,11 +240,16 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(f"Unknown key: {error}")
             except Exception as error:
                 raise _SchemaPathEvaluationError(error)
+        # Check that the user-specified path generates a unique mapping
+        link_check = {j.workspace(): path_function(j) for j in jobs}
+        if len(set(link_check.values())) != len(link_check):
+            print("Error caught inside _make_path_function")
 
     else:
         raise ValueError(
             "The path argument must either be `None`, `False`, or of type `str`."
         )
+
 
     return path_function
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -244,7 +244,7 @@ def _make_path_function(jobs, path):
         link_check = {j.workspace(): path_function(j) for j in jobs}
         if len(set(link_check.values())) != len(link_check):
             raise RuntimeError(
-                "Paths generated with given path function are not 1-1. The easiest "
+                "Links generated with the given path function are not 1-1. The easiest "
                 "way to fix this is to add the job id to the path specification."
             )
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -333,6 +333,10 @@ def _export_jobs(jobs, path, copytree):
     dst : str
         Destination path.
 
+    Raises
+    ------
+    RuntimeError
+        If paths generated with given path function are not unique.
     """
     # Transform the path argument into a callable if necessary.
     if callable(path):

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -240,10 +240,11 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(f"Unknown key: {error}")
             except Exception as error:
                 raise _SchemaPathEvaluationError(error)
-        # Check that the user-specified path generates a unique mapping
+        # Check that the user-specified path generates a 1-1 mapping
         link_check = {j.workspace(): path_function(j) for j in jobs}
         if len(set(link_check.values())) != len(link_check):
-            print("Error caught inside _make_path_function")
+            raise RuntimeError("Paths generated with given path function are not 1-1. The easiest "
+                               "way to fix this is to add the job id to the path specification.")
 
     else:
         raise ValueError(

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -149,13 +149,15 @@ class _SchemaPathEvaluationError(RuntimeError):
     pass
 
 
-def _check_path_function(jobs, path_function):
+def _check_path_function(jobs, path_spec, path_function):
     """Validate that path function specifies a 1-1 mapping.
 
     Parameters
     ----------
     jobs : iterable of :class:`~signac.contrib.job.Job`
         A sequence of jobs (instances of :class:`~signac.contrib.job.Job`).
+    path_spec : str
+        The path string that generated the path_function. Displayed in the error message.
     path_function : callable
         A callable path generating function.
 
@@ -177,7 +179,7 @@ def _check_path_function(jobs, path_function):
             else:
                 links.add(job_path)
         raise RuntimeError(
-            f"The path specification would result in duplicate links. "
+            f"The path specification {path_spec} would result in duplicate links. "
             "See the debug log for the list. The easiest way to fix "
             "this is to append the job id to the path "
             f"specification like '{os.path.join('id', '{job.id}')}'."
@@ -276,7 +278,7 @@ def _make_path_function(jobs, path):
             except Exception as error:
                 raise _SchemaPathEvaluationError(error)
         # Check that the user-specified path generates a 1-1 mapping
-        _check_path_function(jobs, path_function)
+        _check_path_function(jobs, path_spec=path, path_function=path_function)
 
     else:
         raise ValueError(
@@ -335,7 +337,7 @@ def _export_jobs(jobs, path, copytree):
     # Transform the path argument into a callable if necessary.
     if callable(path):
         path_function = path
-        _check_path_function(jobs, path_function)
+        _check_path_function(jobs, path_spec=path, path_function=path_function)
     else:
         path_function = _make_path_function(jobs, path)
         # path_function is checked inside _make_path_function

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -277,6 +277,7 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(f"Unknown key: {error}")
             except Exception as error:
                 raise _SchemaPathEvaluationError(error)
+
         # Check that the user-specified path generates a 1-1 mapping
         _check_path_function(jobs, path_spec=path, path_function=path_function)
 
@@ -284,7 +285,6 @@ def _make_path_function(jobs, path):
         raise ValueError(
             "The path argument must either be `None`, `False`, or of type `str`."
         )
-
 
     return path_function
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -242,7 +242,7 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(error)
         # Check that the user-specified path generates a 1-1 mapping
         links = set()
-        duplicate_links = set() # helps only log once per duplicate
+        duplicate_links = set()  # helps only log once per duplicate
         for job in jobs:
             job_path = path_function(job)
             if job_path not in duplicate_links and job_path in links:
@@ -257,9 +257,7 @@ def _make_path_function(jobs, path):
                 "links. See the debug log for the list. The easiest way to fix "
                 "this is to append the job id to the path specification like '/id/{{job.id}}'."
             )
-        logger.info(
-            f"Path specification {path} uniquely maps workspaces."
-        )
+        logger.info(f"Path specification {path} uniquely maps workspaces.")
 
     else:
         raise ValueError(

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -166,7 +166,7 @@ def _check_path_function(jobs, path_function):
 
     """
     # quick check first
-    links = (set(path_function(job) for job in jobs))
+    links = {path_function(job) for job in jobs}
     if len(links) != len(jobs):
         # report all mismatches
         links = set()

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -258,7 +258,6 @@ def _make_path_function(jobs, path):
                 "links. See the debug log for the list. The easiest way to fix "
                 f"this is to append the job id to the path specification like '{path_correction}'."
             )
-        logger.info(f"Path specification {path} uniquely maps workspaces.")
 
     else:
         raise ValueError(

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -243,8 +243,10 @@ def _make_path_function(jobs, path):
         # Check that the user-specified path generates a 1-1 mapping
         link_check = {j.workspace(): path_function(j) for j in jobs}
         if len(set(link_check.values())) != len(link_check):
-            raise RuntimeError("Paths generated with given path function are not 1-1. The easiest "
-                               "way to fix this is to add the job id to the path specification.")
+            raise RuntimeError(
+                "Paths generated with given path function are not 1-1. The easiest "
+                "way to fix this is to add the job id to the path specification."
+            )
 
     else:
         raise ValueError(

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -169,6 +169,9 @@ def _make_path_function(jobs, path):
     ValueError
         The path argument must either be ``None``, ``False``, or of type ``str``.
 
+    RuntimeError
+        If paths generated with given path function are not unique.
+
     """
     if path is None:
         # Generate a path function based on the schema detected for jobs.

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -149,7 +149,7 @@ class _SchemaPathEvaluationError(RuntimeError):
     pass
 
 
-def _check_path_function(jobs, path_spec, path_function):
+def _check_path_function_unique(jobs, path_spec, path_function):
     """Validate that path function specifies a 1-1 mapping.
 
     Parameters
@@ -275,7 +275,7 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(error)
 
         # Check that the user-specified path generates a 1-1 mapping
-        _check_path_function(jobs, path_spec=path, path_function=path_function)
+        _check_path_function_unique(jobs, path_spec=path, path_function=path_function)
 
     else:
         raise ValueError(
@@ -337,7 +337,7 @@ def _export_jobs(jobs, path, copytree):
     # Transform the path argument into a callable if necessary.
     if callable(path):
         path_function = path
-        _check_path_function(jobs, path_spec=path, path_function=path_function)
+        _check_path_function_unique(jobs, path_spec=path, path_function=path_function)
     else:
         path_function = _make_path_function(jobs, path)
         # path_function is checked inside _make_path_function

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import tarfile
 import zipfile
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from contextlib import closing, contextmanager
 from string import Formatter
 from tempfile import TemporaryDirectory
@@ -168,12 +168,12 @@ def _check_path_function(jobs, path_spec, path_function):
 
     """
     # quick check first
-    links = {path_function(job) for job in jobs}
-    if len(links) != len(jobs):
+    job_paths = Counter({job: path_function(job) for job in jobs})
+    if len(set(job_paths.values())) != len(jobs):
         # report all mismatches
         links = set()
         for job in jobs:
-            job_path = path_function(job)
+            job_path = job_paths[job]
             if job_path in links:
                 logger.debug(f"Generated path '{job_path}' is not unique.")
             else:

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -341,7 +341,7 @@ def _export_jobs(jobs, path, copytree):
         _check_path_function_unique(jobs, path_spec=path, path_function=path_function)
     else:
         path_function = _make_path_function(jobs, path)
-        # path_function is checked inside _make_path_function
+        # path_function is checked for uniqueness inside _make_path_function
 
     # Determine export path for each job.
     paths = {job.workspace(): path_function(job) for job in jobs}

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -182,7 +182,7 @@ def _check_path_function(jobs, path_spec, path_function):
             f"The path specification {path_spec} would result in duplicate links. "
             "See the debug log for the list. The easiest way to fix "
             "this is to append the job id to the path "
-            f"specification like '{os.path.join('id', '{job.id}')}'."
+            f"specification like '{os.path.join(str(path_spec), 'id', '{job.id}')}'."
         )
 
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -245,21 +245,18 @@ def _make_path_function(jobs, path):
                 raise _SchemaPathEvaluationError(error)
         # Check that the user-specified path generates a 1-1 mapping
         links = set()
-        duplicate_links = set()  # helps only log once per duplicate
         for job in jobs:
             job_path = path_function(job)
-            if job_path not in duplicate_links and job_path in links:
+            if job_path in links:
                 logger.debug(f"Generated path '{job_path}' is not unique.")
-                duplicate_links.add(job_path)
             else:
                 links.add(job_path)
-        num_dups = len(duplicate_links)
-        if num_dups > 0:
-            path_correction = os.path.join("id", "{job.id}")
+        if len(links) != len(jobs)
             raise RuntimeError(
-                f"The path specification '{path}' would result in {num_dups} duplicate "
-                "links. See the debug log for the list. The easiest way to fix "
-                f"this is to append the job id to the path specification like '{path_correction}'."
+                f"The path specification '{path}' would result in duplicate links."
+                "See the debug log for the list. The easiest way to fix "
+                "this is to append the job id to the path "
+                f"specification like '{os.path.join("id", "{job.id}")}'."
             )
 
     else:

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -252,10 +252,11 @@ def _make_path_function(jobs, path):
                 links.add(job_path)
         num_dups = len(duplicate_links)
         if num_dups > 0:
+            path_correction = os.path.join("id", "{job.id}")
             raise RuntimeError(
                 f"The path specification '{path}' would result in {num_dups} duplicate "
                 "links. See the debug log for the list. The easiest way to fix "
-                "this is to append the job id to the path specification like '/id/{{job.id}}'."
+                f"this is to append the job id to the path specification like '{path_correction}'."
             )
         logger.info(f"Path specification {path} uniquely maps workspaces.")
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -157,29 +157,28 @@ def _check_path_function(jobs, path_spec, path_function):
     jobs : iterable of :class:`~signac.contrib.job.Job`
         A sequence of jobs (instances of :class:`~signac.contrib.job.Job`).
     path_spec : str
-        The path string that generated the path_function. Displayed in the error message.
+        The path string that generated the path_function. Displayed in the
+        error message.
     path_function : callable
         A callable path generating function.
 
     Raises
-    -----
+    ------
     RuntimeError
         If paths generated with given path function are not unique.
 
     """
-    # quick check first
     job_paths = Counter(path_function(job) for job in jobs)
-    common_paths = job_paths.most_common()
-    if common_paths[0][1] > 1:
-        # log paths generated more than once
-        duplicates = [c[0] for c in common_paths if c[1] > 1]
-        for dup in duplicates:
-            logger.debug(f"Generated path '{dup}' is not unique.")
+    duplicates = {path for path, count in job_paths if count > 1}
+    if len(duplicates) > 0:
+        # Log paths generated more than once
+        for path in duplicates:
+            logger.debug(f"Generated path '{path}' is not unique.")
         raise RuntimeError(
             f"The path specification {path_spec} would result in duplicate links. "
-            "See the debug log for the list. The easiest way to fix "
-            "this is to append the job id to the path "
-            f"specification like '{os.path.join(str(path_spec), 'id', '{job.id}')}'."
+            "See the debug log for the list. The easiest way to fix this is "
+            "to append the job id to the path specification like "
+            f"'{os.path.join(str(path_spec), 'id', '{job.id}')}'."
         )
 
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -165,19 +165,22 @@ def _check_path_function(jobs, path_function):
         If paths generated with given path function are not unique.
 
     """
-    links = set()
-    for job in jobs:
-        job_path = path_function(job)
-        if job_path in links:
-            logger.debug(f"Generated path '{job_path}' is not unique.")
-        else:
-            links.add(job_path)
-    if len(links) != len(jobs)
+    # quick check first
+    links = (set(path_function(job) for job in jobs))
+    if len(links) != len(jobs):
+        # report all mismatches
+        links = set()
+        for job in jobs:
+            job_path = path_function(job)
+            if job_path in links:
+                logger.debug(f"Generated path '{job_path}' is not unique.")
+            else:
+                links.add(job_path)
         raise RuntimeError(
-            f"The path specification '{path}' would result in duplicate links."
+            f"The path specification would result in duplicate links. "
             "See the debug log for the list. The easiest way to fix "
             "this is to append the job id to the path "
-            f"specification like '{os.path.join("id", "{job.id}")}'."
+            f"specification like '{os.path.join('id', '{job.id}')}'."
         )
 
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -252,7 +252,7 @@ def _make_path_function(jobs, path):
                 links.add(job_path)
         num_dups = len(duplicate_links)
         if num_dups > 0:
-            raise ValueError(
+            raise RuntimeError(
                 f"The path specification '{path}' would result in {num_dups} duplicate "
                 "links. See the debug log for the list. The easiest way to fix "
                 "this is to append the job id to the path specification like '/id/{{job.id}}'."

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -99,9 +99,14 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
         raise RuntimeError(err_msg)
 
     path_function = _make_path_function(jobs, path)
+
     links = {job.workspace(): path_function(job) for job in jobs}
     _check_directory_structure_validity(links.values())
-    _update_view(prefix, links)
+
+    # invert the dictionary
+    to_update = {links[k]: k for k in links}
+
+    _update_view(prefix, to_update)
 
     return links
 

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -100,13 +100,16 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
 
     path_function = _make_path_function(jobs, path)
 
-    links = {job.workspace(): path_function(job) for job in jobs}
-    _check_directory_structure_validity(links.values())
-
-    # invert the dictionary
-    to_update = {links[k]: k for k in links}
-
-    _update_view(prefix, to_update)
+    links = {}
+    for job in jobs:
+        paths = os.path.join(path_function(job), "job")
+        links[paths] = job.workspace()
+    if not links:  # data space contains less than two elements
+        for job in project.find_jobs():
+            links["./job"] = job.workspace()
+        assert len(links) < 2
+    _check_directory_structure_validity(links.keys())
+    _update_view(prefix, links)
 
     return links
 

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -99,26 +99,11 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
         raise RuntimeError(err_msg)
 
     path_function = _make_path_function(jobs, path)
-    incomplete_links = {}
-    for job in jobs:
-        paths = os.path.join(path_function(job), "job")
-        incomplete_links[paths] = job.workspace()
-
     links = {job.workspace(): path_function(job) for job in jobs}
-    # Check whether the paths are unique
-    if len(set(links.values())) != len(links):
-        print("Paths generated with given path function are not unique. Caught in linked_view.py")
-        #raise RuntimeError("Paths generated with given path function are not unique.")
-
-    if not incomplete_links:  # data space contains less than two elements
-        for job in project.find_jobs():
-            incomplete_links["./job"] = job.workspace()
-        assert len(incomplete_links) < 2
-    _check_directory_structure_validity(incomplete_links.keys())
     _check_directory_structure_validity(links.values())
+    _update_view(prefix, links)
 
-    _update_view(prefix, incomplete_links)
-    return links #incomplete_links
+    return links
 
 
 def _update_view(prefix, links, leaf="job"):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2006,7 +2006,7 @@ class TestLinkedViewProject(TestProjectBase):
         # Should error if user-provided path doesn't make 1-1 mapping
         with pytest.raises(RuntimeError):
             self.project.create_linked_view(
-                prefix=view_prefix, path=os.path.join("a","{a}")
+                prefix=view_prefix, path=os.path.join("a", "{a}")
             )
 
         self.project.create_linked_view(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2236,6 +2236,23 @@ class TestLinkedViewProject(TestProjectBase):
             with pytest.raises(RuntimeError):
                 self.project.create_linked_view(prefix=view_prefix)
 
+    @pytest.mark.skipif(WINDOWS, reason="Linked views unsupported on Windows.")
+    def test_create_linked_view_duplicate_paths(self):
+        view_prefix = os.path.join(self._tmp_pr, "view")
+        a_vals = range(2)
+        b_vals = range(3, 8)
+        for a in a_vals:
+            for b in b_vals:
+                sp = {"a": a, "b": b}
+                self.project.open_job(sp).init()
+
+        # An error should be raised if the user-provided path function doesn't
+        # make a 1-1 mapping.
+        with pytest.raises(RuntimeError):
+            self.project.create_linked_view(
+                prefix=view_prefix, path=os.path.join("a", "{a}")
+            )
+
 
 class UpdateCacheAfterInitJob(signac.contrib.job.Job):
     def init(self, *args, **kwargs):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2003,6 +2003,12 @@ class TestLinkedViewProject(TestProjectBase):
                     sp = {"a": a, "d": {"b": b, "c": c}}
                     self.project.open_job(sp).init()
 
+        # Should error if user-provided path doesn't make 1-1 mapping
+        with pytest.raises(RuntimeError):
+            self.project.create_linked_view(
+                prefix=view_prefix, path=os.path.join("a","{a}")
+            )
+
         self.project.create_linked_view(
             prefix=view_prefix, path="a/{a}/d.c/{d.c}/{{auto}}"
         )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -237,6 +237,19 @@ class TestBasicShell:
                 "view/a/{}/job".format(sp["a"])
             ) == os.path.realpath(project.open_job(sp).workspace())
 
+    @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
+    def test_view_incomplete_path_spec(self):
+        self.call("python -m signac init my_project".split())
+        project = signac.Project()
+        sps = [{"a": i} for i in range(3)]
+        for sp in sps:
+            project.open_job(sp).init()
+        os.mkdir("view")
+
+        # Should error if user-provided path doesn't make 1-1 mapping
+        err = self.call("python -m signac view non_unique".split(), error=True)
+        assert "duplicate links" in err
+
     def test_find(self):
         self.call("python -m signac init my_project".split())
         project = signac.Project()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -246,7 +246,8 @@ class TestBasicShell:
             project.open_job(sp).init()
         os.mkdir("view")
 
-        # Should error if user-provided path doesn't make 1-1 mapping
+        # An error should be raised if the user-provided path function
+        # doesn't make a 1-1 mapping.
         err = self.call(
             "python -m signac view view non_unique".split(),
             error=True,

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -252,7 +252,7 @@ class TestBasicShell:
             error=True,
             raise_error=False,
         )
-        assert "duplicate links" in err
+        assert "duplicate paths" in err
 
     def test_find(self):
         self.call("python -m signac init my_project".split())

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -247,7 +247,11 @@ class TestBasicShell:
         os.mkdir("view")
 
         # Should error if user-provided path doesn't make 1-1 mapping
-        err = self.call("python -m signac view non_unique".split(), error=True)
+        err = self.call(
+            "python -m signac view view non_unique".split(),
+            error=True,
+            raise_error=False,
+        )
         assert "duplicate links" in err
 
     def test_find(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

Just the bug fix.

There is some duplicate code, but that will be refactored in the rest of #642.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

see #642 for a description

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
