### PR TITLE
Changed code to use id_ instead of _id

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -361,11 +361,11 @@ def read_benchmark(filename, filter=None, include_metadata=False):
         docs = list(c.find(filter))
 
     df_data = pd.DataFrame(
-        {doc["_id"]: dict(normalize(doc["data"], doc["meta"]["N"])) for doc in docs}
+        {doc["id_"]: dict(normalize(doc["data"], doc["meta"]["N"])) for doc in docs}
     ).T
 
     if include_metadata:
-        df_meta = pd.DataFrame({doc["_id"]: doc["meta"] for doc in docs}).T
+        df_meta = pd.DataFrame({doc["id_"]: doc["meta"] for doc in docs}).T
         return pd.concat([df_meta, df_data], axis=1)
     else:
         return df_data

--- a/changelog.txt
+++ b/changelog.txt
@@ -340,7 +340,7 @@ Added
  - Adds the ``signac.Project.temporary_project()`` context manager which creates a temporary project within the root project workspace.
  - Add ``signac`` to the default namespace when invoking ``signac shell``.
  - Add option to specify a custom view path for the ``signac view``/ ``Project.create_linked_view()`` function.
- - Iterables of documents used to construct a Collection no longer require an ``_id`` field.
+ - Iterables of documents used to construct a Collection no longer require an ``id_`` field.
 
 Changed
 +++++++
@@ -809,7 +809,7 @@ Added
 Changed
 +++++++
 
- - The ``crawl()`` function yields only the index documents and not a tuple of (_id, doc).
+ - The ``crawl()`` function yields only the index documents and not a tuple of (id_, doc).
  - ``export()`` and ``export_pymongo()`` expect the index documents as first argument, not a crawler instance. The old API is still supported, but will trigger a DeprecationWarning.
 
 [0.2.7] -- 2016-02-29

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -384,11 +384,11 @@ def main_find(args):
         if args.doc is None:
             args.doc = []
 
-    def format_lines(cat, _id, s):
+    def format_lines(cat, id_, s):
         if args.one_line:
             if isinstance(s, dict):
                 s = json.dumps(s, sort_keys=True)
-            return f"{_id[:len_id]} {cat}\t{s}"
+            return f"{id_[:len_id]} {cat}\t{s}"
         else:
             return pformat(s, depth=args.pretty)
 
@@ -1101,8 +1101,8 @@ def main_shell(args):
         _jobs = find_with_filter(args)
 
         def jobs():
-            for _id in _jobs:
-                yield project.open_job(id=_id)
+            for id_ in _jobs:
+                yield project.open_job(id=id_)
 
         if len(_jobs) == 1:
             job = _open_job_by_id(project, list(_jobs)[0])

--- a/signac/contrib/filesystems.py
+++ b/signac/contrib/filesystems.py
@@ -75,38 +75,38 @@ class LocalFS:
             type(self), ", ".join(f"{k}={v}" for k, v in self.config().items())
         )
 
-    def _fn(self, _id, n=2, suffix=".dat"):
+    def _fn(self, id_, n=2, suffix=".dat"):
         fn = (
-            os.path.join(self.root, *(_id[i : i + n] for i in range(0, len(_id), n)))
+            os.path.join(self.root, *(id_[i : i + n] for i in range(0, len(id_), n)))
             + suffix
         )
         return fn
 
-    def new_file(self, _id, mode=None):
-        """Create a new file for _id.
+    def new_file(self, id_, mode=None):
+        """Create a new file for id_.
 
-        :param _id: The file identifier.
-        :type _id: str
+        :param id_: The file identifier.
+        :type id_: str
         :returns: A file-like object to write to."""
         if mode is None:
             mode = "xb"
         if "x" not in mode:
             raise ValueError(mode)
-        fn = self._fn(_id)
+        fn = self._fn(id_)
         _mkdir_p(os.path.dirname(fn))
         return open(fn, mode=mode)
 
-    def get(self, _id, mode="r"):
+    def get(self, id_, mode="r"):
         """Open the file with the specified id.
 
