### PR TITLE
Remove doc_filter arguments in tests

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1053,35 +1053,35 @@ class TestProject(TestProjectBase):
             job = self.project.open_job({"i": i}).init()
             job.document = get_doc(i)
 
-        for k, g in self.project.groupbydoc("a"):
+        for k, g in self.project.groupby("doc.a"):
             assert len(list(g)) == 1
             for job in list(g):
                 assert job.document["a"] == k
-        for k, g in self.project.groupbydoc("b"):
+        for k, g in self.project.groupby("doc.b"):
             assert len(list(g)) == 6
             for job in list(g):
                 assert job.document["b"] == k
         with pytest.raises(KeyError):
-            for k, g in self.project.groupbydoc("d"):
+            for k, g in self.project.groupby("doc.d"):
                 pass
-        for k, g in self.project.groupbydoc("d", default=-1):
+        for k, g in self.project.groupby("doc.d", default=-1):
             assert k == -1
             assert len(list(g)) == len(self.project)
-        for k, g in self.project.groupbydoc(("b", "c")):
+        for k, g in self.project.groupby(("doc.b", "doc.c")):
             assert len(list(g)) == 2
             for job in list(g):
                 assert job.document["b"] == k[0]
                 assert job.document["c"] == k[1]
-        for k, g in self.project.groupbydoc(lambda doc: doc["a"] % 4):
+        for k, g in self.project.groupby(lambda job: job.doc["a"] % 4):
             assert len(list(g)) == 3
             for job in list(g):
                 assert job.document["a"] % 4 == k
-        for k, g in self.project.groupbydoc(lambda doc: str(doc)):
+        for k, g in self.project.groupby(lambda job: str(job.doc)):
             assert len(list(g)) == 1
             for job in list(g):
                 assert str(job.document) == k
         group_count = 0
-        for k, g in self.project.groupbydoc():
+        for k, g in self.project.groupby():
             assert len(list(g)) == 1
             group_count = group_count + 1
             for job in list(g):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -339,7 +339,7 @@ class TestProject(TestProjectBase):
                 assert self.project.open_job(sp) in cursor_first
             else:
                 assert self.project.open_job(sp) not in cursor_first
-        cursor_doc = self.project.find_jobs(doc_filter={"test": True})
+        cursor_doc = self.project.find_jobs(filter={"doc.test": True})
         for sp in statepoints:
             assert self.project.open_job(sp) in cursor_doc
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

Remove `doc_filter` arguments after #586 #516.
Probably need to test deprecation before signac 2.0.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Related to  #725.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
