### PR TITLE
Improve test coverage of Collection class's find methods.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ Fixed
 
  - ``H5Store.mode`` returns the file mode (#607).
  - User-provided path functions now raise an error if not unique (#666).
+ - ``Collection`` class no longer raises an error when searching by a primary key that does not exist (#676).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/signac/contrib/collection.py
+++ b/signac/contrib/collection.py
@@ -796,7 +796,8 @@ class Collection:
             When Bad operator expression/ Bad operator placement or
             the expression-operator is unknown.
         ValueError
-            The value is not bool when operator for '$exists' operator.
+            The value is not bool for '$exists' operator or not a
+            supported type for '$type' operator.
 
         """
         logger.debug(f"Find documents for expression '{key}: {value}'.")
@@ -876,8 +877,8 @@ class Collection:
         # Check if filter contains primary key, in which case we can
         # immediately reduce the result.
         _id = expr.pop(self._primary_key, None)
-        if _id is not None and _id in self:
-            reduce_results({_id})
+        if _id is not None:
+            reduce_results({_id} if _id in self else set())
 
         # Extract all logical-operator expressions for now.
         or_expressions = expr.pop("$or", None)
@@ -1049,7 +1050,7 @@ class Collection:
 
                     .. code-block:: python
 
-                        project.find({"protocol": {"$type": str}})
+                        project.find({"protocol": {"$type": "str"}})
 
             Finds all docs, where the value of protocol is of type str.
             Other types that can be checked are: *int*, *float*, *bool*, *list*, and *null*.


### PR DESCRIPTION
## Description
While working on removing internal usage of the `Collection` class in #667 for signac 2.0, I wanted to improve the test coverage for the `Collection` class's find methods to ensure that the new code in signac 2.0 does not introduce bugs/regressions.

I fixed one bug when searching by the primary key (an `AssertionError` was raised unexpectedly when searching for an id that did not exist, when the result should just be an empty set). Additionally, I expanded test coverage of several other features relating to search operators like `$and` and `$type`. I also fixed some mistakes/omissions in the class documentation.

## Motivation and Context
These tests will be used to improve #667 and ensure that we have greater coverage of our `find` API in the smaller Collection-like class in that PR.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.