-        :param _id: The file identifier.
-        :type _id: str
+        :param id_: The file identifier.
+        :type id_: str
         :param mode: The file mode used for opening.
         :returns: A file-like object to read from."""
 
         if "r" not in mode:
             raise ValueError(mode)
-        return open(self._fn(_id), mode=mode)
+        return open(self._fn(id_), mode=mode)
 
 
 _register_fs_class(LocalFS)
@@ -165,15 +165,15 @@ if GRIDFS:
                 self._gridfs = gridfs.GridFS(self.db, collection=self.collection)
             return self._gridfs
 
-        def new_file(self, _id):
-            """Create a new file for _id.
+        def new_file(self, id_):
+            """Create a new file for id_.
 
-            :param _id: The file identifier.
-            :type _id: str
+            :param id_: The file identifier.
+            :type id_: str
             :returns: A file-like object to write to."""
-            return self.gridfs.new_file(_id=_id)
+            return self.gridfs.new_file(id_=id_)
 
-        def get(self, _id, mode="r"):
+        def get(self, id_, mode="r"):
             """Open the file with the specified id.
 
             .. warning::
@@ -183,19 +183,19 @@ if GRIDFS:
                 for higher efficiency, files should generally
                 be opened in binary mode (`rb`) whenever possible.
 
-            :param _id: The file identifier.
-            :type _id: str
+            :param id_: The file identifier.
+            :type id_: str
             :param mode: The file mode used for opening.
             :returns: A file-like object to read from."""
             if mode == "r":
-                file = io.StringIO(self.gridfs.get(_id).read().decode())
+                file = io.StringIO(self.gridfs.get(id_).read().decode())
                 if len(file.getvalue()) > GRIDFS_LARGE_FILE_WARNING_THRSHLD:
                     warnings.warn(
                         "Open large GridFS files more efficiently in 'rb' mode."
                     )
                 return file
             elif mode == "rb":
