### PR TITLE
Move discovery to separate functions.

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -363,7 +363,7 @@ def main_sync(args):
     """Handle sync subcommand."""
     # TODO: This function appears to be untested.
     #
-    # Valid provided argument combinations
+    # Validate provided argument combinations
     #
     if args.archive:
         args.recursive = True

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -412,6 +412,7 @@ def main_sync(args):
         destination = get_project(root=args.destination)
     except LookupError:
         if args.allow_workspace:
+            # TODO: Remove allow_workspace entirely.
             destination = Project(os.path.relpath(args.destination))
         else:
             _print_err(

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -361,6 +361,7 @@ def main_schema(args):
 
 def main_sync(args):
     """Handle sync subcommand."""
+    # TODO: This function appears to be untested.
     #
     # Valid provided argument combinations
     #
@@ -411,13 +412,7 @@ def main_sync(args):
         destination = get_project(root=args.destination)
     except LookupError:
         if args.allow_workspace:
-            destination = Project(
-                config={
-                    "project": os.path.relpath(args.destination),
-                    "project_dir": args.destination,
-                    "workspace_dir": ".",
-                }
-            )
+            destination = Project(os.path.relpath(args.destination))
         else:
             _print_err(
                 "WARNING: The destination appears to not be a project path. "
@@ -723,7 +718,7 @@ def main_config_show(args):
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
-        cfg = config.load_config()
+        cfg = config.load_config(config._locate_config_dir(os.getcwd()))
     if not cfg:
         if args.local:
             mode = "local"
@@ -756,7 +751,7 @@ def main_config_verify(args):
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
-        cfg = config.load_config()
+        cfg = config.load_config(config._locate_config_dir(os.getcwd()))
     if not cfg:
         if args.local:
             mode = "local"

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -20,65 +20,64 @@ def _get_project_config_fn(root):
     return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
 
 
-def _get_config_dirname(fn):
-    # We could use pathlib's `.paths` attribute to remove the trailing project
-    # config filename, but that has significant performance
-    # implications: this takes ~200 ns, whereas
-    # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
-    # 20x slowdown.
-    return fn.replace(os.sep + PROJECT_CONFIG_FN, "")
-
-
-def _search_local(root):
-    fn_ = _get_project_config_fn(root)
-    if os.path.isfile(fn_):
-        yield fn_
-
-
-def _search_tree(root=None):
-    """Locates signac configuration files in a directory hierarchy.
+def _contains_config_file(root):
+    """Determine if the root directory contains a signac configuration file.
 
     Parameters
     ----------
     root : str
         Path to search. Uses ``os.getcwd()`` if None (Default value = None).
 
+    Returns
+    --------
+    str or None
+        The path to the configuration file if one is found, otherwise None.
     """
-    if root is None:
-        root = os.getcwd()
+    fn_ = _get_project_config_fn(root)
+    if os.path.isfile(fn_):
+        return root
+    return None
+
+
+def _locate_config_dir(root):
+    """Locates root directory containing a signac configuration file in a directory hierarchy.
+
+    Parameters
+    ----------
+    root : str
+        Starting path to search.
+
+    Returns
+    --------
+    str or None
+        The root directory containing the configuration file if one is found, otherwise None.
+    """
     while True:
-        yield from _search_local(root)
+        if _contains_config_file(root):
+            return root
         up = os.path.abspath(os.path.join(root, ".."))
         if up == root:
             logger.debug("Reached filesystem root, no config found.")
-            return
+            return None
         else:
             root = up
-
-
-def _search_standard_dirs():
-    """Locates signac configuration files in standard directories."""
-    # For now this search only finds user-specific files, but it could be
-    # updated in the future to support e.g. system-wide config files.
-    for fn in (USER_CONFIG_FN,):
-        if os.path.isfile(fn):
-            yield fn
 
 
 def read_config_file(filename, configspec=None, *args, **kwargs):
     """Read a configuration file.
 
-    Parameters
-    ----------
-    filename : str
-        The path to the file to read.
-    configspec : List[str], optional
-        The key-value pairs supported in the config.
+        Parameters
+        ----------
+        filename : str
+            The path to the file to read.
+        configspec : List[str], optional
+            The key-value pairs supported in the config.
 
-    Returns
-    --------
-    :class:`Config`
-        The config contained in the file.
+        Returns
+        --------
+        :class:`Config`
+
+    The config contained in the file.
     """
     logger.debug(f"Reading config file '{filename}'.")
     if configspec is None:
@@ -99,45 +98,33 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
     return config
 
 
-def load_config(root=None, local=False):
-    """Load configuration, searching upward from a root path if desired.
+def load_config(root=None):
+    """Load configuration at root directory.
 
     Parameters
     ----------
     root : str
-        The path from which to begin searching for config files.
-    local : bool, optional
-        If ``True``, only search in the provided directory and do not traverse
-        upwards through the filesystem (Default value: False).
+        The path from which to load the local config.
 
     Returns
     --------
     :class:`Config`
         The composite configuration including both local and global config data
-        if requested.
+        if requested. Note that because this config is a composite,
+        modifications to the returned value will not be reflected in the files.
     """
     if root is None:
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))
-    if local:
-        search_func = _search_local
-    else:
-        for fn in _search_standard_dirs():
-            config.merge(read_config_file(fn))
-        search_func = _search_tree
 
