### PR TITLE
Remove non-str key support

### DIFF
--- a/signac/synced_collections/data_types/synced_dict.py
+++ b/signac/synced_collections/data_types/synced_dict.py
@@ -171,17 +171,9 @@ class SyncedDict(SyncedCollection, MutableMapping):
             )
 
     def __setitem__(self, key, value):
-        # TODO: Remove in signac 2.0, currently we're constructing a dict to
-        # allow in-place modification by _convert_key_to_str, but validators
-        # should not have side effects once that backwards compatibility layer
-        # is removed, so we can validate a temporary dict {key: value} and
-        # directly set using those rather than looping over data.
-
-        data = {key: value}
-        self._validate(data)
+        self._validate({key: value})
         with self._load_and_save, self._suspend_sync:
-            for key, value in data.items():
-                self._data[key] = self._from_base(value, parent=self)
+            self._data[key] = self._from_base(value, parent=self)
 
     def reset(self, data):
         """Update the instance with new data.
@@ -257,16 +249,7 @@ class SyncedDict(SyncedCollection, MutableMapping):
             if key in self._data:
                 ret = self._data[key]
             else:
-                ret = self._from_base(default, parent=self)
-                # TODO: Remove in signac 2.0, currently we're constructing a dict
-                # to allow in-place modification by _convert_key_to_str, but
-                # validators should not have side effects once that backwards
-                # compatibility layer is removed, so we can validate a temporary
-                # dict {key: value} and directly set using those rather than
-                # looping over data.
-                data = {key: ret}
-                self._validate(data)
+                self._validate({key: default})
                 with self._suspend_sync:
-                    for key, value in data.items():
-                        self._data[key] = value
+                    ret = self._data[key] = self._from_base(default, parent=self)
         return ret

--- a/signac/synced_collections/validators.py
+++ b/signac/synced_collections/validators.py
@@ -45,8 +45,6 @@ def no_dot_in_key(data):
         If the key contains invalid characters or is otherwise malformed.
 
     """
-    VALID_KEY_TYPES = (str, int, bool, type(None))
-
     switch_type = _no_dot_in_key_type_resolver.get_type(data)
 
     if switch_type == "MAPPING":
@@ -56,10 +54,9 @@ def no_dot_in_key(data):
                     raise InvalidKeyError(
                         f"Mapping keys may not contain dots ('.'): {key}"
                     )
-            # TODO: Make it an error to have a non-str key here in signac 2.0.
-            elif not isinstance(key, VALID_KEY_TYPES):
+            else:
                 raise KeyTypeError(
-                    f"Mapping keys must be str, int, bool or None, not {type(key).__name__}"
+                    f"Mapping keys must be str, not {type(key).__name__}"
                 )
             no_dot_in_key(value)
     elif switch_type == "SEQUENCE":

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -432,16 +432,11 @@ class TestJobSpInterface(TestJobBase):
             assert job.sp == job2.sp
             assert job.id == job2.id
 
-    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_valid_sp_key_types(self):
-        job = self.open_job(dict(invalid_key=True)).init()
+        job = self.open_job(dict(valid_key=True)).init()
 
-        class A:
-            pass
-
-        for key in ("0", 0, True, False, None):
+        # Only strings are permitted as keys
+        for key in ("0", "1"):
             job.sp[key] = "test"
             assert str(key) in job.sp
 
@@ -454,7 +449,7 @@ class TestJobSpInterface(TestJobBase):
 
         job = self.open_job(dict(invalid_key=True)).init()
 
-        for key in (0.0, A(), (1, 2, 3)):
+        for key in (1, True, False, None, 0.0, A(), (1, 2, 3)):
             with pytest.raises(KeyTypeError):
                 job.sp[key] = "test"
             with pytest.raises(KeyTypeError):
@@ -465,16 +460,11 @@ class TestJobSpInterface(TestJobBase):
             with pytest.raises(TypeError):
                 job.sp = {key: "test"}
 
-    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_valid_doc_key_types(self):
-        job = self.open_job(dict(invalid_key=True)).init()
+        job = self.open_job(dict(valid_key=True)).init()
 
-        class A:
-            pass
-
-        for key in ("0", 0, True, False, None):
+        # Only strings are permitted as keys
+        for key in ("0", "1"):
             job.doc[key] = "test"
             assert str(key) in job.doc
 
@@ -484,7 +474,7 @@ class TestJobSpInterface(TestJobBase):
         class A:
             pass
 
-        for key in (0.0, A(), (1, 2, 3)):
+        for key in (1, True, False, None, 0.0, A(), (1, 2, 3)):
             with pytest.raises(KeyTypeError):
                 job.doc[key] = "test"
             with pytest.raises(KeyTypeError):

--- a/tests/test_jsondict.py
+++ b/tests/test_jsondict.py
@@ -219,16 +219,14 @@ class TestJSONDict(TestJSONDictBase):
         with pytest.raises(InvalidKeyError):
             jsd["a.b"] = None
 
-    @pytest.mark.filterwarnings("ignore:Use of int as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of NoneType as key is deprecated")
-    @pytest.mark.filterwarnings("ignore:Use of bool as key is deprecated")
     def test_keys_valid_type(self):
         jsd = self.get_json_dict()
 
         class MyStr(str):
             pass
 
-        for key in ("key", MyStr("key"), 0, None, True):
+        # Only strings are permitted as keys
+        for key in ("key", MyStr("key")):
             d = jsd[key] = self.get_testdata()
             assert str(key) in jsd
             assert jsd[str(key)] == d
@@ -239,7 +237,7 @@ class TestJSONDict(TestJSONDictBase):
         class A:
             pass
 
-        for key in (0.0, A(), (1, 2, 3)):
+        for key in (1, True, False, None, 0.0, A(), (1, 2, 3)):
             with pytest.raises(KeyTypeError):
                 jsd[key] = self.get_testdata()
         for key in ([], {}):

--- a/tests/test_synced_collections/test_json_collection.py
+++ b/tests/test_synced_collections/test_json_collection.py
@@ -47,16 +47,6 @@ class TestJSONDict(JSONCollectionTest, SyncedDictTest):
 
     _collection_type = JSONDict
 
-    # The following test tests the support for non-str keys
-    # for JSON backend which will be removed in version 2.0.
-    # See issue: https://github.com/glotzerlab/signac/issues/316.
-    def test_keys_non_str_valid_type(self, synced_collection, testdata):
-        for key in (0, None, True):
-            with pytest.warns(FutureWarning, match="Use of.+as key is deprecated"):
-                synced_collection[key] = testdata
-            assert str(key) in synced_collection
-            assert synced_collection[str(key)] == testdata
-
 
 class TestJSONList(JSONCollectionTest, SyncedListTest):
 

--- a/tests/test_synced_collections/test_validators.py
+++ b/tests/test_synced_collections/test_validators.py
@@ -39,7 +39,7 @@ class TestNoDotInKey:
     def test_valid_data(self, testdata):
         test_dict = {}
         # valid data
-        for key in ("valid_str", 1, False, None):
+        for key in ("valid_str", "another_valid_str"):
             test_dict[key] = testdata
             no_dot_in_key(test_dict)
             assert key in test_dict


### PR DESCRIPTION
## Description
This PR closes a handful of TODO items related to automatically converting non-string keys to strings for synced collections.

## Motivation and Context
See #316 for the original motivation to remove non-string keys.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
