### PR TITLE
Run tests in parallel with pytest-xdist.

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -8,6 +8,7 @@ packaging==15.0
 pandas==1.0.0
 pymongo==3.0.0
 pytest-cov==2.10.1
+pytest-xdist==2.5.0
 pytest==6.2.1
 tables==3.4.2
 tqdm==4.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest --cov signac --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n auto --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ${PYTHON} -m pytest --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n auto --cov=signac --cov-report=xml tests/ -v
             codecov
 
   macos-python-3:
@@ -195,7 +195,7 @@ jobs:
             python -m pip install --progress-bar off -U -r requirements/requirements-test.txt
             python -m pip install --progress-bar off -U -r requirements/requirements-test-optional.txt
             python -m pip install --progress-bar off -U -e .
-            python -m pytest --cov=signac --cov-report=xml tests/ -v
+            python -m pytest -n auto --cov=signac --cov-report=xml tests/ -v
             codecov
 
   check-metadata:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest -n 2 --dist loadscope --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ${PYTHON} -m pytest -n 2 --dist loadscope --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
             codecov
 
   macos-python-3:
@@ -195,7 +195,7 @@ jobs:
             python -m pip install --progress-bar off -U -r requirements/requirements-test.txt
             python -m pip install --progress-bar off -U -r requirements/requirements-test-optional.txt
             python -m pip install --progress-bar off -U -e .
-            python -m pytest -n 2 --dist loadscope --cov=signac --cov-report=xml tests/ -v
+            python -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
             codecov
 
   check-metadata:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest -n auto --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ${PYTHON} -m pytest -n auto --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --cov=signac --cov-report=xml tests/ -v
             codecov
 
   macos-python-3:
@@ -195,7 +195,7 @@ jobs:
             python -m pip install --progress-bar off -U -r requirements/requirements-test.txt
             python -m pip install --progress-bar off -U -r requirements/requirements-test-optional.txt
             python -m pip install --progress-bar off -U -e .
-            python -m pytest -n auto --cov=signac --cov-report=xml tests/ -v
+            python -m pytest -n 2 --cov=signac --cov-report=xml tests/ -v
             codecov
 
   check-metadata:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest -n 2 --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ${PYTHON} -m pytest -n 2 --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
             codecov
 
   macos-python-3:
@@ -195,7 +195,7 @@ jobs:
             python -m pip install --progress-bar off -U -r requirements/requirements-test.txt
             python -m pip install --progress-bar off -U -r requirements/requirements-test-optional.txt
             python -m pip install --progress-bar off -U -e .
-            python -m pytest -n 2 --cov=signac --cov-report=xml tests/ -v
+            python -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
             codecov
 
   check-metadata:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadscope --cov=signac --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ${PYTHON} -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
+            ${PYTHON} -m pytest -n 2 --dist loadscope --cov=signac --cov-report=xml tests/ -v
             codecov
 
   macos-python-3:
@@ -195,7 +195,7 @@ jobs:
             python -m pip install --progress-bar off -U -r requirements/requirements-test.txt
             python -m pip install --progress-bar off -U -r requirements/requirements-test-optional.txt
             python -m pip install --progress-bar off -U -e .
-            python -m pytest -n 2 --dist loadfile --cov=signac --cov-report=xml tests/ -v
+            python -m pytest -n 2 --dist loadscope --cov=signac --cov-report=xml tests/ -v
             codecov
 
   check-metadata:

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@ Added
 
  - Official support for Python 3.10 (#631).
  - Benchmarks can be run using the ``asv`` (airspeed velocity) tool (#629).
- - Tests run in parallel with ``pytest-xdist`` (#705).
+ - Continuous integration tests run in parallel with ``pytest-xdist`` (#705).
 
 Changed
 +++++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Added
 
  - Official support for Python 3.10 (#631).
  - Benchmarks can be run using the ``asv`` (airspeed velocity) tool (#629).
+ - Tests run in parallel with ``pytest-xdist`` (#705).
 
 Changed
 +++++++

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,3 +1,4 @@
 coverage==6.3.2
 pytest==7.0.1
 pytest-cov==3.0.0
+pytest-xdist==2.5.0


### PR DESCRIPTION
## Description
This PR adds the plugin [pytest-xdist](https://pypi.org/project/pytest-xdist/) to run tests in parallel. Each CircleCI machine has two cores. This cuts off around 45 seconds from each CI job, which adds up to a decent amount of time across all jobs. The output is a little more verbose.

Before:
![image](https://user-images.githubusercontent.com/3943761/156471389-6a78b5be-60be-42b2-9a78-fbde19da4ea3.png)

After (ignore pypy, I pushed another commit before it finished):
![image](https://user-images.githubusercontent.com/3943761/156471472-93937a96-fe95-44a1-9b85-db80de1297f5.png)


## Motivation and Context
Might as well use all of the CI resources we are given. Saves a bit of time and probably reduces the energy needed by the server since it can sleep sooner.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