-    for fn in search_func(root):
-        tmp = read_config_file(fn)
-        config.merge(tmp)
-        # Once a valid config file is found, we cease looking any further, i.e.
-        # we assume that the first directory with a valid config file is the
-        # project root.
-        # TODO: Rather than adding the project directory to the config, it
-        # should be returned separately (i.e. the return should become a tuple
-        # (root_dir, config). The current approach confuses the discovery with
-        # the contents of the config.
-        config["project_dir"] = _get_config_dirname(fn)
-        break
+    # Add in any global or user config files. For now this search only finds user-specific
+    # files, but it could be updated in the future to support e.g. system-wide config files.
+    for fn in (USER_CONFIG_FN,):
+        if os.path.isfile(fn):
+            config.merge(read_config_file(fn))
+
+    if _contains_config_file(root):
+        config.merge(read_config_file(_get_project_config_fn(root)))
     return config
 
 

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -15,12 +15,15 @@ logger = logging.getLogger(__name__)
 PROJECT_CONFIG_FN = os.path.join(".signac", "config")
 USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
 
+# TODO: Consider making this entire module internal and removing all its
+# functions from the public API.
+
 
 def _get_project_config_fn(root):
     return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
 
 
-def _locate_config_dir(root):
+def _locate_config_dir(search_path):
     """Locates root directory containing a signac configuration file in a directory hierarchy.
 
     Parameters
@@ -33,7 +36,7 @@ def _locate_config_dir(root):
     str or None
         The root directory containing the configuration file if one is found, otherwise None.
     """
-    root = os.path.abspath(root)
+    root = os.path.abspath(search_path)
     while True:
         if os.path.isfile(_get_project_config_fn(root)):
             return root
@@ -47,17 +50,13 @@ def _locate_config_dir(root):
             root = up
 
 
-def read_config_file(filename, configspec=None, *args, **kwargs):
+def read_config_file(filename):
     """Read a configuration file.
 
     Parameters
     ----------
     filename : str
         The path to the file to read.
-    configspec : List[str], optional
-        The key-value pairs supported in the config. If None, uses the default
-        pairs supported by signac, see :data:`signac.common.validate.cfg`
-        (Default value = None).
 
     Returns
     --------
@@ -65,10 +64,9 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
         The config contained in the file.
     """
     logger.debug(f"Reading config file '{filename}'.")
-    if configspec is None:
-        configspec = cfg.split("\n")
+    configspec = cfg.split("\n")
     try:
-        config = Config(filename, configspec=configspec, *args, **kwargs)
+        config = Config(filename, configspec=configspec)
     except (OSError, ConfigObjError) as error:
         raise ConfigError(f"Failed to read configuration file '{filename}':\n{error}")
     verification = config.verify()

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -14,6 +14,7 @@ def get_validator():  # noqa: D103
     return Validator()
 
 
