### PR TITLE
Catch KeyError as another possible failure of multithreading

### DIFF
--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -481,7 +481,7 @@ class SyncedDictTest(SyncedCollectionTest):
         try:
             with ThreadPoolExecutor(max_workers=num_threads) as executor:
                 list(executor.map(set_value, [synced_collection] * num_threads * 10))
-        except (RuntimeError, JSONDecodeError):
+        except (RuntimeError, JSONDecodeError, KeyError):
             # This line may raise an exception, or it may successfully complete
             # but not modify all the expected data. If it raises an exception,
             # then the underlying data is likely to be invalid, so we must


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
When multithreading support is disabled, it is possible for operations on synced dicts to fail with a KeyError (as well as the other errors that were already being caught), so the multithreading test now catches that failure. Note that this is a bug in the test only, not in signac itself.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
PyPy3 tests of multithreading have been failing due to this omission (see #705 and #706). Additionally, once this failure occurs, the buffer is in an invalid state, so future multithreading tests can fail in unpredictable ways. I reproduced the issue by running `test_json_buffered_collection.py::TestBufferedJSONDictWriteConcern::test_multithreaded` using pytest-repeat to run the test 100 times. I invariably observed failures within this number of tests. I then verified that catching the KeyError and clearing the collection prevents the error by running the test a few times with 1000 repeats (with pytest-xdist just to make sure that #705 was safe). I observed no further errors.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
