### PR TITLE
Run asv benchmarks instead of `benchmark.py` in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,7 @@ jobs:
               . venv/bin/activate
               ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-benchmark.txt
               ${PYTHON} -m pip freeze
-              ${PYTHON} -m asv machine --machine circleci
-              ${PYTHON} -m asv continuous --machine circleci master "${CIRCLE_SHA1}"
+              ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report
               git reset --hard origin/master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ jobs:
               . venv/bin/activate
               ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-benchmark.txt
               ${PYTHON} -m pip freeze
+              ${PYTHON} -m asv check
+              ${PYTHON} -m asv machine --yes
               ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ jobs:
               . venv/bin/activate
               ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-benchmark.txt
               ${PYTHON} -m pip freeze
+              ${PYTHON} -m asv machine --yes
+              ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report
               git reset --hard origin/master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
               ${PYTHON} -m pip freeze
               ${PYTHON} -m asv check
               ${PYTHON} -m asv machine --yes
-              ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
+              ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}" --no-only-changed
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report
               git reset --hard origin/master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
               ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-benchmark.txt
               ${PYTHON} -m pip freeze
               ${PYTHON} -m asv machine --machine circleci
-              ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
+              ${PYTHON} -m asv continuous --machine circleci master "${CIRCLE_SHA1}"
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report
               git reset --hard origin/master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
               . venv/bin/activate
               ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-benchmark.txt
               ${PYTHON} -m pip freeze
-              ${PYTHON} -m asv machine --yes
+              ${PYTHON} -m asv machine --machine circleci
               ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}"
               ${PYTHON} benchmark.py run -N 100 1000  # this revision
               ${PYTHON} benchmark.py report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,12 +95,12 @@ jobs:
               ${PYTHON} -m asv check
               ${PYTHON} -m asv machine --yes
               ${PYTHON} -m asv continuous master "${CIRCLE_SHA1}" --no-only-changed
-              ${PYTHON} benchmark.py run -N 100 1000  # this revision
-              ${PYTHON} benchmark.py report
-              git reset --hard origin/master
-              git checkout "${CIRCLE_SHA1}" -- benchmark.py  # ensure that we use the same benchmark script
-              ${PYTHON} benchmark.py run -N 100 1000 --force
-              ${PYTHON} benchmark.py compare origin/master "${CIRCLE_SHA1}"
+              #${PYTHON} benchmark.py run -N 100 1000  # this revision
+              #${PYTHON} benchmark.py report
+              #git reset --hard origin/master
+              #git checkout "${CIRCLE_SHA1}" -- benchmark.py  # ensure that we use the same benchmark script
+              #${PYTHON} benchmark.py run -N 100 1000 --force
+              #${PYTHON} benchmark.py compare origin/master "${CIRCLE_SHA1}"
             fi
 
   linux-python-310-minimal:

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -98,6 +98,10 @@ PARAMETERS = {
 class _ProjectBenchBase:
     param_names = PARAMETERS.keys()
     params = PARAMETERS.values()
+    rounds = 3
+    repeat = (1, 1, 0)
+    sample_time = 0.1
+    min_run_count = 3
 
     def setup(self, *params):
         N, num_keys, num_doc_keys, data_size_mean, data_size_std = params

--- a/requirements/requirements-benchmark.txt
+++ b/requirements/requirements-benchmark.txt
@@ -5,3 +5,4 @@ GitPython==3.1.26
 numpy==1.22.2
 pandas==1.4.1; implementation_name=='cpython' --no-binary :none:
 psutil==5.9.0
+virtualenv==20.13.2

--- a/requirements/requirements-benchmark.txt
+++ b/requirements/requirements-benchmark.txt
@@ -1,3 +1,4 @@
+asv==0.5.1
 click==8.0.4
 gitdb2==4.0.2
 GitPython==3.1.26


### PR DESCRIPTION
## Description
This PR runs benchmarks with asv instead of `benchmark.py`. This uses `asv continuous`, which is intended for CI testing: https://asv.readthedocs.io/en/stable/commands.html#asv-continuous

Currently, I am not very satisfied with the results I get here. I have experimented locally and in CI, and I have not found a good way to keep the benchmark runtime low while ensuring a small runtime variance (through repetitions). asv's approach spawns processes for each test and creates virtual environments for each commit, which may help with reproducibility but costs a lot of time. Previously, the CI benchmarks took less than 15 seconds for jobs like [this one](https://app.circleci.com/pipelines/github/glotzerlab/signac/2760/workflows/39215278-126c-4f55-89be-04503d706af2/jobs/19027). Meanwhile, the current [asv CI benchmarks](https://app.circleci.com/pipelines/github/glotzerlab/signac/2776/workflows/4eb5e0d7-980a-4324-9661-eaa88fcd0432/jobs/19153) take longer and have an unacceptably variance in runtime, leading to some [random failures](https://app.circleci.com/pipelines/github/glotzerlab/signac/2777/workflows/0b38d126-1104-41d0-bd9e-c8e5999adc4d/jobs/19161). Increasing the numbers of repetitions/rounds/samples/etc. can help with variance but will also increase runtime. I don't think we can get asv benchmarks to run as quickly as `benchmark.py` (or within, say, 1 minute) while keeping the limits on variance that we need for accuracy.

I'm not sure what to do with this and am near the limit of my interest in retaining CI benchmarks, so I might recommend removing CI benchmarks entirely (the existing CI benchmarks also have somewhat high variance).

## Motivation and Context
`benchmark.py` relies on `signac.Collection` which we plan to remove in #683. Using asv instead of `benchmark.py` is one way to keep CI benchmarks while removing that script.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.