### PR TITLE
Vendor deprecation package, modified to raise FutureWarnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,11 @@
 ci:
   autoupdate_schedule: quarterly
 
-exclude: '(?:^signac/common/configobj/)'
+exclude: |
+  (?x)^(
+    ^signac/common/configobj/|
+    ^signac/common/deprecation/
+  )
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -45,6 +49,7 @@ repos:
             ^doc/|
             ^tests/|
             ^signac/common/configobj/|
+            ^signac/common/deprecation/|
             ^signac/db/
           )
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/signac/common/deprecation/LICENSE
+++ b/signac/common/deprecation/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/signac/common/deprecation/README
+++ b/signac/common/deprecation/README
@@ -1,0 +1,5 @@
+The `__init__.py` file is copied from `deprecation.py`, available at https://github.com/briancurtin/deprecation.
+Its license can be found in `LICENSE`.
+
+The file has been modified in the following ways:
+- Use `FutureWarning` instead of `DeprecationWarning`

--- a/signac/common/deprecation/__init__.py
+++ b/signac/common/deprecation/__init__.py
@@ -1,0 +1,290 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import collections
+import functools
+import textwrap
+import warnings
+
+from packaging import version
+from datetime import date
+
+__version__ = "2.1.0"
+
+# This is mostly here so automodule docs are ordered more ideally.
+__all__ = ["deprecated", "message_location", "fail_if_not_removed",
+           "DeprecatedWarning", "UnsupportedWarning"]
+
+#: Location where the details are added to a deprecated docstring
+#:
+#: When set to ``"bottom"``, the details are appended to the end.
+#: When set to ``"top"``, the details are inserted between the
+#: summary line and docstring contents.
+message_location = "bottom"
+
+
+class DeprecatedWarning(DeprecationWarning):
+    """A warning class for deprecated methods
+
+    This is a specialization of the built-in :class:`DeprecationWarning`,
+    adding parameters that allow us to get information into the __str__
+    that ends up being sent through the :mod:`warnings` system.
+    The attributes aren't able to be retrieved after the warning gets
+    raised and passed through the system as only the class--not the
+    instance--and message are what gets preserved.
+
+    :param function: The function being deprecated.
+    :param deprecated_in: The version that ``function`` is deprecated in
+    :param removed_in: The version or :class:`datetime.date` specifying
+                       when ``function`` gets removed.
+    :param details: Optional details about the deprecation. Most often
+                    this will include directions on what to use instead
+                    of the now deprecated code.
+    """
+
+    def __init__(self, function, deprecated_in, removed_in, details=""):
+        # NOTE: The docstring only works for this class if it appears up
+        # near the class name, not here inside __init__. I think it has
+        # to do with being an exception class.
+        self.function = function
+        self.deprecated_in = deprecated_in
+        self.removed_in = removed_in
+        self.details = details
+        super(DeprecatedWarning, self).__init__(function, deprecated_in,
+                                                removed_in, details)
+
+    def __str__(self):
+        # Use a defaultdict to give us the empty string
+        # when a part isn't included.
+        parts = collections.defaultdict(str)
+        parts["function"] = self.function
+
+        if self.deprecated_in:
+            parts["deprecated"] = " as of %s" % self.deprecated_in
+        if self.removed_in:
+            parts["removed"] = " and will be removed {} {}".format("on" if isinstance(self.removed_in, date) else "in",
+                                                                   self.removed_in)
+        if any([self.deprecated_in, self.removed_in, self.details]):
+            parts["period"] = "."
+        if self.details:
+            parts["details"] = " %s" % self.details
+
+        return ("%(function)s is deprecated%(deprecated)s%(removed)s"
+                "%(period)s%(details)s" % (parts))
+
+
+class UnsupportedWarning(DeprecatedWarning):
+    """A warning class for methods to be removed
+
+    This is a subclass of :class:`~deprecation.DeprecatedWarning` and is used
+    to output a proper message about a function being unsupported.
+    Additionally, the :func:`~deprecation.fail_if_not_removed` decorator
+    will handle this warning and cause any tests to fail if the system
+    under test uses code that raises this warning.
+    """
+
+    def __str__(self):
+        parts = collections.defaultdict(str)
+        parts["function"] = self.function
+        parts["removed"] = self.removed_in
+
+        if self.details:
+            parts["details"] = " %s" % self.details
+
+        return ("%(function)s is unsupported as of %(removed)s."
+                "%(details)s" % (parts))
+
+
+def deprecated(deprecated_in=None, removed_in=None, current_version=None,
+               details=""):
+    """Decorate a function to signify its deprecation
+
+    This function wraps a method that will soon be removed and does two things:
+        * The docstring of the method will be modified to include a notice
+          about deprecation, e.g., "Deprecated since 0.9.11. Use foo instead."
+        * Raises a :class:`~deprecation.DeprecatedWarning`
+          via the :mod:`warnings` module, which is a subclass of the built-in
+          :class:`DeprecationWarning`. Note that built-in
+          :class:`DeprecationWarning`s are ignored by default, so for users
+          to be informed of said warnings they will need to enable them--see
+          the :mod:`warnings` module documentation for more details.
+
+    :param deprecated_in: The version at which the decorated method is
+                          considered deprecated. This will usually be the
+                          next version to be released when the decorator is
+                          added. The default is **None**, which effectively
+                          means immediate deprecation. If this is not
+                          specified, then the `removed_in` and
+                          `current_version` arguments are ignored.
+    :param removed_in: The version or :class:`datetime.date` when the decorated
+                       method will be removed. The default is **None**,
+                       specifying that the function is not currently planned
+                       to be removed.
+                       Note: This parameter cannot be set to a value if
+                       `deprecated_in=None`.
+    :param current_version: The source of version information for the
+                            currently running code. This will usually be
+                            a `__version__` attribute on your library.
+                            The default is `None`.
+                            When `current_version=None` the automation to
+                            determine if the wrapped function is actually
+                            in a period of deprecation or time for removal
+                            does not work, causing a
+                            :class:`~deprecation.DeprecatedWarning`
+                            to be raised in all cases.
+    :param details: Extra details to be added to the method docstring and
+                    warning. For example, the details may point users to
+                    a replacement method, such as "Use the foo_bar
+                    method instead". By default there are no details.
+    """
+    # You can't just jump to removal. It's weird, unfair, and also makes
+    # building up the docstring weird.
+    if deprecated_in is None and removed_in is not None:
+        raise TypeError("Cannot set removed_in to a value "
+                        "without also setting deprecated_in")
+
+    # Only warn when it's appropriate. There may be cases when it makes sense
+    # to add this decorator before a formal deprecation period begins.
+    # In CPython, PendingDeprecatedWarning gets used in that period,
+    # so perhaps mimick that at some point.
+    is_deprecated = False
+    is_unsupported = False
+
+    # StrictVersion won't take a None or a "", so make whatever goes to it
+    # is at least *something*. Compare versions only if removed_in is not
+    # of type datetime.date
+    if isinstance(removed_in, date):
+        if date.today() >= removed_in:
+            is_unsupported = True
+        else:
+            is_deprecated = True
+    elif current_version:
+        current_version = version.parse(current_version)
+
+        if (removed_in
+                and current_version >= version.parse(removed_in)):
+            is_unsupported = True
+        elif (deprecated_in
+              and current_version >= version.parse(deprecated_in)):
+            is_deprecated = True
+    else:
+        # If we can't actually calculate that we're in a period of
+        # deprecation...well, they used the decorator, so it's deprecated.
+        # This will cover the case of someone just using
+        # @deprecated("1.0") without the other advantages.
+        is_deprecated = True
+
+    should_warn = any([is_deprecated, is_unsupported])
+
+    def _function_wrapper(function):
+        if should_warn:
+            # Everything *should* have a docstring, but just in case...
+            existing_docstring = function.__doc__ or ""
+
+            # The various parts of this decorator being optional makes for
+            # a number of ways the deprecation notice could go. The following
+            # makes for a nicely constructed sentence with or without any
+            # of the parts.
+
+            # If removed_in is a date, use "removed on"
+            # If removed_in is a version, use "removed in"
+            parts = {
+                "deprecated_in":
+                    " %s" % deprecated_in if deprecated_in else "",
+                "removed_in":
+                    "\n   This will be removed {} {}.".format("on" if isinstance(removed_in, date) else "in",
+                                                              removed_in) if removed_in else "",
+                "details":
+                    " %s" % details if details else ""}
+
+            deprecation_note = (".. deprecated::{deprecated_in}"
+                                "{removed_in}{details}".format(**parts))
+
+            # default location for insertion of deprecation note
+            loc = 1
+
+            # split docstring at first occurrence of newline
+            string_list = existing_docstring.split("\n", 1)
+
+            if len(string_list) > 1:
+                # With a multi-line docstring, when we modify
+                # existing_docstring to add our deprecation_note,
+                # if we're not careful we'll interfere with the
+                # indentation levels of the contents below the
+                # first line, or as PEP 257 calls it, the summary
+                # line. Since the summary line can start on the
+                # same line as the """, dedenting the whole thing
+                # won't help. Split the summary and contents up,
+                # dedent the contents independently, then join
+                # summary, dedent'ed contents, and our
+                # deprecation_note.
+
+                # in-place dedent docstring content
+                string_list[1] = textwrap.dedent(string_list[1])
+
+                # we need another newline
+                string_list.insert(loc, "\n")
+
+                # change the message_location if we add to end of docstring
+                # do this always if not "top"
+                if message_location != "top":
+                    loc = 3
+
+            # insert deprecation note and dual newline
+            string_list.insert(loc, deprecation_note)
+            string_list.insert(loc, "\n\n")
+
+            function.__doc__ = "".join(string_list)
+
+        @functools.wraps(function)
+        def _inner(*args, **kwargs):
+            if should_warn:
+                if is_unsupported:
+                    cls = UnsupportedWarning
+                else:
+                    cls = DeprecatedWarning
+
+                the_warning = cls(function.__name__, deprecated_in,
+                                  removed_in, details)
+                warnings.warn(the_warning, category=DeprecationWarning,
+                              stacklevel=2)
+
+            return function(*args, **kwargs)
+        return _inner
+    return _function_wrapper
+
+
+def fail_if_not_removed(method):
+    """Decorate a test method to track removal of deprecated code
+
+    This decorator catches :class:`~deprecation.UnsupportedWarning`
+    warnings that occur during testing and causes unittests to fail,
+    making it easier to keep track of when code should be removed.
+
+    :raises: :class:`AssertionError` if an
+             :class:`~deprecation.UnsupportedWarning`
+             is raised while running the test method.
+    """
+    # NOTE(briancurtin): Unless this is named test_inner, nose won't work
+    # properly. See Issue #32.
+    @functools.wraps(method)
+    def test_inner(*args, **kwargs):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            rv = method(*args, **kwargs)
+
+        for warning in caught_warnings:
+            if warning.category == UnsupportedWarning:
+                raise AssertionError(
+                    ("%s uses a function that should be removed: %s" %
+                     (method, str(warning.message))))
+        return rv
+    return test_inner

