### PR TITLE
Remove user-provided project name from API

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -342,14 +342,7 @@ def main_view(args):
 
 def main_init(args):
     """Handle init subcommand."""
-    if args.project_id is not None:
-        warnings.warn(
-            "Project names were removed in signac 2.0. If your project name "
-            "contains important information, consider storing it in the project document "
-            "instead.",
-            FutureWarning,
-        )
-    init_project(root=os.getcwd(), workspace=args.workspace)
+    init_project(name=args.project_id, root=os.getcwd(), workspace=args.workspace)
     _print_err("Initialized project.")
 
 
@@ -944,7 +937,7 @@ def main():
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser("init")
-    parser_init.add_argument("project_id", nargs="?")
+    parser_init.add_argument("project_id", nargs="?", help=argparse.SUPPRESS)
     parser_init.add_argument(
         "-w",
         "--workspace",

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -342,10 +342,15 @@ def main_view(args):
 
 def main_init(args):
     """Handle init subcommand."""
-    project = init_project(
-        name=args.project_id, root=os.getcwd(), workspace=args.workspace
-    )
-    _print_err(f"Initialized project '{project}'.")
+    if args.project_id is not None:
+        warnings.warn(
+            "Project names were removed in signac 2.0. If your project name "
+            "contains important information, consider storing it in the project document "
+            "instead.",
+            FutureWarning,
+        )
+    init_project(root=os.getcwd(), workspace=args.workspace)
+    _print_err("Initialized project.")
 
 
 def main_schema(args):
@@ -939,9 +944,7 @@ def main():
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser("init")
-    parser_init.add_argument(
-        "project_id", type=str, help="Initialize a project with the given project id."
-    )
+    parser_init.add_argument("project_id", nargs="?")
     parser_init.add_argument(
         "-w",
         "--workspace",

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1545,7 +1545,7 @@ class Project:
                     f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
             if name is not None:
-                assert version.parse(__version__).major < 3
+                assert version.parse(__version__).release[0] < 3
                 warnings.warn(
                     "Project names were removed in signac 2.0. If your project name contains "
                     "important information, consider storing it in the project document instead.",

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1518,8 +1518,11 @@ class Project:
             configuration.
 
         """
+        # TODO: Remove both the `if args` and `if kwargs` blocks in version 3.0
+        # when we remove backwards compatibility for project name APIs.
         if args:
-            if len(args) == 1:
+            num_args = len(args)
+            if num_args == 1:
                 warnings.warn(
                     "Project names were removed in signac 2.0. If you intended to call "
                     "`init_project` with a root directory, please provided it as a keyword "
@@ -1530,22 +1533,22 @@ class Project:
                 )
             else:
                 # Match the usual error from misusing keyword-only args.
-                num_args = len(args)
                 raise TypeError(
                     f"init_project() takes 0 positional arguments but {num_args} "
-                    f"{'was' if num_args == 1 else 'were'} given"
+                    f"were given"
                 )
         if kwargs:
-            if len(kwargs) == 1 and "name" in kwargs:
+            name = kwargs.pop("name", None)
+            if kwargs:
+                # Match the usual error from extra keyword args.
+                raise TypeError(
+                    f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
+                )
+            if name is not None:
                 warnings.warn(
                     "Project names were removed in signac 2.0. If your project name contains "
                     "important information, consider storing it in the project document instead.",
                     FutureWarning,
-                )
-            else:
-                # Match the usual error from extra keyword args.
-                raise TypeError(
-                    f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
 
         if root is None:
@@ -2167,37 +2170,9 @@ def init_project(*args, root=None, workspace=None, make_dir=True, **kwargs):
         configuration.
 
     """
-    if args:
-        if len(args) == 1:
-            warnings.warn(
-                "Project names were removed in signac 2.0. If you intended to call "
-                "`init_project` with a root directory, please provided it as a keyword "
-                f"argument: `init_project(root={args[0]})`. If your project name "
-                "contains important information, consider storing it in the project document "
-                "instead.",
-                FutureWarning,
-            )
-        else:
-            # Match the usual error from misusing keyword-only args.
-            num_args = len(args)
-            raise TypeError(
-                f"init_project() takes 0 positional arguments but {num_args} "
-                "{'was' if num_args == 1 else 'were'} given"
-            )
-    if kwargs:
-        if len(kwargs) == 1 and "name" in kwargs:
-            warnings.warn(
-                "Project names were removed in signac 2.0. If your project name contains "
-                "important information, consider storing it in the project document instead.",
-                FutureWarning,
-            )
-        else:
-            # Match the usual error from extra keyword args.
-            raise TypeError(
-                f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
-            )
-
-    return Project.init_project(root=root, workspace=workspace, make_dir=make_dir)
+    return Project.init_project(
+        *args, root=root, workspace=workspace, make_dir=make_dir, **kwargs
+    )
 
 
 def get_project(root=None, search=True, **kwargs):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1485,7 +1485,7 @@ class Project:
 
     @classmethod
     def init_project(cls, *args, root=None, workspace=None, make_dir=True, **kwargs):
-        """Initialize a project at the provided root directory.
+        """Initialize a project in the provided root directory.
 
         It is safe to call this function multiple times with the same
         arguments. However, a `RuntimeError` is raised if an existing project
@@ -1545,6 +1545,7 @@ class Project:
                     f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
             if name is not None:
+                assert version.parse(__version__).major < 3
                 warnings.warn(
                     "Project names were removed in signac 2.0. If your project name contains "
                     "important information, consider storing it in the project document instead.",

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1564,7 +1564,6 @@ class Project:
                     f"project document in which {name_key}={existing_name}."
                 )
         except LookupError:
-            name = name or "project"
             fn_config = os.path.join(root, "signac.rc")
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
@@ -1575,7 +1574,7 @@ class Project:
             config["schema_version"] = SCHEMA_VERSION
             config.write()
             project = cls.get_project(root=root)
-            if name != "project":
+            if name is not None:
                 project.doc[name_key] = name
             assert project.id == str(name)
             return project

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1545,7 +1545,7 @@ class Project:
                     f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
             if name is not None:
-                assert int(version.parse(__version__).public.split(".")[0]) < 3
+                assert version.parse(__version__) < version.parse("3.0.0")
                 warnings.warn(
                     "Project names were removed in signac 2.0. If your project name contains "
                     "important information, consider storing it in the project document instead.",

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1547,13 +1547,13 @@ class Project:
                 raise TypeError(
                     f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
-        name = "project"
 
         if root is None:
             root = os.getcwd()
         try:
             project = cls.get_project(root=root, search=False)
         except LookupError:
+            name = "project"
             fn_config = os.path.join(root, "signac.rc")
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
@@ -1567,15 +1567,12 @@ class Project:
             assert project.id == str(name)
             return project
         else:
-            if project.id != str(name) or (
-                workspace is not None
-                and os.path.realpath(workspace) != os.path.realpath(project.workspace())
-            ):
+            if workspace is not None and os.path.realpath(
+                workspace
+            ) != os.path.realpath(project.workspace()):
                 raise RuntimeError(
-                    "Failed to initialize project. Path '{}' already "
-                    "contains a conflicting project configuration.".format(
-                        os.path.abspath(root)
-                    )
+                    f"Failed to initialize project. Path '{os.path.abspath(root)}' already "
+                    "contains a conflicting project configuration."
                 )
             return project
 

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1545,7 +1545,7 @@ class Project:
                     f"init_project() got an unexpected keyword argument '{next(iter(kwargs))}'"
                 )
             if name is not None:
-                assert version.parse(__version__).release[0] < 3
+                assert int(version.parse(__version__).public.split(".")[0]) < 3
                 warnings.warn(
                     "Project names were removed in signac 2.0. If your project name contains "
                     "important information, consider storing it in the project document instead.",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -16,9 +16,7 @@ class TestDiffBase:
     def setUp(self, request):
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
-        self.project = self.project_class.init_project(
-            name="diff_test_project", root=self._tmp_dir.name
-        )
+        self.project = self.project_class.init_project(root=self._tmp_dir.name)
 
 
 class TestDiff(TestDiffBase):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -74,7 +74,7 @@ class TestJobBase:
         os.mkdir(self._tmp_pr)
         self.config = signac.common.config.load_config()
         self.project = self.project_class.init_project(
-            name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
+            root=self._tmp_pr, workspace=self._tmp_wd
         )
 
     def tearDown(self):
@@ -1349,7 +1349,7 @@ class TestJobOpenData(TestJobBase):
         job = self.open_job(test_token).init()
         project_a = self.project
         project_b = self.project_class.init_project(
-            name="project_b", root=os.path.join(self._tmp_pr, "project_b")
+            root=os.path.join(self._tmp_pr, "project_b")
         )
         job.move(project_b)
         job.move(project_a)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -113,7 +113,6 @@ class TestProject(TestProjectBase):
             with TemporaryDirectory() as tmp_dir:
                 os.environ["SIGNAC_ENV_DIR_TEST"] = os.path.join(tmp_dir, "work_here")
                 project = self.project_class.init_project(
-                    name="testing_test_project",
                     root=tmp_dir,
                     workspace="${SIGNAC_ENV_DIR_TEST}",
                 )
@@ -218,16 +217,12 @@ class TestProject(TestProjectBase):
 
         with TemporaryDirectory() as tmp_dir:
             abs_path = os.path.join(tmp_dir, "path", "to", "workspace")
-            project = self.project_class.init_project(
-                name="testing_test_project", root=tmp_dir, workspace=abs_path
-            )
+            project = self.project_class.init_project(root=tmp_dir, workspace=abs_path)
             assert project.workspace() == norm_path(abs_path)
 
         with TemporaryDirectory() as tmp_dir:
             rel_path = norm_path(os.path.join("path", "to", "workspace"))
-            project = self.project_class.init_project(
-                name="testing_test_project", root=tmp_dir, workspace=rel_path
-            )
+            project = self.project_class.init_project(root=tmp_dir, workspace=rel_path)
             assert project.workspace() == norm_path(
                 os.path.join(project.root_directory(), rel_path)
             )
@@ -247,7 +242,7 @@ class TestProject(TestProjectBase):
     def test_workspace_broken_link_error_on_find(self):
         with TemporaryDirectory() as tmp_dir:
             project = self.project_class.init_project(
-                name="testing_test_project", root=tmp_dir, workspace="workspace-link"
+                root=tmp_dir, workspace="workspace-link"
             )
             os.rmdir(os.path.join(tmp_dir, "workspace-link"))
             os.symlink(
@@ -715,8 +710,8 @@ class TestProject(TestProjectBase):
 
     def test_job_move(self):
         root = self._tmp_dir.name
-        project_a = signac.init_project("ProjectA", root=os.path.join(root, "a"))
-        project_b = signac.init_project("ProjectB", root=os.path.join(root, "b"))
+        project_a = signac.init_project(root=os.path.join(root, "a"))
+        project_b = signac.init_project(root=os.path.join(root, "b"))
         job = project_a.open_job(dict(a=0))
         job_b = project_b.open_job(dict(a=0))
         assert job != job_b
@@ -744,8 +739,8 @@ class TestProject(TestProjectBase):
 
     def test_job_clone(self):
         root = self._tmp_dir.name
-        project_a = signac.init_project("ProjectA", root=os.path.join(root, "a"))
-        project_b = signac.init_project("ProjectB", root=os.path.join(root, "b"))
+        project_a = signac.init_project(root=os.path.join(root, "a"))
+        project_b = signac.init_project(root=os.path.join(root, "b"))
         job_a = project_a.open_job(dict(a=0))
         assert job_a not in project_a
         assert job_a not in project_b
@@ -2221,10 +2216,10 @@ class TestProjectInit:
         root = self._tmp_dir.name
         with pytest.raises(LookupError):
             signac.get_project(root=root)
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         assert project.workspace() == os.path.join(root, "workspace")
         assert project.root_directory() == root
-        project = signac.Project.init_project(name="testproject", root=root)
+        project = signac.Project.init_project(root=root)
         assert project.workspace() == os.path.join(root, "workspace")
         assert project.root_directory() == root
         project = signac.get_project(root=root)
@@ -2236,7 +2231,7 @@ class TestProjectInit:
 
     def test_project_no_id(self):
         root = self._tmp_dir.name
-        signac.init_project(name="testproject", root=root)
+        signac.init_project(root=root)
         config = load_config(root)
         del config["project"]
         with pytest.raises(LookupError):
@@ -2246,7 +2241,7 @@ class TestProjectInit:
         root = self._tmp_dir.name
         subdir = os.path.join(root, "subdir")
         os.mkdir(subdir)
-        project = signac.init_project(root=root, name="testproject")
+        project = signac.init_project(root=root)
         assert project == project.get_project(root=root)
         assert project == signac.get_project(root=root)
         assert project == project.get_project(root=root, search=False)
@@ -2264,11 +2259,11 @@ class TestProjectInit:
         root = self._tmp_dir.name
         with pytest.raises(LookupError):
             signac.get_project(root=root)
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         assert project.workspace() == os.path.join(root, "workspace")
         assert project.root_directory() == root
         # Second initialization should not make any difference.
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         project = signac.get_project(root=root)
         assert project.workspace() == os.path.join(root, "workspace")
         assert project.root_directory() == root
@@ -2277,7 +2272,7 @@ class TestProjectInit:
         assert project.root_directory() == root
         # Deviating initialization parameters should result in errors.
         with pytest.raises(RuntimeError):
-            signac.init_project(name="testproject", root=root, workspace="workspace2")
+            signac.init_project(root=root, workspace="workspace2")
 
     def test_nested_project(self):
         def check_root(root=None):
@@ -2290,9 +2285,9 @@ class TestProjectInit:
         root = self._tmp_dir.name
         root_a = os.path.join(root, "project_a")
         root_b = os.path.join(root_a, "project_b")
-        signac.init_project("testprojectA", root=root_a)
+        signac.init_project(root=root_a)
         check_root(root_a)
-        signac.init_project("testprojectB", root=root_b)
+        signac.init_project(root=root_b)
         check_root(root_b)
         cwd = os.getcwd()
         try:
@@ -2309,7 +2304,7 @@ class TestProjectInit:
     def test_get_job_valid_workspace(self):
         # Test case: The root-path is the job workspace path.
         root = self._tmp_dir.name
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         job = project.open_job({"a": 1})
         job.init()
         with job:
@@ -2320,7 +2315,7 @@ class TestProjectInit:
     def test_get_job_invalid_workspace(self):
         # Test case: The root-path is not the job workspace path.
         root = self._tmp_dir.name
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         job = project.open_job({"a": 1})
         job.init()
         # We shouldn't be able to find a job while in the workspace directory,
@@ -2338,11 +2333,11 @@ class TestProjectInit:
     def test_get_job_nested_project(self):
         # Test case: The job workspace dir is also a project root dir.
         root = self._tmp_dir.name
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         job = project.open_job({"a": 1})
         job.init()
         with job:
-            nestedproject = signac.init_project("nestedproject")
+            nestedproject = signac.init_project()
             nestedproject.open_job({"b": 2}).init()
             assert project.get_job() == job
             assert signac.get_job() == job
@@ -2350,7 +2345,7 @@ class TestProjectInit:
     def test_get_job_subdir(self):
         # Test case: Get a job from a sub-directory of the job workspace dir.
         root = self._tmp_dir.name
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         job = project.open_job({"a": 1})
         job.init()
         with job:
@@ -2364,11 +2359,11 @@ class TestProjectInit:
         # Test case: Get a job from a sub-directory of the job workspace dir
         # when the job workspace is also a project root dir
         root = self._tmp_dir.name
-        project = signac.init_project(name="testproject", root=root)
+        project = signac.init_project(root=root)
         job = project.open_job({"a": 1})
         job.init()
         with job:
-            nestedproject = signac.init_project("nestedproject")
+            nestedproject = signac.init_project()
             nestedproject.open_job({"b": 2}).init()
             os.mkdir("test_subdir")
             assert project.get_job("test_subdir") == job
@@ -2384,8 +2379,8 @@ class TestProjectInit:
         project_b_dir = os.path.join(root, "project_b")
         os.mkdir(project_a_dir)
         os.mkdir(project_b_dir)
-        project_a = signac.init_project(name="project_a", root=project_a_dir)
-        project_b = signac.init_project(name="project_b", root=project_b_dir)
+        project_a = signac.init_project(root=project_a_dir)
+        project_b = signac.init_project(root=project_b_dir)
         job_a = project_a.open_job({"a": 1})
         job_a.init()
         job_b = project_b.open_job({"b": 1})
@@ -2410,9 +2405,7 @@ class TestProjectSchema(TestProjectBase):
         config["schema_version"] = impossibly_high_schema_version
         config.write()
         with pytest.raises(IncompatibleSchemaVersion):
-            signac.init_project(
-                name=str(self.project), root=self.project.root_directory()
-            )
+            signac.init_project(root=self.project.root_directory())
 
         # Ensure that migration fails on an unsupported version.
         with pytest.raises(RuntimeError):
@@ -2512,7 +2505,7 @@ class TestProjectStoreBase(test_h5store.TestH5StoreBase):
         os.mkdir(self._tmp_pr)
         self.config = load_config()
         self.project = self.project_class.init_project(
-            name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
+            root=self._tmp_pr, workspace=self._tmp_wd
         )
 
         self._fn_store = os.path.join(self._tmp_dir.name, "signac_data.h5")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1047,21 +1047,21 @@ class TestProjectNameDeprecations:
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
-        assert version.parse(signac.__version__).major < 3
+        assert version.parse(signac.__version__).release[0] < 3
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
         ):
             signac.init_project("project", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
-        assert version.parse(signac.__version__).major < 3
+        assert version.parse(signac.__version__).release[0] < 3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
-        assert version.parse(signac.__version__).major < 3
+        assert version.parse(signac.__version__).release[0] < 3
         os.chdir(self._tmp_dir.name)
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
@@ -1069,7 +1069,7 @@ class TestProjectNameDeprecations:
             signac.init_project(name="project")
 
     def test_name_with_other_args_keyword(self):
-        assert version.parse(signac.__version__).major < 3
+        assert version.parse(signac.__version__).release[0] < 3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1042,7 +1042,8 @@ class TestProject(TestProjectBase):
 
 
 # Use the major version to fail tests expected to fail in 3.0.
-_MAJOR_VERSION = int(version.parse(signac.__version__).public.split(".")[0])
+_MAJOR_VERSION = version.parse(signac.__version__)
+_VERSION_3 = version.parse("3.0.0")
 
 
 class TestProjectNameDeprecations:
@@ -1051,21 +1052,21 @@ class TestProjectNameDeprecations:
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
-        assert _MAJOR_VERSION < 3
+        assert _MAJOR_VERSION < _VERSION_3
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
         ):
             signac.init_project("project", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
-        assert _MAJOR_VERSION < 3
+        assert _MAJOR_VERSION < _VERSION_3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
-        assert _MAJOR_VERSION < 3
+        assert _MAJOR_VERSION < _VERSION_3
         os.chdir(self._tmp_dir.name)
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
@@ -1073,7 +1074,7 @@ class TestProjectNameDeprecations:
             signac.init_project(name="project")
 
     def test_name_with_other_args_keyword(self):
-        assert _MAJOR_VERSION < 3
+        assert _MAJOR_VERSION < _VERSION_3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1041,6 +1041,35 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(tmp_root_dir)
 
 
+class TestProjectNameDeprecations:
+    @pytest.fixture(autouse=True)
+    def setUp(self, request):
+        self._tmp_dir = TemporaryDirectory()
+
+    def test_name_only_positional(self):
+        with pytest.warns(
+            FutureWarning, match="Project names were removed in signac 2.0"
+        ):
+            signac.init_project("project", root=self._tmp_dir.name)
+
+    def test_name_with_other_args_positional(self):
+        with pytest.raises(
+            TypeError, match="takes 0 positional arguments but 2 were given"
+        ):
+            signac.init_project("project", self._tmp_dir.name)
+
+    def test_name_only_keyword(self):
+        os.chdir(self._tmp_dir.name)
+        with pytest.warns(
+            FutureWarning, match="Project names were removed in signac 2.0"
+        ):
+            signac.init_project(name="project")
+
+    def test_name_with_other_args_keyword(self):
+        with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
+            signac.init_project(name="project", foo="bar")
+
+
 class TestProjectExportImport(TestProjectBase):
     def test_export(self):
         prefix_data = os.path.join(self._tmp_dir.name, "data")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1047,18 +1047,21 @@ class TestProjectNameDeprecations:
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
+        assert version.parse(signac.__version__).major < 3
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
         ):
             signac.init_project("project", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
+        assert version.parse(signac.__version__).major < 3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
+        assert version.parse(signac.__version__).major < 3
         os.chdir(self._tmp_dir.name)
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
@@ -1066,6 +1069,7 @@ class TestProjectNameDeprecations:
             signac.init_project(name="project")
 
     def test_name_with_other_args_keyword(self):
+        assert version.parse(signac.__version__).major < 3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1041,27 +1041,31 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(tmp_root_dir)
 
 
+# Use the major version to fail tests expected to fail in 3.0.
+_MAJOR_VERSION = int(version.parse(signac.__version__).public.split(".")[0])
+
+
 class TestProjectNameDeprecations:
     @pytest.fixture(autouse=True)
     def setUp(self, request):
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
-        assert version.parse(signac.__version__).release[0] < 3
+        assert _MAJOR_VERSION < 3
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
         ):
             signac.init_project("project", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
-        assert version.parse(signac.__version__).release[0] < 3
+        assert _MAJOR_VERSION < 3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
-        assert version.parse(signac.__version__).release[0] < 3
+        assert _MAJOR_VERSION < 3
         os.chdir(self._tmp_dir.name)
         with pytest.warns(
             FutureWarning, match="Project names were removed in signac 2.0"
@@ -1069,7 +1073,7 @@ class TestProjectNameDeprecations:
             signac.init_project(name="project")
 
     def test_name_with_other_args_keyword(self):
-        assert version.parse(signac.__version__).release[0] < 3
+        assert _MAJOR_VERSION < 3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1670,7 +1670,6 @@ class TestProjectRepresentation(TestProjectBase):
     def test_project_repr_methods(self, project_generator, num_jobs):
         project_generator(self.project, num_jobs)
         assert len(str(self.project)) > 0
-        assert "project" in str(self.project)
         assert len(repr(self.project)) > 0
         assert eval(repr(self.project)) == self.project
         for use_pandas in (True, False):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -92,22 +92,10 @@ class TestBasicShell:
 
     def test_init_project(self):
         self.call("python -m signac init my_project".split())
-        assert str(signac.get_project()) == "my_project"
-
-    def test_init_project_in_project_root(self):
-        self.call("python -m signac init my_project".split())
-        assert str(signac.get_project()) == "my_project"
-        with pytest.raises(ExitCodeError):
-            self.call("python -m signac init second_project".split())
-
-    def test_project_id(self):
-        self.call("python -m signac init my_project".split())
-        assert str(signac.get_project()) == "my_project"
-        assert self.call("python -m signac project".split()).strip() == "my_project"
+        assert signac.get_project().root_directory() == os.getcwd()
 
     def test_project_workspace(self):
         self.call("python -m signac init my_project".split())
-        assert str(signac.get_project()) == "my_project"
         assert os.path.realpath(
             self.call("python -m signac project --workspace".split()).strip()
         ) == os.path.realpath(os.path.join(self.tmpdir.name, "workspace"))
@@ -311,7 +299,9 @@ class TestBasicShell:
     def test_clone(self):
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         job = project_a.open_job({"a": 0})
         job.init()
         assert len(project_a) == 1
@@ -353,7 +343,9 @@ class TestBasicShell:
     def test_move(self):
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         job = project_a.open_job({"a": 0})
         job.init()
         assert len(project_a) == 1
@@ -435,7 +427,9 @@ class TestBasicShell:
         assert s.format() == out.strip().replace(os.linesep, "\n")
 
     def test_sync(self):
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
         for i in range(4):
@@ -480,7 +474,9 @@ class TestBasicShell:
             )
 
     def test_sync_merge(self):
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
         for i in range(4):
@@ -513,7 +509,9 @@ class TestBasicShell:
     def test_sync_document(self):
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         job_src = project_a.open_job({"a": 0})
         job_dst = project_b.open_job({"a": 0})
 
@@ -583,7 +581,9 @@ class TestBasicShell:
     def test_sync_file(self):
         self.call("python -m signac init ProjectA".split())
         project_a = signac.Project()
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         job_src = project_a.open_job({"a": 0}).init()
         job_dst = project_b.open_job({"a": 0}).init()
         for i, job in enumerate([job_src, job_dst]):
@@ -661,7 +661,9 @@ class TestBasicShell:
             )
 
     def test_import_sync(self):
-        project_b = signac.init_project("ProjectB", os.path.join(self.tmpdir.name, "b"))
+        project_b = signac.init_project(
+            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
+        )
         self.call("python -m signac init ProjectA".split())
         prefix_data = os.path.join(self.tmpdir.name, "data")
         project_a = signac.Project()
@@ -683,7 +685,6 @@ class TestBasicShell:
             "print(str(tmp_project), len(tmp_project)); exit()",
             shell=True,
         )
-        assert "ProjectA" in out
         assert "4" in out
 
     def test_shell(self):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -91,24 +91,24 @@ class TestBasicShell:
         assert ("options:" if py310_or_greater else "optional arguments:") in out
 
     def test_init_project(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         assert signac.get_project().root_directory() == os.getcwd()
 
     def test_project_workspace(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         assert os.path.realpath(
             self.call("python -m signac project --workspace".split()).strip()
         ) == os.path.realpath(os.path.join(self.tmpdir.name, "workspace"))
 
     def test_job_with_argument(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         assert (
             self.call(["python", "-m", "signac", "job", '{"a": 0}']).strip()
             == "9bfd29df07674bc4aa960cf661b5acd2"
         )
 
     def test_job_with_argument_workspace(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         wd_path = os.path.join(
             self.tmpdir.name, "workspace", "9bfd29df07674bc4aa960cf661b5acd2"
         )
@@ -119,7 +119,7 @@ class TestBasicShell:
         ) == os.path.realpath(wd_path)
 
     def test_job_with_argument_create_workspace(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         wd_path = os.path.join(
             self.tmpdir.name, "workspace", "9bfd29df07674bc4aa960cf661b5acd2"
         )
@@ -128,7 +128,7 @@ class TestBasicShell:
         assert os.path.isdir(wd_path)
 
     def test_statepoint(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         self.call(["python", "-m", "signac", "job", "--create", '{"a": 0}'])
         project = signac.Project()
         assert len(project) == 1
@@ -144,7 +144,7 @@ class TestBasicShell:
         assert len(project) == 1
 
     def test_document(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         job_a = project.open_job({"a": 0})
         job_a.init()
@@ -164,7 +164,7 @@ class TestBasicShell:
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_single(self):
         """Check whether command line views work for single job workspaces."""
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(1)]
         for sp in sps:
@@ -179,7 +179,7 @@ class TestBasicShell:
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
         for sp in sps:
@@ -195,7 +195,7 @@ class TestBasicShell:
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_incomplete_path_spec(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
         for sp in sps:
@@ -213,7 +213,7 @@ class TestBasicShell:
 
     @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
         sps.append({"a": [0, 1, 0]})
@@ -285,7 +285,7 @@ class TestBasicShell:
             )
 
     def test_diff(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         job_a = project.open_job({"a": 0, "b": 1})
         job_a.init()
@@ -297,11 +297,9 @@ class TestBasicShell:
         assert set(expected) == set(outputs)
 
     def test_clone(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project_a = signac.Project()
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
         job = project_a.open_job({"a": 0})
         job.init()
         assert len(project_a) == 1
@@ -341,11 +339,9 @@ class TestBasicShell:
         assert len(project_b) == 1
 
     def test_move(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project_a = signac.Project()
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
         job = project_a.open_job({"a": 0})
         job.init()
         assert len(project_a) == 1
@@ -386,7 +382,7 @@ class TestBasicShell:
         assert len(project_b) == 1
 
     def test_remove(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
         for sp in sps:
@@ -408,7 +404,7 @@ class TestBasicShell:
         assert job_to_remove not in project
 
     def test_schema(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         for i in range(10):
             project.open_job(
@@ -427,10 +423,8 @@ class TestBasicShell:
         assert s.format() == out.strip().replace(os.linesep, "\n")
 
     def test_sync(self):
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
-        self.call("python -m signac init ProjectA".split())
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
+        self.call("python -m signac init".split())
         project_a = signac.Project()
         for i in range(4):
             project_a.open_job({"a": i}).init()
@@ -474,10 +468,8 @@ class TestBasicShell:
             )
 
     def test_sync_merge(self):
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
-        self.call("python -m signac init ProjectA".split())
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
+        self.call("python -m signac init".split())
         project_a = signac.Project()
         for i in range(4):
             project_a.open_job({"a": i}).init()
@@ -507,11 +499,9 @@ class TestBasicShell:
         assert len(project_b) == 6
 
     def test_sync_document(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project_a = signac.Project()
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
         job_src = project_a.open_job({"a": 0})
         job_dst = project_b.open_job({"a": 0})
 
@@ -579,11 +569,9 @@ class TestBasicShell:
             )
 
     def test_sync_file(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project_a = signac.Project()
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
         job_src = project_a.open_job({"a": 0}).init()
         job_dst = project_b.open_job({"a": 0}).init()
         for i, job in enumerate([job_src, job_dst]):
@@ -617,7 +605,7 @@ class TestBasicShell:
         )
 
     def test_export(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         prefix_data = os.path.join(self.tmpdir.name, "data")
 
@@ -635,7 +623,7 @@ class TestBasicShell:
             assert os.path.isdir(os.path.join(prefix_data, "a", str(i)))
 
     def test_import(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         prefix_data = os.path.join(self.tmpdir.name, "data")
 
@@ -661,10 +649,8 @@ class TestBasicShell:
             )
 
     def test_import_sync(self):
-        project_b = signac.init_project(
-            "ProjectB", root=os.path.join(self.tmpdir.name, "b")
-        )
-        self.call("python -m signac init ProjectA".split())
+        project_b = signac.init_project(root=os.path.join(self.tmpdir.name, "b"))
+        self.call("python -m signac init".split())
         prefix_data = os.path.join(self.tmpdir.name, "data")
         project_a = signac.Project()
         for i in range(4):
@@ -688,7 +674,7 @@ class TestBasicShell:
         assert "4" in out
 
     def test_shell(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         out = self.call(
             "python -m signac shell",
@@ -707,7 +693,7 @@ class TestBasicShell:
         out = self.call("python -m signac shell", shell=True)
         assert "No project within this directory" in out
 
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         for i in range(3):
             project.open_job(dict(a=i)).init()
@@ -720,7 +706,7 @@ class TestBasicShell:
         assert out.strip() == f">>> {project} None {len(project)}"
 
     def test_shell_with_jobs_and_selection(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         for i in range(3):
             project.open_job(dict(a=i)).init()
@@ -737,7 +723,7 @@ class TestBasicShell:
         assert out.strip() == f">>> {project} None {n}"
 
     def test_shell_with_jobs_and_selection_only_one_job(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         for i in range(3):
             project.open_job(dict(a=i)).init()
@@ -756,7 +742,7 @@ class TestBasicShell:
         ).strip()
         assert "Did not find a local configuration file" in err
 
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         out = self.call("python -m signac config --local show".split()).strip()
         cfg = config.read_config_file("signac.rc")
         expected = config.Config(cfg).write()
@@ -773,7 +759,7 @@ class TestBasicShell:
         assert out.split(os.linesep) == expected
 
     def test_config_set(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         self.call("python -m signac config set a b".split())
         cfg = self.call("python -m signac config --local show".split())
         assert "a" in cfg
@@ -805,7 +791,7 @@ class TestBasicShell:
                 os.remove(config.FN_CONFIG)
 
     def test_update_cache(self):
-        self.call("python -m signac init ProjectA".split())
+        self.call("python -m signac init".split())
         project_a = signac.Project()
         assert not os.path.isfile(project_a.FN_CACHE)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -545,12 +545,8 @@ class TestProjectSync:
         self._tmp_pr_b = os.path.join(self._tmp_dir.name, "pr_b")
         os.mkdir(self._tmp_pr_a)
         os.mkdir(self._tmp_pr_b)
-        self.project_a = signac.Project.init_project(
-            name="test-project-a", root=self._tmp_pr_a
-        )
-        self.project_b = signac.Project.init_project(
-            name="test-project-b", root=self._tmp_pr_b
-        )
+        self.project_a = signac.Project.init_project(root=self._tmp_pr_a)
+        self.project_b = signac.Project.init_project(root=self._tmp_pr_b)
 
     def _init_job(self, job, data="data"):
         with job:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR removes the ability for users to set a project name. The name still exists, but it is always just "project". These changes were split off from #643. Currently this changeset only includes the minimal set of changes to ensure that tests pass, but a large number of tests will now trigger warnings. Once reviewers indicate their approval of the new API I can go through and clean up tests.

Specifically, the changes here ensure that in 2.0 a user who accidentally passes a project name as either a positional or keyword argument will only see a warning, not an error. This choice is intended to provide a softer off-ramp for project names since they have been an integral part of signac since its inception. The only cases that were previously valid that will now fail are if the user provides multiple positional arguments in order to set the root directory, e.g. `init_project("project_name", "/root/directory")`. I think that this is an acceptable level of breakage since the vast majority of users do not set the root explicitly.

I haven't removed the `Project.id` property here since the name still exists and users can still access it until the 2.0 migration actually removes it. I will remove the id property at that time.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Prep for 2.0. Part of #541.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
