### PR TITLE
Initial migration to schema version 2 including config rename

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -720,14 +720,13 @@ def main_config_show(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn):
-                if cfg is None:
-                    cfg = config.read_config_file(fn)
-                else:
-                    cfg.merge(config.read_config_file(fn))
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            if cfg is None:
+                cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
+            else:
+                cfg.merge(config.read_config_file(config.PROJECT_CONFIG_FN))
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
     if cfg is None:
@@ -759,14 +758,13 @@ def main_config_verify(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn):
-                if cfg is None:
-                    cfg = config.read_config_file(fn)
-                else:
-                    cfg.merge(config.read_config_file(fn))
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            if cfg is None:
+                cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
+            else:
+                cfg.merge(config.read_config_file(config.PROJECT_CONFIG_FN))
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
     if cfg is None:
@@ -792,11 +790,10 @@ def main_config_set(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn_config in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn_config):
-                break
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            fn_config = config.PROJECT_CONFIG_FN
     elif args.globalcfg:
-        fn_config = config.FN_CONFIG
+        fn_config = config.USER_CONFIG_FN
     else:
         raise ValueError(
             "You need to specify either -l/--local or -g/--global "

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -721,10 +721,7 @@ def main_config_show(args):
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
         if os.path.isfile(config.PROJECT_CONFIG_FN):
-            if cfg is None:
-                cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
-            else:
-                cfg.merge(config.read_config_file(config.PROJECT_CONFIG_FN))
+            cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
@@ -759,10 +756,7 @@ def main_config_verify(args):
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
         if os.path.isfile(config.PROJECT_CONFIG_FN):
-            if cfg is None:
-                cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
-            else:
-                cfg.merge(config.read_config_file(config.PROJECT_CONFIG_FN))
+            cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -12,12 +12,22 @@ from .validate import cfg, get_validator
 
 logger = logging.getLogger(__name__)
 
-PROJECT_CONFIG_FN = "signac.rc"
+PROJECT_CONFIG_FN = os.path.join(".signac", "config")
 USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
 
 
 def _get_project_config_fn(root):
     return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
+
+
+def _get_config_dirname(fn):
+    # TODO: Is the string replace a sufficiently portable solution? We could
+    # use pathlib's `.paths` attribute, but that has significant performance
+    # implications: this takes ~200 ns, whereas
+    # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
+    # 20x slowdown. On the other hand, loading a project should not be a
+    # frequent operation that leading to bottlenecks.
+    return fn.replace(os.path.sep + PROJECT_CONFIG_FN, "")
 
 
 def _search_local(root):
@@ -127,7 +137,7 @@ def load_config(root=None, local=False):
         # should be returned separately (i.e. the return should become a tuple
         # (root_dir, config). The current approach confuses the discovery with
         # the contents of the config.
-        config["project_dir"] = os.path.dirname(fn)
+        config["project_dir"] = _get_config_dirname(fn)
         break
     return config
 

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -21,13 +21,12 @@ def _get_project_config_fn(root):
 
 
 def _get_config_dirname(fn):
-    # TODO: Is the string replace a sufficiently portable solution? We could
-    # use pathlib's `.paths` attribute, but that has significant performance
-    # implications: this takes ~200 ns, whereas
+    # We could use pathlib's `.paths` attribute to remove the trailing project
+    # config filename, but that has significant performance
+    # implications: it takes ~200 ns, whereas
     # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
-    # 20x slowdown. On the other hand, loading a project should not be a
-    # frequent operation that leading to bottlenecks.
-    return fn.replace(os.path.sep + PROJECT_CONFIG_FN, "")
+    # 20x slowdown.
+    return fn.replace(os.sep + PROJECT_CONFIG_FN, "")
 
 
 def _search_local(root):

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -12,18 +12,14 @@ from .validate import cfg, get_validator
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_FILENAME = ".signacrc"
-CONFIG_FILENAMES = [DEFAULT_FILENAME, "signac.rc"]
-HOME = os.path.expanduser("~")
-CONFIG_PATH = [HOME]
-FN_CONFIG = os.path.expanduser("~/.signacrc")
+PROJECT_CONFIG_FN = "signac.rc"
+USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
 
 
 def _search_local(root):
-    for fn in CONFIG_FILENAMES:
-        fn_ = os.path.abspath(os.path.join(root, fn))
-        if os.path.isfile(fn_):
-            yield fn_
+    fn_ = os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
+    if os.path.isfile(fn_):
+        yield fn_
 
 
 def _search_tree(root=None):
@@ -41,8 +37,7 @@ def _search_tree(root=None):
         yield from _search_local(root)
         up = os.path.abspath(os.path.join(root, ".."))
         if up == root:
-            msg = "Reached filesystem root."
-            logger.debug(msg)
+            logger.debug("Reached filesystem root, no config found.")
             return
         else:
             root = up
@@ -50,8 +45,11 @@ def _search_tree(root=None):
 
 def _search_standard_dirs():
     """Locates signac configuration files in standard directories."""
-    for path in CONFIG_PATH:
-        yield from _search_local(path)
+    # For now this search only finds user-specific files, but it could be
+    # updated in the future to support e.g. system-wide config files.
+    for fn in (USER_CONFIG_FN,):
+        if os.path.isfile(fn):
+            yield fn
 
 
 def read_config_file(filename, configspec=None, *args, **kwargs):
@@ -75,10 +73,11 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
     try:
         config = Config(filename, configspec=configspec, *args, **kwargs)
     except (OSError, ConfigObjError) as error:
-        msg = "Failed to read configuration file '{}':\n{}"
-        raise ConfigError(msg.format(filename, error))
+        raise ConfigError(f"Failed to read configuration file '{filename}':\n{error}")
     verification = config.verify()
     if verification is not True:
+        # TODO: In the future this should raise an error, not just a
+        # debug-level logging notice.
         logger.debug(
             "Config file '{}' may contain invalid values.".format(
                 os.path.abspath(filename)
@@ -108,21 +107,24 @@ def load_config(root=None, local=False):
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))
     if local:
-        for fn in _search_local(root):
-            tmp = read_config_file(fn)
-            config.merge(tmp)
-            if "project" in tmp:
-                config["project_dir"] = os.path.dirname(fn)
-                break
+        search_func = _search_local
     else:
         for fn in _search_standard_dirs():
             config.merge(read_config_file(fn))
-        for fn in _search_tree(root):
-            tmp = read_config_file(fn)
-            config.merge(tmp)
-            if "project" in tmp:
-                config["project_dir"] = os.path.dirname(fn)
-                break
+        search_func = _search_tree
+
+    for fn in search_func(root):
+        tmp = read_config_file(fn)
+        config.merge(tmp)
+        # Once a valid config file is found, we cease looking any further, i.e.
+        # we assume that the first directory with a valid config file is the
+        # project root.
+        # TODO: Rather than adding the project directory to the config, it
+        # should be returned separately (i.e. the return should become a tuple
+        # (root_dir, config). The current approach confuses the discovery with
+        # the contents of the config.
+        config["project_dir"] = os.path.dirname(fn)
+        break
     return config
 
 

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -23,7 +23,7 @@ def _get_project_config_fn(root):
 def _get_config_dirname(fn):
     # We could use pathlib's `.paths` attribute to remove the trailing project
     # config filename, but that has significant performance
-    # implications: it takes ~200 ns, whereas
+    # implications: this takes ~200 ns, whereas
     # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
     # 20x slowdown.
     return fn.replace(os.sep + PROJECT_CONFIG_FN, "")

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -16,8 +16,12 @@ PROJECT_CONFIG_FN = "signac.rc"
 USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
 
 
+def _get_project_config_fn(root):
+    return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
+
+
 def _search_local(root):
-    fn_ = os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
+    fn_ = _get_project_config_fn(root)
     if os.path.isfile(fn_):
         yield fn_
 

--- a/signac/contrib/migration/__init__.py
+++ b/signac/contrib/migration/__init__.py
@@ -11,6 +11,7 @@ from packaging import version
 
 from ...version import SCHEMA_VERSION, __version__
 from .v0_to_v1 import _load_config_v1, _migrate_v0_to_v1
+from .v1_to_v2 import _load_config_v2, _migrate_v1_to_v2
 
 FN_MIGRATION_LOCKFILE = ".SIGNAC_PROJECT_MIGRATION_LOCK"
 
@@ -25,11 +26,13 @@ FN_MIGRATION_LOCKFILE = ".SIGNAC_PROJECT_MIGRATION_LOCK"
 # objects to the underlying config files.
 _CONFIG_LOADERS = {
     "1": _load_config_v1,
+    "2": _load_config_v2,
 }
 
 
 _MIGRATIONS = {
     ("0", "1"): _migrate_v0_to_v1,
+    ("1", "2"): _migrate_v1_to_v2,
 }
 
 _PARSED_SCHEMA_VERSION = version.parse(SCHEMA_VERSION)

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -4,6 +4,7 @@
 """Migrate from schema version 1 to version 2.
 
 This migration involves the following changes:
+    - Moving the signac.rc config file to .signac/config
 """
 
 import os

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -9,6 +9,7 @@ This migration involves the following changes:
 import os
 
 from signac.common import configobj
+from signac.common.config import _get_project_config_fn
 
 # A minimal v2 config.
 _cfg = """
@@ -20,16 +21,19 @@ workspace_dir = string(default='workspace')
 
 def _load_config_v2(root_directory):
     cfg = configobj.ConfigObj(
-        os.path.join(root_directory, "signac.rc"), configspec=_cfg.split("\n")
+        os.path.join(root_directory, ".signac", "config"), configspec=_cfg.split("\n")
     )
     validator = configobj.validate.Validator()
     if cfg.validate(validator) is not True:
         raise RuntimeError(
-            "This project's config file is not compatible with signac's v1 schema."
+            "This project's config file is not compatible with signac's v2 schema."
         )
     return cfg
 
 
-def _migrate_v1_to_v2(project):
+def _migrate_v1_to_v2(root_directory):
     """Migrate from schema version 1 to version 2."""
-    pass
+    v1_fn = os.path.join(root_directory, "signac.rc")
+    v2_fn = _get_project_config_fn(root_directory)
+    os.mkdir(os.path.dirname(v2_fn))
+    os.rename(v1_fn, v2_fn)

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Migrate from schema version 1 to version 2.
+
+This migration involves the following changes:
+"""
+
+import os
+
+from signac.common import configobj
+
+# A minimal v2 config.
+_cfg = """
+schema_version = string(default='0')
+project = string()
+workspace_dir = string(default='workspace')
+"""
+
+
+def _load_config_v2(root_directory):
+    cfg = configobj.ConfigObj(
+        os.path.join(root_directory, "signac.rc"), configspec=_cfg.split("\n")
+    )
+    validator = configobj.validate.Validator()
+    if cfg.validate(validator) is not True:
+        raise RuntimeError(
+            "This project's config file is not compatible with signac's v1 schema."
+        )
+    return cfg
+
+
+def _migrate_v1_to_v2(project):
+    """Migrate from schema version 1 to version 2."""
+    pass

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -22,7 +22,12 @@ from threading import RLock
 
 from packaging import version
 
-from ..common.config import Config, load_config, read_config_file
+from ..common.config import (
+    Config,
+    _get_project_config_fn,
+    load_config,
+    read_config_file,
+)
 from ..core.h5store import H5StoreManager
 from ..sync import sync_projects
 from ..synced_collections.backends.collection_json import BufferedJSONAttrDict
@@ -1531,7 +1536,7 @@ class Project:
         try:
             project = cls.get_project(root=root, search=False)
         except LookupError:
-            fn_config = os.path.join(root, "signac.rc")
+            fn_config = _get_project_config_fn(root)
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
             config = read_config_file(fn_config)

--- a/signac/version.py
+++ b/signac/version.py
@@ -6,7 +6,7 @@
 
 __version__ = "1.7.0"
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 
 
 __all__ = [

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2487,17 +2487,15 @@ class TestSchemaMigration:
                         """\
                         project = project
                         workspace_dir = workspace
-                        schema_version = 1"""
+                        schema_version = 0"""
                     )
                 )
 
             config = read_config_file(cfg_fn)
-            print(config)
             if implicit_version:
                 del config["schema_version"]
                 assert "schema_version" not in config
             else:
-                config["schema_version"] = "0"
                 assert config["schema_version"] == "0"
             config.write()
             err = io.StringIO()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,7 +23,7 @@ from packaging import version
 from test_job import TestJobBase
 
 import signac
-from signac.common.config import load_config, read_config_file
+from signac.common.config import load_config, read_config_file, PROJECT_CONFIG_FN, _get_project_config_fn
 from signac.contrib.errors import (
     IncompatibleSchemaVersion,
     JobsCorruptedError,
@@ -2434,7 +2434,7 @@ class TestProjectSchema(TestProjectBase):
         assert version.parse(self.project.config["schema_version"]) < version.parse(
             impossibly_high_schema_version
         )
-        config = read_config_file(self.project.fn("signac.rc"))
+        config = read_config_file(_get_project_config_fn(self.project.root_directory()))
         config["schema_version"] = impossibly_high_schema_version
         config.write()
         with pytest.raises(IncompatibleSchemaVersion):
@@ -2448,7 +2448,7 @@ class TestProjectSchema(TestProjectBase):
 
         # Ensure that migration fails on an invalid version.
         invalid_schema_version = "0.5"
-        config = read_config_file(self.project.fn("signac.rc"))
+        config = read_config_file(_get_project_config_fn(self.project.root_directory()))
         config["schema_version"] = invalid_schema_version
         config.write()
         with pytest.raises(RuntimeError):
@@ -2458,7 +2458,14 @@ class TestProjectSchema(TestProjectBase):
     def test_project_schema_version_migration(self, implicit_version):
         from signac.contrib.migration import apply_migrations
 
-        config = read_config_file(self.project.fn("signac.rc"))
+        # First need to move the v2 config file to a suitable v0/v1 file.
+        v2_fn = _get_project_config_fn(self.project.root_directory())
+        v1_fn = self.project.fn("signac.rc")
+        os.rename(v2_fn, v1_fn)
+        os.rmdir(os.path.dirname(v2_fn))
+
+        # First need to move the v2 config file to a suitable v0/v1 file.
+        config = read_config_file(v1_fn)
         if implicit_version:
             del config["schema_version"]
             assert "schema_version" not in config
@@ -2469,13 +2476,14 @@ class TestProjectSchema(TestProjectBase):
         err = io.StringIO()
         with redirect_stderr(err):
             apply_migrations(self.project.root_directory())
-        config = read_config_file(self.project.fn("signac.rc"))
+        config = load_config(self.project.root_directory())
         assert config["schema_version"] == "2"
         project = signac.get_project(root=self.project.root_directory())
         assert project.config["schema_version"] == "2"
         assert "OK" in err.getvalue()
         assert "0 to 1" in err.getvalue()
         assert "1 to 2" in err.getvalue()
+        assert os.path.isfile(project.fn(PROJECT_CONFIG_FN))
 
     def test_no_migration(self):
         # This unit test should fail as long as there are no schema migrations

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,7 +23,12 @@ from packaging import version
 from test_job import TestJobBase
 
 import signac
-from signac.common.config import load_config, read_config_file, PROJECT_CONFIG_FN, _get_project_config_fn
+from signac.common.config import (
+    PROJECT_CONFIG_FN,
+    _get_project_config_fn,
+    load_config,
+    read_config_file,
+)
 from signac.contrib.errors import (
     IncompatibleSchemaVersion,
     JobsCorruptedError,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2470,11 +2470,12 @@ class TestProjectSchema(TestProjectBase):
         with redirect_stderr(err):
             apply_migrations(self.project.root_directory())
         config = read_config_file(self.project.fn("signac.rc"))
-        assert config["schema_version"] == "1"
+        assert config["schema_version"] == "2"
         project = signac.get_project(root=self.project.root_directory())
-        assert project.config["schema_version"] == "1"
+        assert project.config["schema_version"] == "2"
         assert "OK" in err.getvalue()
         assert "0 to 1" in err.getvalue()
+        assert "1 to 2" in err.getvalue()
 
     def test_no_migration(self):
         # This unit test should fail as long as there are no schema migrations

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -767,7 +767,7 @@ class TestBasicShell:
         assert out.split(os.linesep) == expected
 
         out = self.call("python -m signac config --global show".split()).strip()
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 
@@ -783,12 +783,12 @@ class TestBasicShell:
         assert "[x]" in cfg
         assert "y = z" in cfg
 
-        backup_config = os.path.exists(config.FN_CONFIG)
-        global_config_path_backup = config.FN_CONFIG + ".tmp"
+        backup_config = os.path.exists(config.USER_CONFIG_FN)
+        global_config_path_backup = config.USER_CONFIG_FN + ".tmp"
         try:
             # Make a backup of the global config if it exists
             if backup_config:
-                shutil.copy2(config.FN_CONFIG, global_config_path_backup)
+                shutil.copy2(config.USER_CONFIG_FN, global_config_path_backup)
 
             # Test the global config CLI
             self.call("python -m signac config --global set b c".split())
@@ -799,9 +799,9 @@ class TestBasicShell:
             # Revert the global config to its previous state (or remove it if
             # it did not exist)
             if backup_config:
-                shutil.move(global_config_path_backup, config.FN_CONFIG)
+                shutil.move(global_config_path_backup, config.USER_CONFIG_FN)
             else:
-                os.remove(config.FN_CONFIG)
+                os.remove(config.USER_CONFIG_FN)
 
     def test_update_cache(self):
         self.call("python -m signac init ProjectA".split())

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -757,7 +757,7 @@ class TestBasicShell:
 
         self.call("python -m signac init my_project".split())
         out = self.call("python -m signac config --local show".split()).strip()
-        cfg = config.read_config_file("signac.rc")
+        cfg = config.read_config_file(".signac/config")
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR contains the first components of a migration to schema version 2. The primary change in this PR is that the config file for a signac project has been moved to ".signac/config" rather than "signac.rc". ".signacrc" is no longer supported except as the global configuration file. Additionally, root discovery via `load_config` no longer checks for the presence of the "project" key in a config file to determine the project root. Any directory containing ".signac/config" file is sufficient to terminate the search and establish a project root directory.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Contributes to #197. Part of schema 2 changes.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
