### PR TITLE
Remove configurable workspace directory 

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -409,7 +409,7 @@ def main_sync(args):
     try:
         destination = get_project(root=args.destination)
     except LookupError:
-        _print_err("WARNING: The destination appears to not be a project path. ")
+        _print_err("WARNING: The destination does not appear to be a project path.")
         raise
     selection = find_with_filter_or_none(args)
 

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -29,7 +29,7 @@ except ImportError:
 else:
     READLINE = True
 
-from . import Project, get_project, init_project
+from . import get_project, init_project
 from .common import config
 from .common.configobj import Section, flatten_errors
 from .contrib.filterparse import _add_prefix, parse_filter_arg
@@ -74,7 +74,6 @@ SHELL_BANNER = """Python {python_version}
 signac {signac_version} 🎨
 
 Project:\t{root_path}{job_banner}
-Workspace:\t{workspace_path}
 Size:\t\t{size}
 
 Interact with the project interface using the "project" or "pr" variable.
@@ -343,7 +342,7 @@ def main_view(args):
 
 def main_init(args):
     """Handle init subcommand."""
-    init_project(name=args.project_id, root=os.getcwd(), workspace=args.workspace)
+    init_project(name=args.project_id, root=os.getcwd())
     _print_err("Initialized project.")
 
 
@@ -410,21 +409,8 @@ def main_sync(args):
     try:
         destination = get_project(root=args.destination)
     except LookupError:
-        if args.allow_workspace:
-            destination = Project(
-                config={
-                    "project": os.path.relpath(args.destination),
-                    "project_dir": args.destination,
-                    "workspace_dir": ".",
-                }
-            )
-        else:
-            _print_err(
-                "WARNING: The destination appears to not be a project path. "
-                "Use the '-w/--allow-workspace' option if you want to "
-                "synchronize to a workspace directory directly."
-            )
-            raise
+        _print_err("WARNING: The destination appears to not be a project path. ")
+        raise
     selection = find_with_filter_or_none(args)
 
     if args.strategy:
@@ -552,7 +538,6 @@ def _main_import_interactive(project, origin, args):
                     signac_version=__version__,
                     job_banner="",
                     root_path=project.root_directory(),
-                    workspace_path=project.workspace(),
                     size=len(project),
                     origin=args.origin,
                 ),
@@ -894,7 +879,6 @@ def main_shell(args):
                     signac_version=__version__,
                     job_banner=f"\nJob:\t\t{job.id}" if job is not None else "",
                     root_path=project.root_directory(),
-                    workspace_path=project.workspace(),
                     size=len(project),
                 ),
             )
@@ -923,13 +907,6 @@ def main():
 
     parser_init = subparsers.add_parser("init")
     parser_init.add_argument("project_id", nargs="?", help=argparse.SUPPRESS)
-    parser_init.add_argument(
-        "-w",
-        "--workspace",
-        type=str,
-        default="workspace",
-        help="The path to the workspace directory.",
-    )
     parser_init.set_defaults(func=main_init)
 
     parser_project = subparsers.add_parser("project")
@@ -1469,13 +1446,6 @@ job documents."
         "--no-keys", action="store_true", help="Never overwrite any conflicting keys."
     )
 
-    parser_sync.add_argument(
-        "-w",
-        "--allow-workspace",
-        action="store_true",
-        help="Allow the specification of a workspace (instead of a project) directory "
-        "as the destination path.",
-    )
     parser_sync.add_argument(
         "--force", action="store_true", help="Ignore all warnings, just synchronize."
     )

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -15,6 +15,5 @@ def get_validator():  # noqa: D103
 
 
 cfg = """
-workspace_dir = string(default='workspace')
 schema_version = string(default='1')
 """

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -19,7 +19,6 @@ from .v0_to_v1 import _load_config_v1
 # A minimal v2 config.
 _cfg = """
 schema_version = string(default='0')
