### PR TITLE
Update pre-commit to get fixed version of black.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
   - repo: https://github.com/asottile/pyupgrade
-    rev: 'v2.31.0'
+    rev: 'v2.31.1'
     hooks:
       - id: pyupgrade
         args:
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: '21.12b0'
+    rev: '22.3.0'
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
@@ -53,7 +53,7 @@ repos:
             ^signac/db/
           )
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.930'
+    rev: 'v0.942'
     hooks:
       - id: mypy
         additional_dependencies:

--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -589,7 +589,7 @@ def _convert_schema_path_to_regex(schema_path):
             types[key] = m.groupdict()["type"] or "str"
             start, stop = m.span()
             schema_regex += schema_path[index : index + start].replace(".", r"\.")
-            schema_regex += fr"(?P<{key}>{RE_TYPES[types[key]]})"
+            schema_regex += rf"(?P<{key}>{RE_TYPES[types[key]]})"
             index += stop
             continue
         break

--- a/signac/core/jsondict.py
+++ b/signac/core/jsondict.py
@@ -21,7 +21,7 @@ from .errors import Error
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BUFFER_SIZE = 32 * 2 ** 20  # 32 MB
+DEFAULT_BUFFER_SIZE = 32 * 2**20  # 32 MB
 
 _BUFFERED_MODE = 0
 _BUFFERED_MODE_FORCE_WRITE = None

--- a/signac/synced_collections/buffers/serialized_file_buffered_collection.py
+++ b/signac/synced_collections/buffers/serialized_file_buffered_collection.py
@@ -79,7 +79,7 @@ class SerializedFileBufferedCollection(FileBufferedCollection):
 
     """
 
-    _BUFFER_CAPACITY = 32 * 2 ** 20  # 32 MB
+    _BUFFER_CAPACITY = 32 * 2**20  # 32 MB
 
     def _flush(self, force=False):
         """Save buffered changes to the underlying file.


### PR DESCRIPTION
This updates our pre-commit hooks to get a fixed version of `black` that works with the latest `click`. See https://github.com/psf/black/issues/2964 for details. This is required to make our CI style checks work.