-                return self.gridfs.get(file_id=_id)
+                return self.gridfs.get(file_id=id_)
             else:
                 raise ValueError(mode)
 

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -62,7 +62,7 @@ def _make_schema_based_path_function(jobs, exclude_keys=None, delimiter_nested="
         # signature of the path function below.
         return lambda job, sep=None: ""
 
-    index = [{"_id": job.id, "sp": job.sp()} for job in jobs]
+    index = [{"id_": job.id, "sp": job.sp()} for job in jobs]
     jsi = _build_job_statepoint_index(exclude_const=True, index=index)
     sp_index = OrderedDict(jsi)
 

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -93,7 +93,7 @@ class _StatePointDict(JSONAttrDict):
         # All elements of the job list are shallow copies of each other, so any
         # one of them is representative.
         job = next(iter(self._jobs))
-        old_id = job._id
+        old_id = job.id_
         if old_id == new_id:
             return
 
@@ -122,7 +122,7 @@ class _StatePointDict(JSONAttrDict):
 
         # Update each job instance.
         for job in self._jobs:
-            job._id = new_id
+            job.id_ = new_id
             job._initialize_lazy_properties()
 
         # Remove the temporary state point file if it was created. Have to do it
@@ -227,7 +227,7 @@ class Job:
     Application developers should not directly instantiate this class, but
     use :meth:`~signac.Project.open_job` instead.
 
-    Jobs can be opened by ``statepoint`` or ``_id``. If both values are
+    Jobs can be opened by ``statepoint`` or ``id_``. If both values are
     provided, it is the user's responsibility to ensure that the values
     correspond.
 
@@ -237,7 +237,7 @@ class Job:
         Project handle.
     statepoint : dict
         State point for the job. (Default value = None)
-    _id : str
+    id_ : str
         The job identifier. (Default value = None)
 
     """
@@ -255,17 +255,17 @@ class Job:
     KEY_DATA = "signac_data"
     "The job's datastore key."
 
-    def __init__(self, project, statepoint=None, _id=None):
+    def __init__(self, project, statepoint=None, id_=None):
         self._project = project
         self._lock = RLock()
         self._initialize_lazy_properties()
 
-        if statepoint is None and _id is None:
-            raise ValueError("Either statepoint or _id must be provided.")
+        if statepoint is None and id_ is None:
+            raise ValueError("Either statepoint or id_ must be provided.")
         elif statepoint is not None:
             self._statepoint_requires_init = False
             try:
-                self._id = calc_id(statepoint) if _id is None else _id
+                self.id_ = calc_id(statepoint) if id_ is None else id_
             except TypeError:
                 raise KeyTypeError
             self._statepoint = _StatePointDict(
@@ -276,7 +276,7 @@ class Job:
             self._project._register(self.id, statepoint)
         else:
             # Only an id was provided. State point will be loaded lazily.
-            self._id = _id
+            self.id_ = id_
             self._statepoint_requires_init = True
 
     def _initialize_lazy_properties(self):
@@ -302,7 +302,7 @@ class Job:
             The job id.
 
         """
-        return self._id
+        return self.id_
 
     @property
     def id(self):
@@ -314,7 +314,7 @@ class Job:
             The job id.
 
         """
-        return self._id
+        return self.id_
 
     def __hash__(self):
         return hash(self.id)

--- a/signac/contrib/linked_view.py
+++ b/signac/contrib/linked_view.py
@@ -62,20 +62,20 @@ def create_linked_view(project, prefix=None, job_ids=None, index=None, path=None
 
     if index is None:
         if job_ids is None:
-            index = [{"_id": job.id, "sp": job.sp()} for job in project]
+            index = [{"id_": job.id, "sp": job.sp()} for job in project]
             jobs = list(project)
         else:
             index = [
-                {"_id": job_id, "sp": project.open_job(id=job_id).sp()}
+                {"id_": job_id, "sp": project.open_job(id=job_id).sp()}
                 for job_id in job_ids
             ]
             jobs = list(project.open_job(id=job_id) for job_id in job_ids)
     elif job_ids is not None:
         if not isinstance(job_ids, set):
             job_ids = set(job_ids)
-        index = [doc for doc in index if doc["_id"] in job_ids]
+        index = [doc for doc in index if doc["id_"] in job_ids]
         jobs = list(project.open_job(id=job_id) for job_id in job_ids)
-        if not job_ids.issubset({doc["_id"] for doc in index}):
+        if not job_ids.issubset({doc["id_"] for doc in index}):
             raise ValueError("Insufficient index for selected data space.")
 
     key_list = [k for job in jobs for k in job.statepoint().keys()]

--- a/signac/contrib/schema.py
+++ b/signac/contrib/schema.py
@@ -67,7 +67,7 @@ def _build_job_statepoint_index(exclude_const, index):
     collection = Collection(index, _trust=True)
     for doc in collection.find():
         for key, _ in _nested_dicts_to_dotted_keys(doc):
-            if key == "_id" or key.split(".")[0] != "sp":
+            if key == "id_" or key.split(".")[0] != "sp":
                 continue
             collection.index(key, build=True)
     indexes = collection._indexes

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -71,41 +71,41 @@ class TestCollection:
         assert len(self.c) == 0
 
     def test_buffer_size(self):
-        docs = [{"a": i, "_id": str(i)} for i in range(10)]
+        docs = [{"a": i, "id_": str(i)} for i in range(10)]
         self.c = Collection(docs)
         assert len(self.c._file.getvalue()) == 0
         self.c.flush()
         assert len(self.c._file.getvalue()) > 0
 
     def test_init_with_list_with_ids_sequential(self):
-        docs = [{"a": i, "_id": str(i)} for i in range(10)]
+        docs = [{"a": i, "id_": str(i)} for i in range(10)]
         self.c = Collection(docs)
         assert len(self.c) == len(docs)
         for doc in docs:
-            assert doc["_id"] in self.c
+            assert doc["id_"] in self.c
 
     def test_init_with_list_with_ids_non_sequential(self):
-        docs = [{"a": i, "_id": f"{i ** 3:032d}"} for i in range(10)]
+        docs = [{"a": i, "id_": f"{i ** 3:032d}"} for i in range(10)]
         self.c = Collection(docs)
         assert len(self.c) == len(docs)
         for doc in docs:
-            assert doc["_id"] in self.c
+            assert doc["id_"] in self.c
 
     def test_init_with_list_without_ids(self):
         docs = [{"a": i} for i in range(10)]
         self.c = Collection(docs)
         assert len(self.c) == len(docs)
         for doc in docs:
-            assert doc["_id"] in self.c
+            assert doc["id_"] in self.c
 
     def test_init_with_list_with_and_without_ids(self):
         docs = [{"a": i} for i in range(10)]
         for i, doc in enumerate(islice(docs, 5)):
-            doc.setdefault("_id", str(i))
+            doc.setdefault("id_", str(i))
         self.c = Collection(docs)
         assert len(self.c) == len(docs)
         for doc in docs:
-            assert doc["_id"] in self.c
+            assert doc["id_"] in self.c
 
     def test_init_with_non_serializable(self):
         docs = [dict(a=array.array("f", [1, 2, 3])) for i in range(10)]
@@ -119,7 +119,7 @@ class TestCollection:
         assert self.c["0"] == doc
         assert list(self.c.find()) == [doc]
         with pytest.raises(ValueError):
-            self.c["0"] = dict(_id="1")
+            self.c["0"] = dict(id_="1")
         with pytest.raises(TypeError):
             self.c[0] = dict(a=0)
         with pytest.raises(TypeError):
@@ -151,7 +151,7 @@ class TestCollection:
         """
 
     def test_copy(self):
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         c2 = Collection(self.c)
         assert len(self.c) == len(c2)
@@ -171,16 +171,16 @@ class TestCollection:
 
     def test_contains(self):
         assert "0" not in self.c
-        _id = self.c.insert_one(dict())
-        assert _id in self.c
-        del self.c[_id]
-        assert _id not in self.c
-        docs = [dict(_id=str(i)) for i in range(10)]
+        id_ = self.c.insert_one(dict())
+        assert id_ in self.c
+        del self.c[id_]
+        assert id_ not in self.c
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
-        for _id in self.c.ids:
-            assert _id in self.c
+        for id_ in self.c.ids:
+            assert id_ in self.c
         for doc in docs:
-            assert doc["_id"] in self.c
+            assert doc["id_"] in self.c
 
     def test_update(self):
         docs = [dict(a=i) for i in range(10)]
@@ -188,10 +188,10 @@ class TestCollection:
         assert len(self.c) == len(docs)
 
     def test_update_collision(self):
-        docs = [dict(_id=str(i), a=i) for i in range(10)]
+        docs = [dict(id_=str(i), a=i) for i in range(10)]
         self.c.update(docs)
         # Update the first ten, insert the second ten
-        new_docs = [dict(_id=str(i), a=i * 2) for i in range(20)]
+        new_docs = [dict(id_=str(i), a=i * 2) for i in range(20)]
         self.c.update(new_docs)
         assert len(self.c) == len(new_docs)
         assert self.c["0"] == new_docs[0]
@@ -204,28 +204,28 @@ class TestCollection:
         index = self.c.index("a", build=True)
         assert len(index) == len(self.c)
         for value, _ids in index.items():
-            for _id in _ids:
-                assert self.c[_id]["a"] == value
+            for id_ in _ids:
+                assert self.c[id_]["a"] == value
         index = self.c.index("b", build=True)
-        del self.c[docs[0]["_id"]]
+        del self.c[docs[0]["id_"]]
         assert len(self.c) == len(docs) - 1
         index = self.c.index("a", build=True)
         assert len(index) == len(self.c)
         for value, _ids in index.items():
-            for _id in _ids:
-                assert self.c[_id]["a"] == value
-        self.c[docs[0]["_id"]] = docs[0]
+            for id_ in _ids:
+                assert self.c[id_]["a"] == value
+        self.c[docs[0]["id_"]] = docs[0]
         index = self.c.index("a", build=True)
         assert len(index) == len(self.c)
         for value, _ids in index.items():
-            for _id in _ids:
-                assert self.c[_id]["a"] == value
+            for id_ in _ids:
+                assert self.c[id_]["a"] == value
         self.c["0"] = dict(a=-1)
         index = self.c.index("a", build=True)
         assert len(index) == len(self.c)
         for value, _ids in index.items():
-            for _id in _ids:
-                assert self.c[_id]["a"] == value
+            for id_ in _ids:
+                assert self.c[id_]["a"] == value
 
     def test_reindex(self):
         assert len(self.c) == 0
@@ -259,11 +259,11 @@ class TestCollection:
 
     def test_find_id(self):
         assert len(self.c.find()) == 0
-        assert len(self.c.find({"_id": "0"})) == 0
-        docs = [{"a": i, "_id": str(i)} for i in range(10)]
+        assert len(self.c.find({"id_": "0"})) == 0
+        docs = [{"a": i, "id_": str(i)} for i in range(10)]
         self.c.update(docs)
         assert len(self.c.find()) == len(docs)
-        assert len(self.c.find({"_id": "0"})) == 1
+        assert len(self.c.find({"id_": "0"})) == 1
 
     def test_find_integer(self):
         assert len(self.c.find()) == 0
@@ -280,7 +280,7 @@ class TestCollection:
         assert len(self.c.find(limit=5)) == 5
         assert len(self.c.find({"a": {"$type": "int"}})) == 10
         assert len(self.c.find({"a": {"$type": "float"}})) == 0
-        del self.c[docs[0]["_id"]]
+        del self.c[docs[0]["id_"]]
         assert len(self.c.find({"a": 0})) == 0
 
     def test_find_float(self):
@@ -298,7 +298,7 @@ class TestCollection:
         assert len(self.c.find(limit=5)) == 5
         assert len(self.c.find({"a": {"$type": "int"}})) == 0
         assert len(self.c.find({"a": {"$type": "float"}})) == 10
-        del self.c[docs[0]["_id"]]
+        del self.c[docs[0]["id_"]]
         assert len(self.c.find({"a": 0})) == 0
 
     def test_find_list(self):
@@ -317,8 +317,8 @@ class TestCollection:
         id_int = self.c.insert_one({"a": 1})
         assert len(self.c.find({"a": {"$type": "float"}})) == 1
         assert len(self.c.find({"a": {"$type": "int"}})) == 1
-        assert self.c.find_one({"a": {"$type": "float"}})["_id"] == id_float
-        assert self.c.find_one({"a": {"$type": "int"}})["_id"] == id_int
+        assert self.c.find_one({"a": {"$type": "float"}})["id_"] == id_float
+        assert self.c.find_one({"a": {"$type": "int"}})["id_"] == id_int
 
         # Reversing order
         self.c.clear()
@@ -326,8 +326,8 @@ class TestCollection:
         id_float = self.c.insert_one({"a": float(1.0)})
         assert len(self.c.find({"a": {"$type": "int"}})) == 1
         assert len(self.c.find({"a": {"$type": "float"}})) == 1
-        assert self.c.find_one({"a": {"$type": "int"}})["_id"] == id_int
-        assert self.c.find_one({"a": {"$type": "float"}})["_id"] == id_float
+        assert self.c.find_one({"a": {"$type": "int"}})["id_"] == id_int
+        assert self.c.find_one({"a": {"$type": "float"}})["id_"] == id_float
 
     def test_insert_docs_with_dots(self):
         with pytest.raises(InvalidKeyError):
@@ -341,9 +341,9 @@ class TestCollection:
         with pytest.raises(InvalidKeyError):
             self.c["0"] = {"a": {"b.c": 0}}
         with pytest.raises(InvalidKeyError):
-            self.c.update([{"_id": "0", "a.b": 0}])
+            self.c.update([{"id_": "0", "a.b": 0}])
         with pytest.raises(InvalidKeyError):
-            self.c.update([{"_id": "0", "a": {"b.c": 0}}])
+            self.c.update([{"id_": "0", "a": {"b.c": 0}}])
 
     def test_replace_docs_with_dots(self):
         self.c.insert_one({"a": 0})
@@ -382,7 +382,7 @@ class TestCollection:
         assert len(self.c.find({"a.b": 0})) == 1
         assert len(self.c.find({"a": {"b": 0}})) == 1
         assert list(self.c.find({"a.b": 0}))[0] == docs[0]
-        del self.c[docs[0]["_id"]]
+        del self.c[docs[0]["id_"]]
         assert len(self.c.find({"a.b": 0})) == 0
         assert len(self.c.find({"a": {"b": 0}})) == 0
 
@@ -395,12 +395,12 @@ class TestCollection:
 
     def test_replace_one_simple(self):
         assert len(self.c) == 0
-        doc = {"_id": "0", "a": 0}
-        self.c.replace_one({"_id": "0"}, doc, upsert=False)
+        doc = {"id_": "0", "a": 0}
+        self.c.replace_one({"id_": "0"}, doc, upsert=False)
         assert len(self.c) == 0
-        self.c.replace_one({"_id": "0"}, doc, upsert=True)
+        self.c.replace_one({"id_": "0"}, doc, upsert=True)
         assert len(self.c) == 1
-        self.c.replace_one({"_id": "0"}, doc, upsert=True)
+        self.c.replace_one({"id_": "0"}, doc, upsert=True)
         assert len(self.c) == 1
 
     def test_replace_one(self):
@@ -620,7 +620,7 @@ class TestCompressedCollection(TestCollection):
 
     def test_compression(self):
         # Fill with data
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         self.c.flush()
 
@@ -666,7 +666,7 @@ class TestCollectionToFromJson:
         request.addfinalizer(self._tmp_dir.cleanup)
         self._fn_json = os.path.join(self._tmp_dir.name, "test.json")
         self.c = Collection.open(filename=":memory:")
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         self.c.flush()
 
@@ -686,7 +686,7 @@ class TestFileCollectionReadOnly:
         request.addfinalizer(self._tmp_dir.cleanup)
         self._fn_collection = os.path.join(self._tmp_dir.name, "test.txt")
         with Collection.open(self._fn_collection, "w") as c:
-            c.update([dict(_id=str(i)) for i in range(10)])
+            c.update([dict(id_=str(i)) for i in range(10)])
 
     def test_read(self):
         c = Collection.open(self._fn_collection, mode="r")
@@ -721,13 +721,13 @@ class TestFileCollection(TestCollection):
         request.addfinalizer(self.c.close)
 
     def test_write_and_flush(self):
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         self.c.flush()
         assert os.path.getsize(self._fn_collection) > 0
 
     def test_write_flush_and_reopen(self):
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         self.c.flush()
         assert os.path.getsize(self._fn_collection) > 0
@@ -735,7 +735,7 @@ class TestFileCollection(TestCollection):
         with Collection.open(self._fn_collection) as c:
             assert len(c) == len(docs)
             for doc in self.c:
-                assert doc["_id"] in c
+                assert doc["id_"] in c
 
 
 class TestBinaryFileCollection(TestCollection):
@@ -746,7 +746,7 @@ class TestFileCollectionAppend(TestFileCollection):
     mode = "a"
 
     def test_file_size(self):
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
 
         with open(self._fn_collection) as f:
             assert len(list(f)) == 0
@@ -757,7 +757,7 @@ class TestFileCollectionAppend(TestFileCollection):
         with Collection.open(self._fn_collection) as c:
             assert len(c) == len(docs)
             for doc in docs:
-                c.replace_one({"_id": doc["_id"]}, doc)
+                c.replace_one({"id_": doc["id_"]}, doc)
         with Collection.open(self._fn_collection) as c:
             assert len(c) == len(docs)
         with open(self._fn_collection) as f:
@@ -781,7 +781,7 @@ class TestZippedFileCollection(TestFileCollection):
     mode = "wb"
 
     def test_compression_level(self):
-        docs = [dict(_id=str(i)) for i in range(10)]
+        docs = [dict(id_=str(i)) for i in range(10)]
         self.c.update(docs)
         self.c.flush()
         fn_txt = self._fn_collection + ".txt"

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -89,28 +89,28 @@ class _TestFS:
             self.cache[self.file_id] = self.getvalue()
             super(_TestFS._Writer, self).close()
 
-    def __init__(self, _id="_testFS"):
-        self._id = _id
+    def __init__(self, id_="_testFS"):
+        self.id_ = id_
 
     def config(self):
-        return {"id": self._id}
+        return {"id": self.id_}
 
     @classmethod
     def from_config(cls, config):
-        return _TestFS(_id=config["id"])
+        return _TestFS(id_=config["id"])
 
     def new_file(self, mode="xb", **kwargs):
-        _id = kwargs["_id"]
-        cache = self.files.setdefault(self._id, dict())
-        if _id in cache:
-            raise self.FileExistsError(_id)
+        id_ = kwargs["id_"]
+        cache = self.files.setdefault(self.id_, dict())
+        if id_ in cache:
+            raise self.FileExistsError(id_)
         if mode == "xb":
-            return self._Writer(cache, _id)
+            return self._Writer(cache, id_)
         else:
             raise ValueError(mode)
 
     def get(self, file_id, mode="r"):
-        cache = self.files[self._id]
+        cache = self.files[self.id_]
         buf = cache[file_id]
         if mode == "r":
             return io.StringIO(buf.decode())
@@ -281,7 +281,7 @@ class TestIndexingBase:
         for i, doc in enumerate(docs):
             assert doc["a"] == i
             assert doc["format"] is None
-        ids = {doc["_id"] for doc in docs}
+        ids = {doc["id_"] for doc in docs}
         assert len(ids) == len(docs)
 
     def test_main_crawler(self):
@@ -352,7 +352,7 @@ class TestIndexingBase:
                 signac.export_one(doc, index)
             assert index.replace_one.called
             for doc in crawler.crawl():
-                assert index.find_one({"_id": doc["_id"]}) is not None
+                assert index.find_one({"id_": doc["id_"]}) is not None
 
     def test_export(self):
         self.setup_project()
@@ -363,7 +363,7 @@ class TestIndexingBase:
             signac.export(crawler.crawl(), index)
             assert index.replace_one.called or index.bulk_write.called
             for doc in crawler.crawl():
-                assert index.find_one({"_id": doc["_id"]}) is not None
+                assert index.find_one({"id_": doc["id_"]}) is not None
 
     def test_export_with_update(self):
         self.setup_project()
@@ -374,7 +374,7 @@ class TestIndexingBase:
             signac.export(index, collection, update=True)
         assert collection.replace_one.called or collection.bulk_write.called
         for doc in index:
-            assert collection.find_one({"_id": doc["_id"]}) is not None
+            assert collection.find_one({"id_": doc["id_"]}) is not None
         collection.reset_mock()
         assert len(index) == collection.find().count()
         assert collection.find.called
@@ -382,7 +382,7 @@ class TestIndexingBase:
             signac.export(index, collection, update=True)
         assert collection.replace_one.called or collection.bulk_write.called
         for doc in index:
-            assert collection.find_one({"_id": doc["_id"]}) is not None
+            assert collection.find_one({"id_": doc["id_"]}) is not None
         assert len(index) == collection.find().count()
         collection.reset_mock()
         for fn in ("a_0.txt", "a_1.txt"):
@@ -422,7 +422,7 @@ class TestIndexingBase:
                 signac.export_to_mirror(doc, mirror)
             assert index.replace_one.called
             for doc in crawler.crawl():
-                assert index.find_one({"_id": doc["_id"]}) is not None
+                assert index.find_one({"id_": doc["id_"]}) is not None
                 with mirror.get(doc["file_id"]):
                     pass
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -141,7 +141,7 @@ class TestJob(TestJobBase):
             """Minimal subclass that can be compared with Job objects."""
 
             def __init__(self, job):
-                self._id = job.id
+                self.id_ = job.id
                 self._workspace = job.workspace()
 
             def workspace(self):
@@ -1592,23 +1592,23 @@ class TestJobOpenData(TestJobBase):
 
     def test_statepoint_copy(self):
         job = self.open_job(dict(a=test_token, b=test_token)).init()
-        _id = job.id
+        id_ = job.id
         sp_copy = copy.copy(job.sp)
         del sp_copy["b"]
         assert "a" in job.sp
         assert "b" not in job.sp
         assert job in self.project
-        assert job.id != _id
+        assert job.id != id_
 
     def test_statepoint_deepcopy(self):
         job = self.open_job(dict(a=test_token, b=test_token)).init()
-        _id = job.id
+        id_ = job.id
         sp_copy = copy.deepcopy(job.sp)
         del sp_copy["b"]
         assert "a" in job.sp
         assert "b" in job.sp
         assert job not in self.project
-        assert job.id == _id
+        assert job.id == id_
 
 
 @pytest.mark.skipif(not H5PY, reason="test requires the h5py package")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -660,7 +660,7 @@ class TestProject(TestProjectBase):
             self.project.open_job(sp).document["test"] = True
         job_ids = {job.id for job in self.project.find_jobs()}
         docs = list(self.project.index())
-        job_ids_cmp = {doc["_id"] for doc in docs}
+        job_ids_cmp = {doc["id_"] for doc in docs}
         assert job_ids == job_ids_cmp
         assert len(docs) == len(statepoints)
         for sp in statepoints:
@@ -673,7 +673,7 @@ class TestProject(TestProjectBase):
             )
         )
         assert len(docs) == 2 * len(statepoints)