-workspace_dir = string(default='workspace')
 """
 
 
@@ -37,10 +36,28 @@ def _load_config_v2(root_directory):
 
 def _migrate_v1_to_v2(root_directory):
     """Migrate from schema version 1 to version 2."""
-    # Delete project name from config and store in project doc.
+    # Load the v1 config.
     cfg = _load_config_v1(root_directory)
     fn_doc = os.path.join(root_directory, Project.FN_DOCUMENT)
     doc = BufferedJSONAttrDict(filename=fn_doc, write_concern=True)
+
+    # Try to migrate a custom workspace directory if one exists.
+    current_workspace_name = cfg.get("workspace_dir")
+    if current_workspace_name is not None:
+        if current_workspace_name != "workspace":
+            current_workspace = os.path.join(root_directory, current_workspace_name)
+            new_workspace = os.path.join(root_directory, "workspace")
+            if os.path.exists(new_workspace):
+                raise RuntimeError(
+                    "Workspace directories are no longer configurable in schema version 2, and "
+                    f"must be 'workspace', but {new_workspace} already exists. Please remove or "
+                    f"move it so that the currently configured workspace directory "
+                    "{current_workspace} can be moved to {new_workspace}."
+                )
+            os.replace(current_workspace, new_workspace)
+        del cfg["workspace_dir"]
+
+    # Delete project name from config and store in project doc.
     doc["signac_project_name"] = cfg["project"]
     del cfg["project"]
     cfg.write()

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -52,7 +52,7 @@ def _migrate_v1_to_v2(root_directory):
                     "Workspace directories are no longer configurable in schema version 2, and "
                     f"must be 'workspace', but {new_workspace} already exists. Please remove or "
                     f"move it so that the currently configured workspace directory "
-                    "{current_workspace} can be moved to {new_workspace}."
+                    f"{current_workspace} can be moved to {new_workspace}."
                 )
             os.replace(current_workspace, new_workspace)
         del cfg["workspace_dir"]

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -229,16 +229,6 @@ class Project:
     def workspace(self):
         """Return the project's workspace directory.
 
-        The workspace defaults to `project_root/workspace`. Configure this
-        directory with the ``'workspace_dir'`` configuration option. A relative
-        path is assumed to be relative to the project's root directory.
-
-        .. note::
-            The configuration will respect environment variables,
-            such as ``$HOME``.
-
-        See :ref:`signac project -w <signac-cli-project>` for the command line equivalent.
-
         Returns
         -------
         str

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1552,9 +1552,7 @@ class Project:
             project = cls.get_project(root=root)
             if name is not None:
                 project.doc[name_key] = name
-            return project
-        else:
-            return project
+        return project
 
     @classmethod
     def get_project(cls, root=None, search=True, **kwargs):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -1463,9 +1463,8 @@ class Project:
         with TemporaryProject(cls=type(self), dir=dir) as tmp_project:
             yield tmp_project
 
-    # TODO: Is there a reason to support the make_dir parameter?
     @classmethod
-    def init_project(cls, *args, root=None, make_dir=True, **kwargs):
+    def init_project(cls, *args, root=None, **kwargs):
         """Initialize a project in the provided root directory.
 
         It is safe to call this function multiple times with the same
@@ -1480,9 +1479,6 @@ class Project:
         root : str, optional
             The root directory for the project.
             Defaults to the current working directory.
-        make_dir : bool, optional
-            Create the project root directory if it does not exist yet
-            (Default value = True).
 
         Returns
         -------
@@ -1553,8 +1549,7 @@ class Project:
                 )
         except LookupError:
             fn_config = _get_project_config_fn(root)
-            if make_dir:
-                _mkdir_p(os.path.dirname(fn_config))
+            _mkdir_p(os.path.dirname(fn_config))
             config = read_config_file(fn_config)
             config["schema_version"] = SCHEMA_VERSION
             config.write()
@@ -2125,7 +2120,7 @@ class JobsCursor:
         return repr(self) + self._repr_html_jobs()
 
 
-def init_project(*args, root=None, make_dir=True, **kwargs):
+def init_project(*args, root=None, **kwargs):
     """Initialize a project.
 
     It is safe to call this function multiple times with the same arguments.
@@ -2137,9 +2132,6 @@ def init_project(*args, root=None, make_dir=True, **kwargs):
     root : str, optional
         The root directory for the project.
         Defaults to the current working directory.
-    make_dir : bool, optional
-        Create the project root directory, if it does not exist yet (Default
-        value = True).
 
     Returns
     -------