+# TODO: Rename to something internal and uppercase e.g. _CFG.
 cfg = """
 workspace_dir = string(default='workspace')
 schema_version = string(default='1')

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -23,7 +23,9 @@ from packaging import version
 
 from ..common.config import (
     Config,
+    _contains_config_file,
     _get_project_config_fn,
+    _locate_config_dir,
     load_config,
     read_config_file,
 )
@@ -120,9 +122,14 @@ class Project:
     def __init__(self, root=None):
         if root is None:
             root = os.getcwd()
+        if not _contains_config_file(root):
+            raise LookupError(
+                f"Unable to find project at path '{os.path.abspath(root)}'."
+            )
+
         # Project constructor does not search upward, so the provided root must
         # be a project directory.
-        config = load_config(root, local=True)
+        config = load_config(root)
         self._config = _ProjectConfig(config)
         self._lock = RLock()
 
@@ -137,7 +144,7 @@ class Project:
 
         # Prepare root directory and workspace paths.
         # os.path is used instead of pathlib.Path for performance.
-        self._root_directory = self.config["project_dir"]
+        self._root_directory = os.path.abspath(root)
         self._workspace = os.path.expandvars(
             self.config.get("workspace_dir", "workspace")
         )
@@ -1611,18 +1618,20 @@ class Project:
         """
         if root is None:
             root = os.getcwd()
-        config = load_config(root=root, local=not search)
-        if "project_dir" not in config or (
-            not search
-            and os.path.realpath(config["project_dir"]) != os.path.realpath(root)
-        ):
-            raise LookupError(
-                "Unable to determine project id for path '{}'.".format(
-                    os.path.abspath(root)
+        if not search:
+            if not _contains_config_file(root):
+                raise LookupError(
+                    f"Unable to find project at path '{os.path.abspath(root)}'."
                 )
-            )
+        else:
+            old_root = root
+            root = _locate_config_dir(root)
+            if not root:
+                raise LookupError(
+                    f"Unable to find project at path '{os.path.abspath(old_root)}'."
+                )
 
-        return cls(root=config["project_dir"], **kwargs)
+        return cls(root=root, **kwargs)
 
     @classmethod
     def get_job(cls, root=None):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -23,7 +23,6 @@ from packaging import version
 
 from ..common.config import (
     Config,
-    _contains_config_file,
     _get_project_config_fn,
     _locate_config_dir,
     load_config,
@@ -122,7 +121,7 @@ class Project:
     def __init__(self, root=None):
         if root is None:
             root = os.getcwd()
-        if not _contains_config_file(root):
+        if not os.path.isfile(_get_project_config_fn(root)):
             raise LookupError(
                 f"Unable to find project at path '{os.path.abspath(root)}'."
             )
@@ -1619,7 +1618,7 @@ class Project:
         if root is None:
             root = os.getcwd()
         if not search:
-            if not _contains_config_file(root):
+            if not os.path.isfile(_get_project_config_fn(root)):
                 raise LookupError(
                     f"Unable to find project at path '{os.path.abspath(root)}'."
                 )

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1617,18 +1617,17 @@ class Project:
         """
         if root is None:
             root = os.getcwd()
-        if not search:
-            if not os.path.isfile(_get_project_config_fn(root)):
-                raise LookupError(
-                    f"Unable to find project at path '{os.path.abspath(root)}'."
-                )
+
+        old_root = root
+        if not search and not os.path.isfile(_get_project_config_fn(root)):
+            root = None
         else:
-            old_root = root
             root = _locate_config_dir(root)
-            if not root:
-                raise LookupError(
-                    f"Unable to find project at path '{os.path.abspath(old_root)}'."
-                )
+
+        if not root:
+            raise LookupError(
+                f"Unable to find project at path '{os.path.abspath(old_root)}'."
+            )
 
         return cls(root=root, **kwargs)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR removes the local vs global search option from `config.load_config` API in favor of a separate function to handle discovery. It also removes the `project_dir` key that was previously being automatically populated into the config when calling `load_config`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Populating the `project_dir` key is an unexpected side effect since it adds a key that doesn't actually exist in any config file. One option would be to change `load_config` to return a tuple containing `(root, config)` instead of just the config, but that mixes two distinct pieces of functionality and also makes config loading more expensive than it needs to be. By separating the two functions, calling code can find the config file and load it separately.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added all related issue and pull request numbers for future reference (if applicable). See example below.

<!-- Example for a changelog entry: `Fix issue with launching rockets to the moon (#101, #212).` -->
