### PR TITLE
Split test for signac config verify.

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -866,15 +866,10 @@ class TestBasicShell:
         cfg = self.call("python -m signac config --local show".split())
         assert "Mongo" not in cfg
 
-    @pytest.mark.skipif(
-        not PYMONGO, reason="pymongo is required for host configuration"
-    )
     def test_config_verify(self):
         # no config file
         with pytest.raises(ExitCodeError):
-            err = self.call(
-                "python -m signac config --local verify".split(), error=True
-            )
+            self.call("python -m signac config --local verify".split(), error=True)
         err = self.call(
             "python -m signac config --local verify".split(),
             error=True,
@@ -885,6 +880,11 @@ class TestBasicShell:
         err = self.call("python -m signac config --local verify".split(), error=True)
         assert "Passed" in err
 
+    @pytest.mark.skipif(
+        not PYMONGO, reason="pymongo is required for host configuration"
+    )
+    def test_config_verify_mongo(self):
+        self.call("python -m signac init my_project".split())
         self.call("python -m signac config --local host Mongo -u abc -p 123".split())
         err = self.call("python -m signac config --local verify".split(), error=True)
         assert "hosts.Mongo.password_config.[missing section]" in err


### PR DESCRIPTION
## Description
This splits a test for `signac config verify` so that the parts not requiring pymongo can be executed independently.

## Motivation and Context
Improves testing. @vyasr had asked me about tests for `signac config verify` a while back and I had these changes stored locally.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.