### PR TITLE
Remove support for custom job subclass

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Removed
 +++++++
 
  - The ``Project.config`` property is no longer mutable. Use the command line ``$ signac config`` to modify configuration (#608, #246, #244).
+ - ``Project`` subclasses can no longer define a ``Job`` subclass to use (#588, #693).
 
 Version 1
 =========

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -18,6 +18,7 @@ from tempfile import TemporaryDirectory
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from .errors import DestinationExistsError, StatepointParsingError
+from .job import Job
 from .utility import _dotted_dict_to_nested_dicts, _mkdir_p
 
 logger = logging.getLogger(__name__)
@@ -857,7 +858,7 @@ def _analyze_directory_for_import(root, project, schema):
 
     """
     # Determine schema function
-    read_statepoint_file = _parse_workspaces(project.Job.FN_STATE_POINT)
+    read_statepoint_file = _parse_workspaces(Job.FN_STATE_POINT)
     if schema is None:
         schema_function = read_statepoint_file
     elif callable(schema):
@@ -968,7 +969,7 @@ def _analyze_zipfile_for_import(zipfile, project, schema):
 
         """
         # Must use forward slashes, not os.path.sep.
-        fn_statepoint = path + "/" + project.Job.FN_STATE_POINT
+        fn_statepoint = path + "/" + Job.FN_STATE_POINT
         if fn_statepoint in names:
             return json.loads(zipfile.read(fn_statepoint).decode())
 
@@ -1114,7 +1115,7 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
 
         """
         # Must use forward slashes, not os.path.sep.
-        fn_statepoint = _tarfile_path_join(path, project.Job.FN_STATE_POINT)
+        fn_statepoint = _tarfile_path_join(path, Job.FN_STATE_POINT)
         try:
             with closing(tarfile.extractfile(fn_statepoint)) as file:
                 return json.loads(file.read())

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -97,8 +97,6 @@ class Project:
 
     """
 
-    Job = Job
-
     FN_DOCUMENT = "signac_project_document.json"
     "The project's document filename."
 
@@ -530,10 +528,10 @@ class Project:
             raise ValueError("Either statepoint or id must be provided, but not both.")
         if id is None:
             # Second best case (Job will update self._sp_cache on init)
-            return self.Job(project=self, statepoint=statepoint)
+            return Job(project=self, statepoint=statepoint)
         try:
             # Optimal case (id is in the state point cache)
-            return self.Job(project=self, statepoint=self._sp_cache[id], _id=id)
+            return Job(project=self, statepoint=self._sp_cache[id], _id=id)
         except KeyError:
             # Worst case: no state point was provided and the state point cache
             # missed. The Job will register itself in self._sp_cache when the
@@ -552,7 +550,7 @@ class Project:
             elif not self._contains_job_id(id):
                 # id does not exist in the project data space
                 raise KeyError(id)
-            return self.Job(project=self, _id=id)
+            return Job(project=self, _id=id)
 
     def _job_dirs(self):
         """Generate ids of jobs in the workspace.
@@ -854,7 +852,7 @@ class Project:
         # Performance-critical path. We can rely on the project workspace, job
         # id, and state point file name to be well-formed, so just use str.join
         # with os.sep instead of os.path.join for speed.
-        fn_statepoint = os.sep.join((self.workspace(), job_id, self.Job.FN_STATE_POINT))
+        fn_statepoint = os.sep.join((self.workspace(), job_id, Job.FN_STATE_POINT))
         try:
             with open(fn_statepoint, "rb") as statepoint_file:
                 return json.loads(statepoint_file.read().decode())
@@ -1349,7 +1347,7 @@ class Project:
                     # well-formed, so just use str.join with os.sep instead of
                     # os.path.join for speed.
                     fn_document = os.sep.join(
-                        (self.workspace(), job_id, self.Job.FN_DOCUMENT)
+                        (self.workspace(), job_id, Job.FN_DOCUMENT)
                     )
                     with open(fn_document, "rb") as file:
                         doc["doc"] = json.loads(file.read().decode())

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2227,6 +2227,8 @@ class TestLinkedViewProject(TestProjectBase):
 
 
 class UpdateCacheAfterInitJob(signac.contrib.job.Job):
+    """Test job class that updates the project cache on job init."""
+
     def init(self, *args, **kwargs):
         job = super().init(*args, **kwargs)
         self._project.update_cache()
@@ -2234,8 +2236,14 @@ class UpdateCacheAfterInitJob(signac.contrib.job.Job):
 
 
 class UpdateCacheAfterInitJobProject(signac.Project):
-    "This is a test class that regularly calls the update_cache() method."
-    Job = UpdateCacheAfterInitJob
+    """Test project class that updates the project cache on job init."""
+
+    def open_job(self, *args, **kwargs):
+        job = super().open_job(*args, **kwargs)
+        cache_updating_job = UpdateCacheAfterInitJob(
+            job._project, job.statepoint(), job._id
+        )
+        return cache_updating_job
 
 
 class TestCachedProject(TestProject):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -680,21 +680,6 @@ class TestProject(TestProjectBase):
         assert isinstance(project, signac.Project)
         assert isinstance(project, CustomProject)
 
-    def test_custom_job_class(self):
-        class CustomJob(signac.contrib.job.Job):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-
-        class CustomProject(signac.Project):
-            Job = CustomJob
-
-        project = CustomProject.get_project(root=self.project.root_directory())
-        assert isinstance(project, signac.Project)
-        assert isinstance(project, CustomProject)
-        job = project.open_job(dict(a=0))
-        assert isinstance(job, CustomJob)
-        assert isinstance(job, signac.contrib.job.Job)
-
     def test_project_contains(self):
         job = self.open_job(dict(a=0))
         assert job not in self.project


### PR DESCRIPTION
## Description
This PR removes support for custom `Job` subclasses defined in custom `Project` subclasses.

## Motivation and Context
This feature is inadequately tested, difficult to maintain, and inefficient compared to the default `Job` class where we can exploit the known behavior of functions like `job.workspace()`. This feature is also not used to the best of my knowledge.

Resolves #588.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.