-        assert len({doc["_id"] for doc in docs}) == len(docs)
+        assert len({doc["id_"] for doc in docs}) == len(docs)
 
     # Index schema is changed
     @pytest.mark.xfail()
@@ -684,16 +684,16 @@ class TestProject(TestProjectBase):
         job_ids = {job.id for job in self.project.find_jobs()}
         index = {}
         for doc in self.project.index():
-            index[doc["_id"]] = doc
+            index[doc["id_"]] = doc
         assert len(index) == len(job_ids)
         assert set(index.keys()) == set(job_ids)
         crawler = signac.contrib.SignacProjectCrawler(self.project.root_directory())
         index2 = {}
         for doc in crawler.crawl():
-            index2[doc["_id"]] = doc
-        for _id, _id2 in zip(index, index2):
-            assert _id == _id2
-            assert index[_id] == index2[_id]
+            index2[doc["id_"]] = doc
+        for id_, _id2 in zip(index, index2):
+            assert id_ == _id2
+            assert index[id_] == index2[id_]
         assert index == index2
         for job in self.project.find_jobs():
             with open(job.fn("test.txt"), "w") as file:
@@ -701,7 +701,7 @@ class TestProject(TestProjectBase):
         formats = {r".*" + re.escape(os.path.sep) + r"test\.txt": "TextFile"}
         index = {}
         for doc in self.project.index(formats):
