### PR TITLE
Replace deprecation decorator with vendored deprecation decorator for FutureWarnings

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -1,6 +1,5 @@
 click==7.1.2
 coverage==5.3.1
-deprecation==2.0
 filelock==3.0.0
 h5py==2.9.0
 numpy==1.19.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Removed
 +++++++
 
  - Dropped support for Python 3.6 and Python 3.7 (#715) following the recommended support schedules of `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
+ - Dropped dependency on ``deprecation`` package (#687, #718).
 
 [1.7.0] -- 2021-06-08
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-deprecation>=2
 filelock>=3.0
 packaging>=15.0
 tqdm>=4.10.0

--- a/requirements/requirements-benchmark.txt
+++ b/requirements/requirements-benchmark.txt
@@ -1,4 +1,5 @@
 click==8.0.4
+deprecation==2.1.0
 gitdb2==4.0.2
 GitPython==3.1.27
 numpy==1.22.2

--- a/requirements/requirements-benchmark.txt
+++ b/requirements/requirements-benchmark.txt
@@ -1,5 +1,4 @@
 click==8.0.4
-deprecation==2.1.0
 gitdb2==4.0.2
 GitPython==3.1.27
 numpy==1.22.2

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ import os
 from setuptools import find_packages, setup
 
 requirements = [
-    # Deprecation management
-    "deprecation>=2",
     # Platform-independent file locking
     "filelock>=3.0",
     # Used for version parsing and comparison

--- a/signac/cite.py
+++ b/signac/cite.py
@@ -4,8 +4,7 @@
 """Functions to support citing this software."""
 import sys
 
-from deprecation import deprecated
-
+from .common.deprecation import deprecated
 from .version import __version__
 
 ARXIV_BIBTEX = """@online{signac,

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -7,8 +7,7 @@ import logging
 import os
 import stat
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 from .configobj import ConfigObj, ConfigObjError
 from .errors import ConfigError

--- a/signac/common/connection.py
+++ b/signac/common/connection.py
@@ -6,8 +6,8 @@ import subprocess
 from os.path import expanduser
 
 import pymongo
-from deprecation import deprecated
 
+from ..common.deprecation import deprecated
 from ..version import __version__
 from .errors import ConfigError
 

--- a/signac/common/crypt.py
+++ b/signac/common/crypt.py
@@ -3,8 +3,7 @@
 # This software is licensed under the BSD 3-Clause License.
 import base64
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 try:

--- a/signac/common/host.py
+++ b/signac/common/host.py
@@ -5,8 +5,7 @@ import getpass
 import logging
 import warnings
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..core import json
 from ..version import __version__
 from .config import load_config

--- a/signac/contrib/filesystems.py
+++ b/signac/contrib/filesystems.py
@@ -9,8 +9,7 @@ import os
 import warnings
 from collections.abc import Iterable, Mapping
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..db import get_database
 from ..version import __version__
 from .utility import _mkdir_p

--- a/signac/contrib/indexing.py
+++ b/signac/contrib/indexing.py
@@ -12,9 +12,8 @@ import warnings
 from collections import defaultdict
 from time import sleep
 
-from deprecation import deprecated
-
 from ..common import errors
+from ..common.deprecation import deprecated
 from ..core import json
 from ..version import __version__
 from .hashing import calc_id

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -12,8 +12,7 @@ from json import JSONDecodeError
 from threading import RLock
 from typing import FrozenSet
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..core.h5store import H5StoreManager
 from ..sync import sync_jobs
 from ..synced_collections.backends.collection_json import (

--- a/signac/contrib/mpipool.py
+++ b/signac/contrib/mpipool.py
@@ -23,7 +23,7 @@
 
 This 3rd party module is copied from https://github.com/adrn/mpipool."""
 
-from deprecation import deprecated
+from ..common.deprecation import deprecated
 
 __all__ = ["MPIPool"]
 __version__ = "0.0.1"

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -16,8 +16,7 @@ from datetime import timedelta
 from tempfile import TemporaryDirectory
 from time import time
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 logger = logging.getLogger(__name__)

--- a/signac/core/json.py
+++ b/signac/core/json.py
@@ -7,8 +7,7 @@ from json import JSONEncoder, load, loads
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, Optional
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 logger = logging.getLogger(__name__)

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -13,8 +13,7 @@ from contextlib import contextmanager
 from copy import copy
 from tempfile import mkstemp
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 from . import json
 from .attrdict import SyncedAttrDict

--- a/signac/core/synceddict.py
+++ b/signac/core/synceddict.py
@@ -8,8 +8,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import wraps
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 try:

--- a/signac/core/utility.py
+++ b/signac/core/utility.py
@@ -6,8 +6,7 @@
 import re
 import subprocess
 
-from deprecation import deprecated
-
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 

--- a/signac/db/database.py
+++ b/signac/db/database.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2017 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-from deprecation import deprecated
-
 from ..common import host
+from ..common.deprecation import deprecated
 from ..version import __version__
 
 """

--- a/signac/syncutil.py
+++ b/signac/syncutil.py
@@ -11,8 +11,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from filecmp import dircmp
 
-from deprecation import deprecated
-
+from .common.deprecation import deprecated
 from .version import __version__
 
 LEVEL_MORE = logging.INFO - 5

--- a/tests/test_buffered_mode.py
+++ b/tests/test_buffered_mode.py
@@ -176,12 +176,12 @@ class TestBufferedMode(TestProjectBase):
                 assert job.sp.a > 0
                 job.sp.a = -job.sp.a
                 assert job.sp.a < 0
-                with pytest.deprecated_call():
+                with pytest.warns(FutureWarning):
                     job2 = self.project.open_job(id=job.get_id())
                 assert job2.sp.a < 0
                 job.sp.a = -job.sp.a
                 assert job.sp.a > 0
-                with pytest.deprecated_call():
+                with pytest.warns(FutureWarning):
                     job2 = self.project.open_job(id=job.get_id())
                 assert job2.sp.a > 0
 
@@ -208,7 +208,7 @@ class TestBufferedMode(TestProjectBase):
                 assert signac.get_buffer_load() > 0
                 job.doc.a = not job.doc.a
                 assert job.doc.a == (not x)
-                with pytest.deprecated_call():
+                with pytest.warns(FutureWarning):
                     job2 = self.project.open_job(id=job.get_id())
                 assert job2.doc.a == (not x)
             assert signac.get_buffer_load() == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,7 +6,7 @@ import pytest
 import signac.db
 
 try:
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         signac.db.get_database("testing", hostname="testing")
 except signac.common.errors.ConfigError:
     SKIP_REASON = "No 'testing' host configured."
@@ -20,7 +20,7 @@ else:
 @pytest.mark.skipif(SKIP_REASON != "None", reason=SKIP_REASON)
 class TestDB:
     def get_test_db(self):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             signac.db.get_database("testing", hostname="testing")
 
     def test_get_connector(self):

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -16,7 +16,7 @@ from signac.common import errors
 from signac.contrib import indexing
 
 try:
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         signac.db.get_database("testing", hostname="testing")
 except signac.common.errors.ConfigError:
     SKIP_REASON = "No 'testing' host configured."
@@ -166,11 +166,11 @@ class TestIndexingBase:
             pass
 
         regex = re.compile(r".*a_(?P<a>\d)\.txt")
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             Crawler.define(regex, TestFormat)
         crawler = Crawler(root=self._tmp_dir.name)
         no_find = True
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc in crawler.crawl():
                 no_find = False
                 ffn = os.path.join(doc["root"], doc["filename"])
@@ -190,18 +190,18 @@ class TestIndexingBase:
 
         # First test without pattern
         crawler = Crawler(root=self._tmp_dir.name)
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(list(crawler.crawl())) == 0
 
         # Now with pattern(s)
         pattern = r".*a_(?P<a>\d)\.txt"
         regex = re.compile(pattern)
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             Crawler.define(pattern, TestFormat)
             Crawler.define("negativematch", "negativeformat")
         crawler = Crawler(root=self._tmp_dir.name)
         no_find = True
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc in crawler.crawl():
                 no_find = False
                 ffn = os.path.join(doc["root"], doc["filename"])
@@ -226,7 +226,7 @@ class TestIndexingBase:
         class CrawlerB(indexing.RegexFileCrawler):
             pass
 
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             CrawlerA.define("a", TestFormat)
             CrawlerB.define("b", TestFormat)
         assert len(CrawlerA.definitions) == 1
@@ -238,7 +238,7 @@ class TestIndexingBase:
         assert len(CrawlerA.definitions) == 1
         assert len(CrawlerC.definitions) == 1
         assert len(CrawlerB.definitions) == 1
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             CrawlerC.define("c", TestFormat)
         assert len(CrawlerA.definitions) == 1
         assert len(CrawlerB.definitions) == 1
@@ -249,14 +249,14 @@ class TestIndexingBase:
 
         # First test without pattern
         root = self._tmp_dir.name
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(list(signac.index_files(root))) == 5
 
         # Now with pattern(s)
         pattern_positive = r".*a_(?P<a>\d)\.txt"
         pattern_negative = "nomatch"
 
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(list(signac.index_files(root, pattern_positive))) == 2
             assert len(list(signac.index_files(root, pattern_negative))) == 0
 
@@ -273,9 +273,9 @@ class TestIndexingBase:
 
     def test_json_crawler(self):
         self.setup_project()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             crawler = indexing.JSONCrawler(root=self._tmp_dir.name)
-        # with pytest.deprecated_call():
+        # with pytest.warns(FutureWarning):
         docs = list(sorted(crawler.crawl(), key=lambda d: d["a"]))
         assert len(docs) == 2
         for i, doc in enumerate(docs):
@@ -289,7 +289,7 @@ class TestIndexingBase:
         crawler = indexing.MainCrawler(root=self._tmp_dir.name)
         crawler.tags = {"test1"}
         no_find = True
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc in crawler.crawl():
                 no_find = False
                 ffn = os.path.join(doc["root"], doc["filename"])
@@ -304,7 +304,7 @@ class TestIndexingBase:
     def test_index(self):
         self.setup_project()
         root = self._tmp_dir.name
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert len(list(signac.index(root=root))) == 0
             index = signac.index(root=self._tmp_dir.name, tags={"test1"})
         no_find = True
@@ -315,13 +315,13 @@ class TestIndexingBase:
             with open(ffn) as file:
                 doc2 = json.load(file)
                 assert doc2["a"] == doc["a"]
-            with pytest.deprecated_call():
+            with pytest.warns(FutureWarning):
                 with signac.fetch(doc) as file:
                     pass
         assert not no_find
 
     def test_fetch(self):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             with pytest.raises(ValueError):
                 signac.fetch(None)
             with pytest.raises(errors.FetchError):
@@ -329,14 +329,14 @@ class TestIndexingBase:
         self.setup_project()
         crawler = indexing.MainCrawler(root=self._tmp_dir.name)
         crawler.tags = {"test1"}
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             docs = list(crawler.crawl())
         assert len(docs) == 2
         for doc in docs:
-            with pytest.deprecated_call():
+            with pytest.warns(FutureWarning):
                 with signac.fetch(doc) as file:
                     pass
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc, file in indexing.fetched(docs):
                 doc2 = json.load(file)
                 assert doc["a"] == doc2["a"]
@@ -347,7 +347,7 @@ class TestIndexingBase:
         crawler = indexing.MainCrawler(root=self._tmp_dir.name)
         crawler.tags = {"test1"}
         index = self.get_index_collection()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc in crawler.crawl():
                 signac.export_one(doc, index)
             assert index.replace_one.called
@@ -359,7 +359,7 @@ class TestIndexingBase:
         crawler = indexing.MainCrawler(root=self._tmp_dir.name)
         crawler.tags = {"test1"}
         index = self.get_index_collection()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             signac.export(crawler.crawl(), index)
             assert index.replace_one.called or index.bulk_write.called
             for doc in crawler.crawl():
@@ -367,10 +367,10 @@ class TestIndexingBase:
 
     def test_export_with_update(self):
         self.setup_project()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             index = list(signac.index(root=self._tmp_dir.name, tags={"test1"}))
         collection = self.get_index_collection()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             signac.export(index, collection, update=True)
         assert collection.replace_one.called or collection.bulk_write.called
         for doc in index:
@@ -378,7 +378,7 @@ class TestIndexingBase:
         collection.reset_mock()
         assert len(index) == collection.find().count()
         assert collection.find.called
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             signac.export(index, collection, update=True)
         assert collection.replace_one.called or collection.bulk_write.called
         for doc in index:
@@ -388,18 +388,18 @@ class TestIndexingBase:
         for fn in ("a_0.txt", "a_1.txt"):
             os.remove(os.path.join(self._tmp_dir.name, fn))
             N = len(index)
-            with pytest.deprecated_call():
+            with pytest.warns(FutureWarning):
                 index = list(signac.index(root=self._tmp_dir.name, tags={"test1"}))
             assert len(index) == (N - 1)
             collection.reset_mock()
             if index:
-                with pytest.deprecated_call():
+                with pytest.warns(FutureWarning):
                     signac.export(index, collection, update=True)
                 assert collection.replace_one.called or collection.bulk_write.called
                 assert len(index) == collection.find().count()
             else:
                 with pytest.raises(errors.ExportError):
-                    with pytest.deprecated_call():
+                    with pytest.warns(FutureWarning):
                         signac.export(index, collection, update=True)
 
     def test_export_to_mirror(self):
@@ -408,7 +408,7 @@ class TestIndexingBase:
         crawler.tags = {"test1"}
         index = self.get_index_collection()
         mirror = _TestFS()
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             for doc in crawler.crawl():
                 assert "file_id" in doc
                 doc.pop("file_id")
@@ -429,7 +429,7 @@ class TestIndexingBase:
     def test_main_crawler_tags(self):
         self.setup_project()
         crawler = indexing.MainCrawler(root=self._tmp_dir.name)
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             assert 0 == len(list(crawler.crawl()))
             crawler.tags = None
             assert 0 == len(list(crawler.crawl()))


### PR DESCRIPTION
## Description
This follows up on PR #716 to apply the vendored `@deprecated` decorator to all code. This requires a change of the tests, which should now expect a `FutureWarning` to be raised instead of a subclass of `DeprecationWarning`.

Note: _We expect CI to fail_ at the benchmarks stage for the CI jobs that execute benchmarks. The benchmarks compare to `origin/master`, which still has a requirement for `deprecation` until this PR is merged. Once this PR is merged, then `origin/master` will no longer depend on `deprecation` and the CI benchmarks will run as usual for future PRs. The CI benchmarks have been removed in the `next` branch with PR #683, so this isn't a long term concern.

## Motivation and Context
Step towards resolving #687.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