--- a/signac/common/deprecation/__init__.py
+++ b/signac/common/deprecation/__init__.py
@@ -31,10 +31,10 @@ __all__ = ["deprecated", "message_location", "fail_if_not_removed",
 message_location = "bottom"
 
 
-class DeprecatedWarning(DeprecationWarning):
+class DeprecatedWarning(FutureWarning):
     """A warning class for deprecated methods
 
-    This is a specialization of the built-in :class:`DeprecationWarning`,
+    This is a specialization of the built-in :class:`FutureWarning`,
     adding parameters that allow us to get information into the __str__
     that ends up being sent through the :mod:`warnings` system.
     The attributes aren't able to be retrieved after the warning gets
@@ -112,10 +112,7 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
           about deprecation, e.g., "Deprecated since 0.9.11. Use foo instead."
         * Raises a :class:`~deprecation.DeprecatedWarning`
           via the :mod:`warnings` module, which is a subclass of the built-in
-          :class:`DeprecationWarning`. Note that built-in
-          :class:`DeprecationWarning`s are ignored by default, so for users
-          to be informed of said warnings they will need to enable them--see
-          the :mod:`warnings` module documentation for more details.
+          :class:`FutureWarning`.
 
     :param deprecated_in: The version at which the decorated method is
                           considered deprecated. This will usually be the
@@ -254,7 +251,7 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
 
                 the_warning = cls(function.__name__, deprecated_in,
                                   removed_in, details)
-                warnings.warn(the_warning, category=DeprecationWarning,
+                warnings.warn(the_warning, category=FutureWarning,
                               stacklevel=2)
 
             return function(*args, **kwargs)

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -22,10 +22,10 @@ from multiprocessing.pool import ThreadPool
 from tempfile import TemporaryDirectory
 from threading import RLock
 
-from deprecation import deprecated
 from packaging import version
 
 from ..common.config import Config, _get_config, load_config
+from ..common.deprecation import deprecated
 from ..core.h5store import H5StoreManager
 from ..sync import sync_projects
 from ..synced_collections.backends.collection_json import BufferedJSONAttrDict

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1064,7 +1064,7 @@ class TestJobDocument(TestJobBase):
         src_job.data[key] = d
         assert key in src_job.data
         assert len(src_job.data) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             self.project.reset_statepoint(src_job, dst)
         src_job = self.open_job(src)
         dst_job = self.open_job(dst)
@@ -1074,7 +1074,7 @@ class TestJobDocument(TestJobBase):
         assert key in dst_job.data
         assert len(dst_job.data) == 1
         assert key not in src_job.data
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(RuntimeError):
                 self.project.reset_statepoint(src_job, dst)
             with pytest.raises(DestinationExistsError):
@@ -1098,7 +1098,7 @@ class TestJobDocument(TestJobBase):
         src_job.data[key] = d
         assert key in src_job.data
         assert len(src_job.data) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             self.project.update_statepoint(src_job, extension)
         src_job = self.open_job(src)
         dst_job = self.open_job(dst)
@@ -1109,7 +1109,7 @@ class TestJobDocument(TestJobBase):
         assert key in dst_job.data
         assert len(dst_job.data) == 1
         assert key not in src_job.data
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(RuntimeError):
                 self.project.reset_statepoint(src_job, dst)
             with pytest.raises(DestinationExistsError):
@@ -1535,7 +1535,7 @@ class TestJobOpenData(TestJobBase):
             src_job.data[key] = d
             assert key in src_job.data
             assert len(src_job.data) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             self.project.reset_statepoint(src_job, dst)
         src_job = self.open_job(src)
         dst_job = self.open_job(dst)
@@ -1544,7 +1544,7 @@ class TestJobOpenData(TestJobBase):
             assert len(dst_job.data) == 1
         with self.open_data(src_job):
             assert key not in src_job.data
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(RuntimeError):
                 self.project.reset_statepoint(src_job, dst)
             with pytest.raises(DestinationExistsError):
@@ -1565,7 +1565,7 @@ class TestJobOpenData(TestJobBase):
             src_job.data[key] = d
             assert key in src_job.data
             assert len(src_job.data) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             self.project.update_statepoint(src_job, extension)
         src_job = self.open_job(src)
         dst_job = self.open_job(dst)
@@ -1575,12 +1575,12 @@ class TestJobOpenData(TestJobBase):
             assert len(dst_job.data) == 1
         with self.open_data(src_job):
             assert key not in src_job.data
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(RuntimeError):
                 self.project.reset_statepoint(src_job, dst)
             with pytest.raises(DestinationExistsError):
                 self.project.reset_statepoint(src_job, dst)
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(KeyError):
                 self.project.update_statepoint(dst_job, extension2)
             self.project.update_statepoint(dst_job, extension2, overwrite=True)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -88,8 +88,9 @@ class TestProject(TestProjectBase):
         pass
 
     def test_get_id(self):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert self.project.get_id() == "testing_test_project"
+        with pytest.warns(FutureWarning):
             assert str(self.project) == self.project.get_id()
 
     def test_property_id(self):
@@ -222,7 +223,7 @@ class TestProject(TestProjectBase):
         read2 = list(self.project.read_statepoints())
         assert len(read2) == len(statepoints) + len(more_statepoints)
         for id_ in self.project.read_statepoints().keys():
-            with pytest.deprecated_call():
+            with pytest.warns(FutureWarning):
                 self.project.get_statepoint(id_)
 
     def test_workspace_path_normalization(self):
@@ -291,7 +292,7 @@ class TestProject(TestProjectBase):
         statepoints = [{"a": i} for i in range(5)]
         for sp in statepoints:
             self.project.open_job(sp).document["b"] = sp["a"]
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(statepoints) == len(list(self.project.find_job_ids()))
             assert 1 == len(list(self.project.find_job_ids({"a": 0})))
             assert 0 == len(list(self.project.find_job_ids({"a": 5})))
@@ -714,7 +715,7 @@ class TestProject(TestProjectBase):
                 return doc
 
         for p, fmt in formats.items():
-            with pytest.deprecated_call():
+            with pytest.warns(FutureWarning):
                 Crawler.define(p, fmt)
         index2 = {}
         for doc in Crawler(root=self.project.root_directory()).crawl():
@@ -1098,7 +1099,7 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(tmp_root_dir)
 
     def test_access_module(self):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             self.project.create_access_module()
 
 
@@ -2306,7 +2307,7 @@ class TestProjectInit:
             signac.get_project(root=root)
         project_name = "testproject" + string.printable
         project = signac.init_project(name=project_name, root=root)
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert project.get_id() == project_name
 
     def test_get_project_non_local(self):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -171,7 +171,7 @@ class TestBasicShell:
         project = signac.Project()
         project.open_job({"a": 0}).init()
         assert len(project) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(list(project.index())) == 1
             assert len(list(signac.index())) == 1
         doc = json.loads(self.call("python -m signac index".split()))
@@ -311,7 +311,7 @@ class TestBasicShell:
                 == next(iter(project.find_jobs({"a": i}))).id
             )
 
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for i in range(3):
                 assert (
                     self.call(
@@ -320,7 +320,7 @@ class TestBasicShell:
                     == list(project.find_job_ids(doc_filter={"a": i}))[0]
                 )
 
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for i in range(1, 4):
                 assert (
                     self.call(


### PR DESCRIPTION
## Description
This PR vendors the `deprecation` package from https://github.com/briancurtin/deprecation/ (Apache 2 License) so that we can raise `FutureWarning` instead of `DeprecationWarning`, which is silenced by default.

I have not yet updated the changelog. We need to decide if we like this approach before making the replacement everywhere, which can be done in follow-up PRs. Finally, we can update the changelog when we remove the dependency on the `deprecation` package.

## Motivation and Context
Next step towards #687.

An alternative to raising `FutureWarning` would be to alter the `warnings` filters when signac is imported, so that all `DeprecationWarning`s are shown by default when raised by the `signac` module. However, we've already started down the path of using `FutureWarning` and it aligns with a good portion of the scientific Python ecosystem.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