-            index[doc["_id"]] = doc
+            index[doc["id_"]] = doc
         assert len(index) == 2 * len(job_ids)
 
         class Crawler(signac.contrib.SignacProjectCrawler):
@@ -711,7 +711,7 @@ class TestProject(TestProjectBase):
                 Crawler.called = True
                 doc = super().process(doc=doc, dirpath=dirpath, fn=fn)
                 if "format" in doc and doc["format"] is None:
-                    assert doc["_id"] == doc["signac_id"]
+                    assert doc["id_"] == doc["signac_id"]
                 return doc
 
         for p, fmt in formats.items():
@@ -719,7 +719,7 @@ class TestProject(TestProjectBase):
                 Crawler.define(p, fmt)
         index2 = {}
         for doc in Crawler(root=self.project.root_directory()).crawl():
-            index2[doc["_id"]] = doc
+            index2[doc["id_"]] = doc
         assert index == index2
         assert Crawler.called
 
@@ -1764,7 +1764,7 @@ class TestLinkedViewProject(TestProjectBase):
         job_subset = self.project.find_jobs({"b": 0})
         id_subset = [job.id for job in job_subset]
 
-        bad_index = [dict(_id=i) for i in range(3)]
+        bad_index = [dict(id_=i) for i in range(3)]
         with pytest.raises(ValueError):
             self.project.create_linked_view(
                 prefix=view_prefix, job_ids=id_subset, index=bad_index
@@ -2469,7 +2469,7 @@ class TestProjectInit:
         job_a.init()
         job_b = project_b.open_job({"b": 1})
         job_b.init()
-        symlink_path = os.path.join(project_b.workspace(), job_a._id)
+        symlink_path = os.path.join(project_b.workspace(), job_a.id_)
         os.symlink(job_a.ws, symlink_path)
         assert project_a.get_job(symlink_path) == job_a
         assert project_b.get_job(symlink_path) == job_a


### PR DESCRIPTION
I changed the codebase to use id_ instead of _id.

## Motivation and Context
This helps to avoid shadowing builtins.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

N.B. this is a refactor.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
