### PR TITLE
Use `FutureWarning` instead of `DeprecationWarning`.

### DIFF
--- a/signac/common/configobj/__init__.py
+++ b/signac/common/configobj/__init__.py
@@ -1188,7 +1188,7 @@ class ConfigObj(Section):
             warnings.warn(
                 "Passing in an options dictionary to ConfigObj() is "
                 "deprecated. Use **options instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
 
             # TODO: check the values too.

--- a/signac/common/configobj/__init__.py
+++ b/signac/common/configobj/__init__.py
@@ -1188,7 +1188,7 @@ class ConfigObj(Section):
             warnings.warn(
                 "Passing in an options dictionary to ConfigObj() is "
                 "deprecated. Use **options instead.",
-                DeprecationWarning,
+                FutureWarning,
             )
 
             # TODO: check the values too.

--- a/signac/contrib/indexing.py
+++ b/signac/contrib/indexing.py
@@ -620,7 +620,7 @@ class MasterCrawler(MainCrawler):
         warnings.warn(
             "The MasterCrawler class has been replaced by the MainCrawler class. "
             "Both classes are deprecated and will be removed in a future release.",
-            DeprecationWarning,
+            FutureWarning,
         )
         super().__init__(*args, **kwargs)
 

--- a/signac/synced_collections/backends/collection_json.py
+++ b/signac/synced_collections/backends/collection_json.py
@@ -49,7 +49,7 @@ def _str_key(key):
         warnings.warn(
             f"Use of {type(key).__name__} as key is deprecated "
             "and will be removed in version 2.0",
-            DeprecationWarning,
+            FutureWarning,
         )
         key = str(key)
     return key
@@ -146,7 +146,7 @@ def json_attr_dict_validator(data):
                 warnings.warn(
                     f"Use of {type(key).__name__} as key is deprecated "
                     "and will be removed in version 2.0.",
-                    DeprecationWarning,
+                    FutureWarning,
                 )
                 data[str(key)] = data.pop(key)
             else:

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -364,9 +364,7 @@ class FileBufferedCollection(BufferedCollection):
         """
         if force_write is not None:
             warnings.warn(
-                FutureWarning(
                     "The force_write parameter is deprecated and will be removed in "
-                    "signac 2.0. This functionality is no longer supported."
-                )
-            )
+                    "signac 2.0. This functionality is no longer supported.", FutureWarning)
+            
         return cls._buffer_context(buffer_size)

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -364,7 +364,7 @@ class FileBufferedCollection(BufferedCollection):
         """
         if force_write is not None:
             warnings.warn(
-                DeprecationWarning(
+                FutureWarning(
                     "The force_write parameter is deprecated and will be removed in "
                     "signac 2.0. This functionality is no longer supported."
                 )

--- a/signac/synced_collections/buffers/file_buffered_collection.py
+++ b/signac/synced_collections/buffers/file_buffered_collection.py
@@ -364,7 +364,9 @@ class FileBufferedCollection(BufferedCollection):
         """
         if force_write is not None:
             warnings.warn(
-                    "The force_write parameter is deprecated and will be removed in "
-                    "signac 2.0. This functionality is no longer supported.", FutureWarning)
-            
+                "The force_write parameter is deprecated and will be removed in "
+                "signac 2.0. This functionality is no longer supported.",
+                FutureWarning,
+            )
+
         return cls._buffer_context(buffer_size)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import signac
 @contextmanager
 def deprecated_in_version(version_string):
     if version.parse(version_string) <= version.parse(signac.__version__):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             yield
     else:
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from packaging import version
 
 import signac
 
+
 @pytest.fixture
 def testdata():
     return str(uuid.uuid4())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,6 @@
 import uuid
-from contextlib import contextmanager
 
 import pytest
-from packaging import version
-
-import signac
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,16 +6,6 @@ from packaging import version
 
 import signac
 
-
-@contextmanager
-def deprecated_in_version(version_string):
-    if version.parse(version_string) <= version.parse(signac.__version__):
-        with pytest.warns(FutureWarning):
-            yield
-    else:
-        yield
-
-
 @pytest.fixture
 def testdata():
     return str(uuid.uuid4())

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,7 +20,6 @@ from zipfile import ZipFile
 
 import pytest
 import test_h5store
-from conftest import deprecated_in_version
 from packaging import version
 from test_job import TestJobBase
 
@@ -1099,7 +1098,7 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(tmp_root_dir)
 
     def test_access_module(self):
-        with deprecated_in_version("1.5"):
+        with pytest.deprecated_call():
             self.project.create_access_module()
 
 

--- a/tests/test_synced_collections/test_json_collection.py
+++ b/tests/test_synced_collections/test_json_collection.py
@@ -52,7 +52,7 @@ class TestJSONDict(JSONCollectionTest, SyncedDictTest):
     # See issue: https://github.com/glotzerlab/signac/issues/316.
     def test_keys_non_str_valid_type(self, synced_collection, testdata):
         for key in (0, None, True):
-            with pytest.deprecated_call(match="Use of.+as key is deprecated"):
+            with pytest.warns(FutureWarning, match="Use of.+as key is deprecated"):
                 synced_collection[key] = testdata
             assert str(key) in synced_collection
             assert synced_collection[str(key)] == testdata


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Fixes issues as described by @vyasr in Issue https://github.com/glotzerlab/signac/issues/687 as we tend to change the DeprecationWarning to FutureWarning instead.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The main motivation of this change is basically that warnings of the deprecated features are visible to the users as in current scenarios of Deprecated warnings python hides these by default.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