@@ -2153,7 +2145,7 @@ def init_project(*args, root=None, make_dir=True, **kwargs):
         configuration.
 
     """
-    return Project.init_project(*args, root=root, make_dir=make_dir, **kwargs)
+    return Project.init_project(*args, root=root, **kwargs)
 
 
 def get_project(root=None, search=True, **kwargs):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -70,7 +70,6 @@ class TestJobBase:
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
-        self._tmp_wd = os.path.join(self._tmp_dir.name, "pr", "workspace")
         os.mkdir(self._tmp_pr)
         self.config = signac.common.config.load_config()
         self.project = self.project_class.init_project(root=self._tmp_pr)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -70,12 +70,10 @@ class TestJobBase:
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
-        self._tmp_wd = os.path.join(self._tmp_dir.name, "wd")
+        self._tmp_wd = os.path.join(self._tmp_dir.name, "pr", "workspace")
         os.mkdir(self._tmp_pr)
         self.config = signac.common.config.load_config()
-        self.project = self.project_class.init_project(
-            root=self._tmp_pr, workspace=self._tmp_wd
-        )
+        self.project = self.project_class.init_project(root=self._tmp_pr)
 
     def tearDown(self):
         pass

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -215,10 +215,10 @@ class TestProject(TestProjectBase):
     def test_workspace_broken_link_error_on_find(self):
         with TemporaryDirectory() as tmp_dir:
             project = self.project_class.init_project(root=tmp_dir)
-            os.rmdir(os.path.join(tmp_dir, "workspace"))
+            os.rmdir(project.workspace())
             os.symlink(
                 os.path.join(tmp_dir, "workspace~"),
-                os.path.join(tmp_dir, "workspace"),
+                project.workspace(),
             )
             with pytest.raises(WorkspaceError):
                 list(project.find_jobs())
@@ -2548,7 +2548,6 @@ class TestProjectStoreBase(test_h5store.TestH5StoreBase):
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
-        self._tmp_wd = os.path.join(self._tmp_dir.name, "pr", "workspace")
         os.mkdir(self._tmp_pr)
         self.config = load_config()
         self.project = self.project_class.init_project(root=self._tmp_pr)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -71,6 +71,12 @@ WINDOWS = sys.platform == "win32"
 test_token = {"test_token": str(uuid.uuid4())}
 
 
+# Use the major version to fail tests expected to fail in 3.0.
+_MAJOR_VERSION = version.parse(signac.__version__)
+_VERSION_3 = version.parse("3.0.0")
+_VERSION_2 = version.parse("2.0.0")
+
+
 S_FORMAT1 = """{
  'a': 'int([0, 1, 2, ..., 8, 9], 10)',
  'b.b2': 'int([0, 1, 2, ..., 8, 9], 10)',
@@ -102,13 +108,14 @@ class TestProject(TestProjectBase):
         assert self._tmp_pr == self.project.root_directory()
 
     def test_workspace_directory(self):
-        assert self._tmp_wd == self.project.workspace()
+        assert os.path.join(self._tmp_pr, "workspace") == self.project.workspace()
 
     def test_config_modification(self):
         # In-memory modification of the project configuration is
         # deprecated as of 1.3, and will be removed in version 2.0.
         # This unit test should reflect that change beginning 2.0,
         # and check that the project configuration is immutable.
+        assert _MAJOR_VERSION < _VERSION_3
         with pytest.raises(ValueError):
             self.project.config["foo"] = "bar"
 
@@ -243,7 +250,6 @@ class TestProject(TestProjectBase):
         finally:
             logging.disable(logging.NOTSET)
 
-        assert not os.path.isdir(self._tmp_wd)
         assert not os.path.isdir(self.project.workspace())
 
     def test_find_jobs(self):
@@ -995,11 +1001,6 @@ class TestProject(TestProjectBase):
                 tmp_project.open_job(dict(a=i)).init()
             assert len(tmp_project) == 10
         assert not os.path.isdir(tmp_root_dir)
-
-
-# Use the major version to fail tests expected to fail in 3.0.
-_MAJOR_VERSION = version.parse(signac.__version__)
-_VERSION_3 = version.parse("3.0.0")
 
 
 class TestProjectNameDeprecations:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -115,7 +115,7 @@ class TestProject(TestProjectBase):
         # deprecated as of 1.3, and will be removed in version 2.0.
         # This unit test should reflect that change beginning 2.0,
         # and check that the project configuration is immutable.
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _MAJOR_VERSION < _VERSION_2
         with pytest.raises(ValueError):
             self.project.config["foo"] = "bar"
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -72,7 +72,7 @@ test_token = {"test_token": str(uuid.uuid4())}
 
 
 # Use the major version to fail tests expected to fail in 3.0.
-_MAJOR_VERSION = version.parse(signac.__version__)
+_CURRENT_VERSION = version.parse(signac.__version__)
 _VERSION_3 = version.parse("3.0.0")
 _VERSION_2 = version.parse("2.0.0")
 
@@ -115,7 +115,7 @@ class TestProject(TestProjectBase):
         # deprecated as of 1.3, and will be removed in version 2.0.
         # This unit test should reflect that change beginning 2.0,
         # and check that the project configuration is immutable.
-        assert _MAJOR_VERSION < _VERSION_2
+        assert _CURRENT_VERSION < _VERSION_2
         with pytest.raises(ValueError):
             self.project.config["foo"] = "bar"
 
@@ -1013,7 +1013,7 @@ class TestProjectNameDeprecations:
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with self.warning_context:
             project = signac.init_project("name", root=self._tmp_dir.name)
 
@@ -1027,14 +1027,14 @@ class TestProjectNameDeprecations:
                 signac.init_project("new_name", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         os.chdir(self._tmp_dir.name)
         with self.warning_context:
             project = signac.init_project(name="name")
@@ -1049,7 +1049,7 @@ class TestProjectNameDeprecations:
                 signac.init_project(name="new_name")
 
     def test_name_with_other_args_keyword(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
This PR removes the functionality for users to use a custom workspace directory. Going forward, the workspace will always be an immediate subdirectory of the project called "workspace".

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #390.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
