### PR TITLE
Schema2

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -730,14 +730,10 @@ def main_config_show(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn):
-                if cfg is None:
-                    cfg = config.read_config_file(fn)
-                else:
-                    cfg.merge(config.read_config_file(fn))
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
     if cfg is None:
@@ -769,14 +765,10 @@ def main_config_verify(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn):
-                if cfg is None:
-                    cfg = config.read_config_file(fn)
-                else:
-                    cfg.merge(config.read_config_file(fn))
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            cfg = config.read_config_file(config.PROJECT_CONFIG_FN)
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
     if cfg is None:
@@ -802,11 +794,10 @@ def main_config_set(args):
     if args.local and args.globalcfg:
         raise ValueError("You can specify either -l/--local or -g/--global, not both.")
     elif args.local:
-        for fn_config in config.CONFIG_FILENAMES:
-            if os.path.isfile(fn_config):
-                break
+        if os.path.isfile(config.PROJECT_CONFIG_FN):
+            fn_config = config.PROJECT_CONFIG_FN
     elif args.globalcfg:
-        fn_config = config.FN_CONFIG
+        fn_config = config.USER_CONFIG_FN
     else:
         raise ValueError(
             "You need to specify either -l/--local or -g/--global "

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -93,6 +93,8 @@ Synchronize your project with the temporary project, for example with:
 )
 
 
+SHELL_HISTORY_FN = os.sep.join((".signac", "shell_history"))
+
 warnings.simplefilter("default")
 
 
@@ -873,7 +875,7 @@ def main_shell(args):
         else:  # interactive
             if READLINE:
                 if "PyPy" not in platform.python_implementation():
-                    fn_hist = project.fn(".signac_shell_history")
+                    fn_hist = project.fn(SHELL_HISTORY_FN)
                     try:
                         readline.read_history_file(fn_hist)
                         readline.set_history_length(1000)

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -29,7 +29,7 @@ except ImportError:
 else:
     READLINE = True
 
-from . import Project, get_project, init_project
+from . import get_project, init_project
 from .common import config
 from .common.configobj import Section, flatten_errors
 from .contrib.filterparse import _add_prefix, parse_filter_arg
@@ -74,7 +74,6 @@ SHELL_BANNER = """Python {python_version}
 signac {signac_version} 🎨
 
 Project:\t{root_path}{job_banner}
-Workspace:\t{workspace_path}
 Size:\t\t{size}
 
 Interact with the project interface using the "project" or "pr" variable.
@@ -355,7 +354,7 @@ def main_view(args):
 
 def main_init(args):
     """Handle init subcommand."""
-    init_project(name=args.project_id, root=os.getcwd(), workspace=args.workspace)
+    init_project(name=args.project_id, root=os.getcwd())
     _print_err("Initialized project.")
 
 
@@ -423,16 +422,8 @@ def main_sync(args):
     try:
         destination = get_project(root=args.destination)
     except LookupError:
-        if args.allow_workspace:
-            # TODO: Remove allow_workspace entirely.
-            destination = Project(os.path.relpath(args.destination))
-        else:
-            _print_err(
-                "WARNING: The destination appears to not be a project path. "
-                "Use the '-w/--allow-workspace' option if you want to "
-                "synchronize to a workspace directory directly."
-            )
-            raise
+        _print_err("WARNING: The destination does not appear to be a project path.")
+        raise
     selection = find_with_filter_or_none(args)
 
     if args.strategy:
@@ -560,7 +551,6 @@ def _main_import_interactive(project, origin, args):
                     signac_version=__version__,
                     job_banner="",
                     root_path=project.root_directory(),
-                    workspace_path=project.workspace,
                     size=len(project),
                     origin=args.origin,
                 ),
@@ -902,7 +892,6 @@ def main_shell(args):
                     signac_version=__version__,
                     job_banner=f"\nJob:\t\t{job.id}" if job is not None else "",
                     root_path=project.root_directory(),
-                    workspace_path=project.workspace,
                     size=len(project),
                 ),
             )
@@ -931,13 +920,6 @@ def main():
 
     parser_init = subparsers.add_parser("init")
     parser_init.add_argument("project_id", nargs="?", help=argparse.SUPPRESS)
-    parser_init.add_argument(
-        "-w",
-        "--workspace",
-        type=str,
-        default="workspace",
-        help="The path to the workspace directory.",
-    )
     parser_init.set_defaults(func=main_init)
 
     parser_project = subparsers.add_parser("project")
@@ -1483,13 +1465,6 @@ job documents."
         "--no-keys", action="store_true", help="Never overwrite any conflicting keys."
     )
 
-    parser_sync.add_argument(
-        "-w",
-        "--allow-workspace",
-        action="store_true",
-        help="Allow the specification of a workspace (instead of a project) directory "
-        "as the destination path.",
-    )
     parser_sync.add_argument(
         "--force", action="store_true", help="Ignore all warnings, just synchronize."
     )

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -373,8 +373,9 @@ def main_schema(args):
 
 def main_sync(args):
     """Handle sync subcommand."""
+    # TODO: This function appears to be untested.
     #
-    # Valid provided argument combinations
+    # Validate provided argument combinations
     #
     if args.archive:
         args.recursive = True
@@ -423,13 +424,8 @@ def main_sync(args):
         destination = get_project(root=args.destination)
     except LookupError:
         if args.allow_workspace:
-            destination = Project(
-                config={
-                    "project": os.path.relpath(args.destination),
-                    "project_dir": args.destination,
-                    "workspace_dir": ".",
-                }
-            )
+            # TODO: Remove allow_workspace entirely.
+            destination = Project(os.path.relpath(args.destination))
         else:
             _print_err(
                 "WARNING: The destination appears to not be a project path. "
@@ -735,7 +731,7 @@ def main_config_show(args):
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
-        cfg = config.load_config()
+        cfg = config.load_config(config._locate_config_dir(os.getcwd()))
     if not cfg:
         if args.local:
             mode = "local"
@@ -768,7 +764,7 @@ def main_config_verify(args):
     elif args.globalcfg:
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
-        cfg = config.load_config()
+        cfg = config.load_config(config._locate_config_dir(os.getcwd()))
     if not cfg:
         if args.local:
             mode = "local"

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -73,8 +73,7 @@ Total transfer volume:       {stats.volume}
 SHELL_BANNER = """Python {python_version}
 signac {signac_version} 🎨
 
-Project:\t{project_id}{job_banner}
-Root:\t\t{root_path}
+Project:\t{root_path}{job_banner}
 Workspace:\t{workspace_path}
 Size:\t\t{size}
 
@@ -561,7 +560,6 @@ def _main_import_interactive(project, origin, args):
                 banner=SHELL_BANNER_INTERACTIVE_IMPORT.format(
                     python_version=sys.version,
                     signac_version=__version__,
-                    project_id=project.id,
                     job_banner="",
                     root_path=project.root_directory(),
                     workspace_path=project.workspace,
@@ -736,16 +734,14 @@ def main_config_show(args):
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
-    if cfg is None:
-        if args.local and args.globalcfg:
-            mode = " local or global "
-        elif args.local:
-            mode = " local "
+    if not cfg:
+        if args.local:
+            mode = "local"
         elif args.globalcfg:
-            mode = " global "
+            mode = "global"
         else:
-            mode = ""
-        _print_err(f"Did not find a{mode}configuration file.")
+            mode = "local or global"
+        _print_err(f"Did not find a {mode} configuration file.")
         return
     for key in args.key:
         for kt in key.split("."):
@@ -771,19 +767,19 @@ def main_config_verify(args):
         cfg = config.read_config_file(config.USER_CONFIG_FN)
     else:
         cfg = config.load_config()
-    if cfg is None:
-        if args.local and args.globalcfg:
-            mode = " local or global "
-        elif args.local:
-            mode = " local "
+    if not cfg:
+        if args.local:
+            mode = "local"
         elif args.globalcfg:
-            mode = " global "
+            mode = "global"
         else:
-            mode = ""
-        raise RuntimeWarning(f"Did not find a{mode}configuration file.")
-    if cfg.filename is not None:
-        _print_err(f"Verification of config file '{cfg.filename}'.")
-    verify_config(cfg)
+            mode = "local or global"
+        _print_err(f"Did not find a {mode} configuration file.")
+        return
+    else:
+        if cfg.filename is not None:
+            _print_err(f"Verification of config file '{cfg.filename}'.")
+        verify_config(cfg)
 
 
 def main_config_set(args):
@@ -906,7 +902,6 @@ def main_shell(args):
                 banner=SHELL_BANNER.format(
                     python_version=sys.version,
                     signac_version=__version__,
-                    project_id=project.id,
                     job_banner=f"\nJob:\t\t{job.id}" if job is not None else "",
                     root_path=project.root_directory(),
                     workspace_path=project.workspace,

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -12,18 +12,27 @@ from .validate import cfg, get_validator
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_FILENAME = ".signacrc"
-CONFIG_FILENAMES = [DEFAULT_FILENAME, "signac.rc"]
-HOME = os.path.expanduser("~")
-CONFIG_PATH = [HOME]
-FN_CONFIG = os.path.expanduser("~/.signacrc")
+PROJECT_CONFIG_FN = os.path.join(".signac", "config")
+USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
+
+
+def _get_project_config_fn(root):
+    return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
+
+
+def _get_config_dirname(fn):
+    # We could use pathlib's `.paths` attribute to remove the trailing project
+    # config filename, but that has significant performance
+    # implications: this takes ~200 ns, whereas
+    # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
+    # 20x slowdown.
+    return fn.replace(os.sep + PROJECT_CONFIG_FN, "")
 
 
 def _search_local(root):
-    for fn in CONFIG_FILENAMES:
-        fn_ = os.path.abspath(os.path.join(root, fn))
-        if os.path.isfile(fn_):
-            yield fn_
+    fn_ = _get_project_config_fn(root)
+    if os.path.isfile(fn_):
+        yield fn_
 
 
 def _search_tree(root=None):
@@ -41,8 +50,7 @@ def _search_tree(root=None):
         yield from _search_local(root)
         up = os.path.abspath(os.path.join(root, ".."))
         if up == root:
-            msg = "Reached filesystem root."
-            logger.debug(msg)
+            logger.debug("Reached filesystem root, no config found.")
             return
         else:
             root = up
@@ -50,8 +58,11 @@ def _search_tree(root=None):
 
 def _search_standard_dirs():
     """Locates signac configuration files in standard directories."""
-    for path in CONFIG_PATH:
-        yield from _search_local(path)
+    # For now this search only finds user-specific files, but it could be
+    # updated in the future to support e.g. system-wide config files.
+    for fn in (USER_CONFIG_FN,):
+        if os.path.isfile(fn):
+            yield fn
 
 
 def read_config_file(filename, configspec=None, *args, **kwargs):
@@ -75,10 +86,11 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
     try:
         config = Config(filename, configspec=configspec, *args, **kwargs)
     except (OSError, ConfigObjError) as error:
-        msg = "Failed to read configuration file '{}':\n{}"
-        raise ConfigError(msg.format(filename, error))
+        raise ConfigError(f"Failed to read configuration file '{filename}':\n{error}")
     verification = config.verify()
     if verification is not True:
+        # TODO: In the future this should raise an error, not just a
+        # debug-level logging notice.
         logger.debug(
             "Config file '{}' may contain invalid values.".format(
                 os.path.abspath(filename)
@@ -108,21 +120,24 @@ def load_config(root=None, local=False):
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))
     if local:
-        for fn in _search_local(root):
-            tmp = read_config_file(fn)
-            config.merge(tmp)
-            if "project" in tmp:
-                config["project_dir"] = os.path.dirname(fn)
-                break
+        search_func = _search_local
     else:
         for fn in _search_standard_dirs():
             config.merge(read_config_file(fn))
-        for fn in _search_tree(root):
-            tmp = read_config_file(fn)
-            config.merge(tmp)
-            if "project" in tmp:
-                config["project_dir"] = os.path.dirname(fn)
-                break
+        search_func = _search_tree
+
+    for fn in search_func(root):
+        tmp = read_config_file(fn)
+        config.merge(tmp)
+        # Once a valid config file is found, we cease looking any further, i.e.
+        # we assume that the first directory with a valid config file is the
+        # project root.
+        # TODO: Rather than adding the project directory to the config, it
+        # should be returned separately (i.e. the return should become a tuple
+        # (root_dir, config). The current approach confuses the discovery with
+        # the contents of the config.
+        config["project_dir"] = _get_config_dirname(fn)
+        break
     return config
 
 

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -15,65 +15,48 @@ logger = logging.getLogger(__name__)
 PROJECT_CONFIG_FN = os.path.join(".signac", "config")
 USER_CONFIG_FN = os.path.expanduser(os.path.join("~", ".signacrc"))
 
+# TODO: Consider making this entire module internal and removing all its
+# functions from the public API.
+
 
 def _get_project_config_fn(root):
     return os.path.abspath(os.path.join(root, PROJECT_CONFIG_FN))
 
 
-def _get_config_dirname(fn):
-    # We could use pathlib's `.paths` attribute to remove the trailing project
-    # config filename, but that has significant performance
-    # implications: this takes ~200 ns, whereas
-    # os.path.join(*(pathlib.PosixPath(fn).parts[:-2])) takes ~6 us, almost a
-    # 20x slowdown.
-    return fn.replace(os.sep + PROJECT_CONFIG_FN, "")
-
-
-def _search_local(root):
-    fn_ = _get_project_config_fn(root)
-    if os.path.isfile(fn_):
-        yield fn_
-
-
-def _search_tree(root=None):
-    """Locates signac configuration files in a directory hierarchy.
+def _locate_config_dir(search_path):
+    """Locates root directory containing a signac configuration file in a directory hierarchy.
 
     Parameters
     ----------
     root : str
-        Path to search. Uses ``os.getcwd()`` if None (Default value = None).
+        Starting path to search.
 
+    Returns
+    --------
+    str or None
+        The root directory containing the configuration file if one is found, otherwise None.
     """
-    if root is None:
-        root = os.getcwd()
+    root = os.path.abspath(search_path)
     while True:
-        yield from _search_local(root)
-        up = os.path.abspath(os.path.join(root, ".."))
+        if os.path.isfile(_get_project_config_fn(root)):
+            return root
+        # TODO: Could use the walrus operator here when we completely drop
+        # Python 3.7 support if we like the operator.
+        up = os.path.dirname(root)
         if up == root:
             logger.debug("Reached filesystem root, no config found.")
-            return
+            return None
         else:
             root = up
 
 
-def _search_standard_dirs():
-    """Locates signac configuration files in standard directories."""
-    # For now this search only finds user-specific files, but it could be
-    # updated in the future to support e.g. system-wide config files.
-    for fn in (USER_CONFIG_FN,):
-        if os.path.isfile(fn):
-            yield fn
-
-
-def read_config_file(filename, configspec=None, *args, **kwargs):
+def read_config_file(filename):
     """Read a configuration file.
 
     Parameters
     ----------
     filename : str
         The path to the file to read.
-    configspec : List[str], optional
-        The key-value pairs supported in the config.
 
     Returns
     --------
@@ -81,10 +64,9 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
         The config contained in the file.
     """
     logger.debug(f"Reading config file '{filename}'.")
-    if configspec is None:
-        configspec = cfg.split("\n")
+    configspec = cfg.split("\n")
     try:
-        config = Config(filename, configspec=configspec, *args, **kwargs)
+        config = Config(filename, configspec=configspec)
     except (OSError, ConfigObjError) as error:
         raise ConfigError(f"Failed to read configuration file '{filename}':\n{error}")
     verification = config.verify()
@@ -99,45 +81,33 @@ def read_config_file(filename, configspec=None, *args, **kwargs):
     return config
 
 
-def load_config(root=None, local=False):
-    """Load configuration, searching upward from a root path if desired.
+def load_config(root=None):
+    """Load configuration from a project directory.
 
     Parameters
     ----------
     root : str
-        The path from which to begin searching for config files.
-    local : bool, optional
-        If ``True``, only search in the provided directory and do not traverse
-        upwards through the filesystem (Default value: False).
+        The project path to pull project-local configuration data from.
 
     Returns
     --------
     :class:`Config`
-        The composite configuration including both local and global config data
-        if requested.
+        The composite configuration including both project-local and global
+        config data if requested. Note that because this config is a composite,
+        modifications to the returned value will not be reflected in the files.
     """
     if root is None:
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))
-    if local:
-        search_func = _search_local
-    else:
-        for fn in _search_standard_dirs():
-            config.merge(read_config_file(fn))
-        search_func = _search_tree
 
-    for fn in search_func(root):
-        tmp = read_config_file(fn)
-        config.merge(tmp)
-        # Once a valid config file is found, we cease looking any further, i.e.
-        # we assume that the first directory with a valid config file is the
-        # project root.
-        # TODO: Rather than adding the project directory to the config, it
-        # should be returned separately (i.e. the return should become a tuple
-        # (root_dir, config). The current approach confuses the discovery with
-        # the contents of the config.
-        config["project_dir"] = _get_config_dirname(fn)
-        break
+    # Add in any global or user config files. For now this only finds user-specific
+    # files, but it could be updated in the future to support e.g. system-wide config files.
+    for fn in (USER_CONFIG_FN,):
+        if os.path.isfile(fn):
+            config.merge(read_config_file(fn))
+
+    if os.path.isfile(_get_project_config_fn(root)):
+        config.merge(read_config_file(_get_project_config_fn(root)))
     return config
 
 

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -15,7 +15,6 @@ def get_validator():  # noqa: D103
 
 
 cfg = """
-project = string()
 workspace_dir = string(default='workspace')
 schema_version = string(default='1')
 """

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -16,6 +16,5 @@ def get_validator():  # noqa: D103
 
 # TODO: Rename to something internal and uppercase e.g. _CFG.
 cfg = """
-workspace_dir = string(default='workspace')
 schema_version = string(default='1')
 """

--- a/signac/common/validate.py
+++ b/signac/common/validate.py
@@ -14,6 +14,7 @@ def get_validator():  # noqa: D103
     return Validator()
 
 
+# TODO: Rename to something internal and uppercase e.g. _CFG.
 cfg = """
 workspace_dir = string(default='workspace')
 schema_version = string(default='1')

--- a/signac/contrib/migration/__init__.py
+++ b/signac/contrib/migration/__init__.py
@@ -11,6 +11,7 @@ from packaging import version
 
 from ...version import SCHEMA_VERSION, __version__
 from .v0_to_v1 import _load_config_v1, _migrate_v0_to_v1
+from .v1_to_v2 import _load_config_v2, _migrate_v1_to_v2
 
 FN_MIGRATION_LOCKFILE = ".SIGNAC_PROJECT_MIGRATION_LOCK"
 
@@ -25,11 +26,13 @@ FN_MIGRATION_LOCKFILE = ".SIGNAC_PROJECT_MIGRATION_LOCK"
 # objects to the underlying config files.
 _CONFIG_LOADERS = {
     "1": _load_config_v1,
+    "2": _load_config_v2,
 }
 
 
 _MIGRATIONS = {
     ("0", "1"): _migrate_v0_to_v1,
+    ("1", "2"): _migrate_v1_to_v2,
 }
 
 _PARSED_SCHEMA_VERSION = version.parse(SCHEMA_VERSION)

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Migrate from schema version 1 to version 2.
+
+This migration involves the following changes:
+    - Moving the signac.rc config file to .signac/config
+"""
+
+import os
+
+from signac.common import configobj
+from signac.common.config import _get_project_config_fn
+
+# A minimal v2 config.
+_cfg = """
+schema_version = string(default='0')
+project = string()
+workspace_dir = string(default='workspace')
+"""
+
+
+def _load_config_v2(root_directory):
+    cfg = configobj.ConfigObj(
+        os.path.join(root_directory, ".signac", "config"), configspec=_cfg.split("\n")
+    )
+    validator = configobj.validate.Validator()
+    if cfg.validate(validator) is not True:
+        raise RuntimeError(
+            "This project's config file is not compatible with signac's v2 schema."
+        )
+    return cfg
+
+
+def _migrate_v1_to_v2(root_directory):
+    """Migrate from schema version 1 to version 2."""
+    v1_fn = os.path.join(root_directory, "signac.rc")
+    v2_fn = _get_project_config_fn(root_directory)
+    os.mkdir(os.path.dirname(v2_fn))
+    os.rename(v1_fn, v2_fn)

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -49,4 +49,16 @@ def _migrate_v1_to_v2(root_directory):
     v1_fn = os.path.join(root_directory, "signac.rc")
     v2_fn = _get_project_config_fn(root_directory)
     os.mkdir(os.path.dirname(v2_fn))
-    os.rename(v1_fn, v2_fn)
+    os.replace(v1_fn, v2_fn)
+
+    # Now move all other files.
+    files_to_move = {
+        ".signac_shell_history": os.sep.join((".signac", "shell_history")),
+        ".signac_sp_cache.json.gz": os.sep.join(
+            (".signac", "statepoint_cache.json.gz")
+        ),
+    }
+    for src, dst in files_to_move.items():
+        os.replace(
+            os.sep.join((root_directory, src)), os.sep.join((root_directory, dst))
+        )

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -5,6 +5,12 @@
 
 This migration involves the following changes:
     - Moving the signac.rc config file to .signac/config
+    - Moving .signac_shell_history to .signac/shell_history
+    - Moving .signac_sp_cache.json.gz to .signac/statepoint_cache.json.gz
+    - Removing the project name from the config. Projects are now identified
+      solely by their directories.
+    - Removing the workspace_dir key from the config. The workspace directory
+      is no longer configurable.
 """
 
 import os

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -136,17 +136,6 @@ class Project:
         self._config = _ProjectConfig(config)
         self._lock = RLock()
 
-        # Ensure that the project id is configured.
-        try:
-            self._id = str(self.config["project"])
-        except KeyError:
-            raise LookupError(
-                "Unable to determine project id. "
-                "Please verify that '{}' is a signac project path.".format(
-                    os.path.abspath(self.config.get("project_dir", os.getcwd()))
-                )
-            )
-
         # Ensure that the project's data schema is supported.
         self._check_schema_compatibility()
 
@@ -172,8 +161,8 @@ class Project:
                 _mkdir_p(self.workspace)
             except OSError:
                 logger.error(
-                    "Error occurred while trying to create "
-                    "workspace directory for project {}.".format(self.id)
+                    "Error occurred while trying to create workspace directory for project at root "
+                    f"{self.root_directory()}."
                 )
                 raise
 
@@ -191,8 +180,7 @@ class Project:
         )
 
     def __str__(self):
-        """Return the project's id."""
-        return str(self.id)
+        return str(self.root_directory())
 
     def __repr__(self):
         return "{type}.get_project({root})".format(
@@ -210,8 +198,7 @@ class Project:
         """
         return (
             "<p>"
-            + f"<strong>Project:</strong> {self.id}<br>"
-            + f"<strong>Root:</strong> {self.root_directory()}<br>"
+            + f"<strong>Project:</strong> {self.path}<br>"
             + f"<strong>Workspace:</strong> {self.workspace}<br>"
             + f"<strong>Size:</strong> {len(self)}"
             + "</p>"
@@ -269,18 +256,6 @@ class Project:
         See :ref:`signac project -w <signac-cli-project>` for the command line equivalent.
         """
         return self._workspace
-
-    @property
-    def id(self):
-        """Get the project identifier.
-
-        Returns
-        -------
-        str
-            The project id.
-
-        """
-        return self._id
 
     def _check_schema_compatibility(self):
         """Check whether this project's data schema is compatible with this version.
@@ -1595,7 +1570,6 @@ class Project:
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
             config = read_config_file(fn_config)
-            config["project"] = name
             if workspace is not None:
                 config["workspace_dir"] = workspace
             config["schema_version"] = SCHEMA_VERSION
@@ -1603,7 +1577,6 @@ class Project:
             project = cls.get_project(root=root)
             if name is not None:
                 project.doc[name_key] = name
-            assert project.id == str(name)
             return project
         else:
             if workspace is not None and os.path.realpath(
@@ -1647,7 +1620,7 @@ class Project:
         if root is None:
             root = os.getcwd()
         config = load_config(root=root, local=False)
-        if "project" not in config or (
+        if "project_dir" not in config or (
             not search
             and os.path.realpath(config["project_dir"]) != os.path.realpath(root)
         ):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -106,16 +106,17 @@ class _ProjectConfig(Config):
 class Project:
     """The handle on a signac project.
 
-    Application developers should usually not need to
-    directly instantiate this class, but use
-    :meth:`~signac.get_project` instead.
+    A :class:`Project` may only be constructed in a directory that is already a
+    signac project, i.e. a directory in which :func:`~signac.init_project` has
+    already been run. If project discovery (searching upwards in the folder
+    hierarchy until a project root is discovered) is desired, users should
+    instead invoke :func:`~signac.get_project` or :meth:`Project.get_project`.
 
     Parameters
     ----------
-    config :
-        The project configuration to use. By default, it loads the first signac
-        project configuration found while searching upward from the current
-        working directory (Default value = None).
+    root : str, optional
+        The project root directory. By default, the current working directory
+        (Default value = None).
 
     """
 
@@ -130,9 +131,12 @@ class Project:
 
     _use_pandas_for_html_repr = True  # toggle use of pandas for html repr
 
-    def __init__(self, config=None):
-        if config is None:
-            config = load_config()
+    def __init__(self, root=None):
+        if root is None:
+            root = os.getcwd()
+        # Project constructor does not search upward, so the provided root must
+        # be a project directory.
+        config = load_config(root, local=True)
         self._config = _ProjectConfig(config)
         self._lock = RLock()
 
@@ -183,9 +187,7 @@ class Project:
         return str(self.root_directory())
 
     def __repr__(self):
-        return "{type}.get_project({root})".format(
-            type=self.__class__.__name__, root=repr(self.root_directory())
-        )
+        return f"{self.__class__.__name__}({repr(self.root_directory())})"
 
     def _repr_html_(self):
         """Project details in HTML format for use in IPython environment.
@@ -1619,7 +1621,7 @@ class Project:
         """
         if root is None:
             root = os.getcwd()
-        config = load_config(root=root, local=False)
+        config = load_config(root=root, local=not search)
         if "project_dir" not in config or (
             not search
             and os.path.realpath(config["project_dir"]) != os.path.realpath(root)
@@ -1630,7 +1632,7 @@ class Project:
                 )
             )
 
-        return cls(config=config, **kwargs)
+        return cls(root=config["project_dir"], **kwargs)
 
     @classmethod
     def get_job(cls, root=None):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -158,12 +158,7 @@ class Project:
         # Prepare root directory and workspace paths.
         # os.path is used instead of pathlib.Path for performance.
         self._root_directory = os.path.abspath(root)
-        ws = os.path.expandvars(
-            self.config.get("workspace_dir", "workspace")
-        )
-        if not os.path.isabs(ws):
-            ws = os.path.join(self._root_directory, ws)
-        self._workspace = _CallableString(ws)
+        self._workspace = _CallableString(os.path.join(self._root_directory, "workspace"))
 
         # Prepare workspace directory.
         if not os.path.isdir(self.workspace):
@@ -251,18 +246,7 @@ class Project:
 
     @property
     def workspace(self):
-        """str: The project's workspace directory.
-
-        The workspace defaults to `project_root/workspace`. Configure this
-        directory with the ``'workspace_dir'`` configuration option. A relative
-        path is assumed to be relative to the project's root directory.
-
-        .. note::
-            The configuration will respect environment variables,
-            such as ``$HOME``.
-
-        See :ref:`signac project -w <signac-cli-project>` for the command line equivalent.
-        """
+        """str: The project's workspace directory."""
         return self._workspace
 
     def _check_schema_compatibility(self):
@@ -1484,7 +1468,7 @@ class Project:
             yield tmp_project
 
     @classmethod
-    def init_project(cls, *args, root=None, workspace=None, make_dir=True, **kwargs):
+    def init_project(cls, *args, root=None, **kwargs):
         """Initialize a project in the provided root directory.
 
         It is safe to call this function multiple times with the same
@@ -1499,12 +1483,6 @@ class Project:
         root : str, optional
             The root directory for the project.
             Defaults to the current working directory.
-        workspace : str, optional
-            The workspace directory for the project.
-            Defaults to a subdirectory ``workspace`` in the project root.
-        make_dir : bool, optional
-            Create the project root directory if it does not exist yet
-            (Default value = True).
 
         Returns
         -------
@@ -1575,26 +1553,14 @@ class Project:
                 )
         except LookupError:
             fn_config = _get_project_config_fn(root)
-            if make_dir:
-                _mkdir_p(os.path.dirname(fn_config))
+            _mkdir_p(os.path.dirname(fn_config))
             config = read_config_file(fn_config)
-            if workspace is not None:
-                config["workspace_dir"] = workspace
             config["schema_version"] = SCHEMA_VERSION
             config.write()
             project = cls.get_project(root=root)
             if name is not None:
                 project.doc[name_key] = name
-            return project
-        else:
-            if workspace is not None and os.path.realpath(
-                workspace
-            ) != os.path.realpath(project.workspace):
-                raise RuntimeError(
-                    f"Failed to initialize project. Path '{os.path.abspath(root)}' already "
-                    "contains a conflicting project configuration."
-                )
-            return project
+        return project
 
     @classmethod
     def get_project(cls, root=None, search=True, **kwargs):
@@ -2157,7 +2123,7 @@ class JobsCursor:
         return repr(self) + self._repr_html_jobs()
 
 
-def init_project(*args, root=None, workspace=None, make_dir=True, **kwargs):
+def init_project(*args, root=None, **kwargs):
     """Initialize a project.
 
     It is safe to call this function multiple times with the same arguments.
@@ -2169,12 +2135,6 @@ def init_project(*args, root=None, workspace=None, make_dir=True, **kwargs):
     root : str, optional
         The root directory for the project.
         Defaults to the current working directory.
-    workspace : str, optional
-        The workspace directory for the project.
-        Defaults to a subdirectory ``workspace`` in the project root.
-    make_dir : bool, optional
-        Create the project root directory, if it does not exist yet (Default
-        value = True).
 
     Returns
     -------
@@ -2188,9 +2148,7 @@ def init_project(*args, root=None, workspace=None, make_dir=True, **kwargs):
         configuration.
 
     """
-    return Project.init_project(
-        *args, root=root, workspace=workspace, make_dir=make_dir, **kwargs
-    )
+    return Project.init_project(*args, root=root, **kwargs)
 
 
 def get_project(root=None, search=True, **kwargs):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -291,8 +291,8 @@ class Project:
             If the schema version is incompatible.
 
         """
-        schema_version = version.parse(SCHEMA_VERSION)
-        config_schema_version = version.parse(self.config["schema_version"])
+        schema_version = SCHEMA_VERSION
+        config_schema_version = int(self.config["schema_version"])
         if config_schema_version > schema_version:
             # Project config schema version is newer and therefore not supported.
             raise IncompatibleSchemaVersion(

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -24,6 +24,7 @@ from packaging import version
 from ..common.config import (
     Config,
     _get_project_config_fn,
+    _locate_config_dir,
     load_config,
     read_config_file,
 )
@@ -134,9 +135,14 @@ class Project:
     def __init__(self, root=None):
         if root is None:
             root = os.getcwd()
+        if not os.path.isfile(_get_project_config_fn(root)):
+            raise LookupError(
+                f"Unable to find project at path '{os.path.abspath(root)}'."
+            )
+
         # Project constructor does not search upward, so the provided root must
         # be a project directory.
-        config = load_config(root, local=True)
+        config = load_config(root)
         self._config = _ProjectConfig(config)
         self._lock = RLock()
 
@@ -151,7 +157,7 @@ class Project:
 
         # Prepare root directory and workspace paths.
         # os.path is used instead of pathlib.Path for performance.
-        self._root_directory = self.config["project_dir"]
+        self._root_directory = os.path.abspath(root)
         ws = os.path.expandvars(
             self.config.get("workspace_dir", "workspace")
         )
@@ -1621,18 +1627,19 @@ class Project:
         """
         if root is None:
             root = os.getcwd()
-        config = load_config(root=root, local=not search)
-        if "project_dir" not in config or (
-            not search
-            and os.path.realpath(config["project_dir"]) != os.path.realpath(root)
-        ):
+
+        old_root = root
+        if not search and not os.path.isfile(_get_project_config_fn(root)):
+            root = None
+        else:
+            root = _locate_config_dir(root)
+
+        if not root:
             raise LookupError(
-                "Unable to determine project id for path '{}'.".format(
-                    os.path.abspath(root)
-                )
+                f"Unable to find project at path '{os.path.abspath(old_root)}'."
             )
 
-        return cls(root=config["project_dir"], **kwargs)
+        return cls(root=root, **kwargs)
 
     @classmethod
     def get_job(cls, root=None):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -21,7 +21,12 @@ from threading import RLock
 
 from packaging import version
 
-from ..common.config import Config, load_config, read_config_file
+from ..common.config import (
+    Config,
+    _get_project_config_fn,
+    load_config,
+    read_config_file,
+)
 from ..common.deprecation import deprecated
 from ..core.h5store import H5StoreManager
 from ..sync import sync_projects
@@ -1586,7 +1591,7 @@ class Project:
                     f"project document in which {name_key}={existing_name}."
                 )
         except LookupError:
-            fn_config = os.path.join(root, "signac.rc")
+            fn_config = _get_project_config_fn(root)
             if make_dir:
                 _mkdir_p(os.path.dirname(fn_config))
             config = read_config_file(fn_config)

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -158,7 +158,9 @@ class Project:
         # Prepare root directory and workspace paths.
         # os.path is used instead of pathlib.Path for performance.
         self._root_directory = os.path.abspath(root)
-        self._workspace = _CallableString(os.path.join(self._root_directory, "workspace"))
+        self._workspace = _CallableString(
+            os.path.join(self._root_directory, "workspace")
+        )
 
         # Prepare workspace directory.
         if not os.path.isdir(self.workspace):
@@ -1332,9 +1334,7 @@ class Project:
                     # workspace, job id, and document file name to be
                     # well-formed, so just use str.join with os.sep instead of
                     # os.path.join for speed.
-                    fn_document = os.sep.join(
-                        (self.workspace, job_id, Job.FN_DOCUMENT)
-                    )
+                    fn_document = os.sep.join((self.workspace, job_id, Job.FN_DOCUMENT))
                     with open(fn_document, "rb") as file:
                         doc["doc"] = json.loads(file.read().decode())
                 except OSError as error:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -126,7 +126,7 @@ class Project:
     KEY_DATA = "signac_data"
     "The project's datastore key."
 
-    FN_CACHE = ".signac_sp_cache.json.gz"
+    FN_CACHE = os.sep.join((".signac", "statepoint_cache.json.gz"))
     "The default filename for the state point cache file."
 
     _use_pandas_for_html_repr = True  # toggle use of pandas for html repr

--- a/signac/version.py
+++ b/signac/version.py
@@ -6,7 +6,7 @@
 
 __version__ = "1.7.0"
 
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = 2
 
 
 __all__ = [

--- a/signac/version.py
+++ b/signac/version.py
@@ -6,7 +6,7 @@
 
 __version__ = "1.7.0"
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 
 
 __all__ = [

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -70,12 +70,9 @@ class TestJobBase:
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
-        self._tmp_wd = os.path.join(self._tmp_dir.name, "wd")
         os.mkdir(self._tmp_pr)
         self.config = signac.common.config.load_config()
-        self.project = self.project_class.init_project(
-            root=self._tmp_pr, workspace=self._tmp_wd
-        )
+        self.project = self.project_class.init_project(root=self._tmp_pr)
 
     def tearDown(self):
         pass

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -88,17 +88,13 @@ class TestProjectBase(TestJobBase):
 
 
 class TestProject(TestProjectBase):
-    def test_get(self):
-        pass
-
     def test_repr(self):
-        repr(self.project)
         p = eval(repr(self.project))
         assert repr(p) == repr(self.project)
         assert p == self.project
 
     def test_str(self):
-        str(self.project) == self.project.id
+        assert str(self.project) == self.project.root_directory()
 
     def test_root_directory(self):
         assert self._tmp_pr == self.project.root_directory()
@@ -2277,14 +2273,6 @@ class TestProjectInit:
         project = signac.Project.get_project(root=root)
         assert project.workspace == os.path.join(root, "workspace")
         assert project.root_directory() == root
-
-    def test_project_no_id(self):
-        root = self._tmp_dir.name
-        signac.init_project(root=root)
-        config = load_config(root)
-        del config["project"]
-        with pytest.raises(LookupError):
-            Project(config=config)
 
     def test_get_project_non_local(self):
         root = self._tmp_dir.name

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -9,6 +9,7 @@ import os
 import pickle
 import re
 import sys
+import textwrap
 import uuid
 from contextlib import contextmanager, redirect_stderr
 from tarfile import TarFile
@@ -22,7 +23,12 @@ from packaging import version
 from test_job import TestJobBase
 
 import signac
-from signac.common.config import load_config, read_config_file
+from signac.common.config import (
+    PROJECT_CONFIG_FN,
+    _get_project_config_fn,
+    load_config,
+    read_config_file,
+)
 from signac.contrib.errors import (
     IncompatibleSchemaVersion,
     JobsCorruptedError,
@@ -2444,7 +2450,7 @@ class TestProjectSchema(TestProjectBase):
         assert version.parse(self.project.config["schema_version"]) < version.parse(
             impossibly_high_schema_version
         )
-        config = read_config_file(self.project.fn("signac.rc"))
+        config = read_config_file(_get_project_config_fn(self.project.root_directory()))
         config["schema_version"] = impossibly_high_schema_version
         config.write()
         with pytest.raises(IncompatibleSchemaVersion):
@@ -2456,33 +2462,11 @@ class TestProjectSchema(TestProjectBase):
 
         # Ensure that migration fails on an invalid version.
         invalid_schema_version = "0.5"
-        config = read_config_file(self.project.fn("signac.rc"))
+        config = read_config_file(_get_project_config_fn(self.project.root_directory()))
         config["schema_version"] = invalid_schema_version
         config.write()
         with pytest.raises(RuntimeError):
             apply_migrations(self.project.root_directory())
-
-    @pytest.mark.parametrize("implicit_version", [True, False])
-    def test_project_schema_version_migration(self, implicit_version):
-        from signac.contrib.migration import apply_migrations
-
-        config = read_config_file(self.project.fn("signac.rc"))
-        if implicit_version:
-            del config["schema_version"]
-            assert "schema_version" not in config
-        else:
-            config["schema_version"] = "0"
-            assert config["schema_version"] == "0"
-        config.write()
-        err = io.StringIO()
-        with redirect_stderr(err):
-            apply_migrations(self.project.root_directory())
-        config = read_config_file(self.project.fn("signac.rc"))
-        assert config["schema_version"] == "1"
-        project = signac.get_project(root=self.project.root_directory())
-        assert project.config["schema_version"] == "1"
-        assert "OK" in err.getvalue()
-        assert "0 to 1" in err.getvalue()
 
     def test_no_migration(self):
         # This unit test should fail as long as there are no schema migrations
@@ -2496,6 +2480,43 @@ class TestProjectSchema(TestProjectBase):
 
         migrations = list(_collect_migrations(self.project.root_directory()))
         assert len(migrations) == 0
+
+
+class TestSchemaMigration:
+    @pytest.mark.parametrize("implicit_version", [True, False])
+    def test_project_schema_version_migration(self, implicit_version):
+        from signac.contrib.migration import apply_migrations
+
+        with TemporaryDirectory() as dirname:
+            cfg_fn = os.path.join(dirname, "signac.rc")
+            with open(cfg_fn, "w") as f:
+                f.write(
+                    textwrap.dedent(
+                        """\
+                        project = project
+                        workspace_dir = workspace
+                        schema_version = 0"""
+                    )
+                )
+
+            config = read_config_file(cfg_fn)
+            if implicit_version:
+                del config["schema_version"]
+                assert "schema_version" not in config
+            else:
+                assert config["schema_version"] == "0"
+            config.write()
+            err = io.StringIO()
+            with redirect_stderr(err):
+                apply_migrations(dirname)
+            config = load_config(dirname)
+            assert config["schema_version"] == "2"
+            project = signac.get_project(root=dirname)
+            assert project.config["schema_version"] == "2"
+            assert "OK" in err.getvalue()
+            assert "0 to 1" in err.getvalue()
+            assert "1 to 2" in err.getvalue()
+            assert os.path.isfile(project.fn(PROJECT_CONFIG_FN))
 
 
 class TestProjectPickling(TestProjectBase):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2460,14 +2460,6 @@ class TestProjectSchema(TestProjectBase):
         with pytest.raises(RuntimeError):
             apply_migrations(self.project.root_directory())
 
-        # Ensure that migration fails on an invalid version.
-        invalid_schema_version = "0.5"
-        config = read_config_file(_get_project_config_fn(self.project.root_directory()))
-        config["schema_version"] = invalid_schema_version
-        config.write()
-        with pytest.raises(RuntimeError):
-            apply_migrations(self.project.root_directory())
-
     def test_no_migration(self):
         # This unit test should fail as long as there are no schema migrations
         # implemented within the signac.contrib.migration package.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+import gzip
 import io
 import itertools
 import json
@@ -35,6 +36,7 @@ from signac.contrib.errors import (
     StatepointParsingError,
     WorkspaceError,
 )
+from signac.contrib.hashing import calc_id
 from signac.contrib.linked_view import _find_all_links
 from signac.contrib.project import JobsCursor, Project  # noqa: F401
 from signac.contrib.schema import ProjectSchema
@@ -2468,6 +2470,7 @@ class TestSchemaMigration:
         from signac.contrib.migration import apply_migrations
 
         with TemporaryDirectory() as dirname:
+            # Create v1 config file.
             cfg_fn = os.path.join(dirname, "signac.rc")
             with open(cfg_fn, "w") as f:
                 f.write(
@@ -2479,6 +2482,21 @@ class TestSchemaMigration:
                     )
                 )
 
+            # Create a shell history file.
+            history_fn = os.path.join(dirname, ".signac_shell_history")
+            with open(history_fn, "w") as f:
+                f.write("print(project)")
+
+            # Create a statepoint cache. Note that this cache does not
+            # correspond to actual statepoints since we don't currently have
+            # any in this project, but that's fine for migration testing.
+            history_fn = os.path.join(dirname, ".signac_sp_cache.json.gz")
+            sp = {"a": 1}
+            with gzip.open(history_fn, "wb") as f:
+                f.write(json.dumps({calc_id(sp): sp}).encode())
+
+            # If no schema version is present in the config it is equivalent to
+            # version 0, so we test both explicit and implicit versions.
             config = read_config_file(cfg_fn)
             if implicit_version:
                 del config["schema_version"]
@@ -2486,6 +2504,7 @@ class TestSchemaMigration:
             else:
                 assert config["schema_version"] == "0"
             config.write()
+
             err = io.StringIO()
             with redirect_stderr(err):
                 apply_migrations(dirname)
@@ -2497,6 +2516,8 @@ class TestSchemaMigration:
             assert "0 to 1" in err.getvalue()
             assert "1 to 2" in err.getvalue()
             assert os.path.isfile(project.fn(PROJECT_CONFIG_FN))
+            assert os.path.isfile(project.fn(os.sep.join((".signac", "shell_history"))))
+            assert os.path.isfile(project.fn(Project.FN_CACHE))
 
 
 class TestProjectPickling(TestProjectBase):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -71,6 +71,12 @@ WINDOWS = sys.platform == "win32"
 test_token = {"test_token": str(uuid.uuid4())}
 
 
+# Use the major version to fail tests expected to fail in 3.0.
+_CURRENT_VERSION = version.parse(signac.__version__)
+_VERSION_3 = version.parse("3.0.0")
+_VERSION_2 = version.parse("2.0.0")
+
+
 S_FORMAT1 = """{
  'a': 'int([0, 1, 2, ..., 8, 9], 10)',
  'b.b2': 'int([0, 1, 2, ..., 8, 9], 10)',
@@ -102,28 +108,16 @@ class TestProject(TestProjectBase):
         assert self._tmp_pr == self.project.root_directory()
 
     def test_workspace_directory(self):
-        assert self._tmp_wd == self.project.workspace
+        assert os.path.join(self._tmp_pr, "workspace") == self.project.workspace
 
     def test_config_modification(self):
         # In-memory modification of the project configuration is
         # deprecated as of 1.3, and will be removed in version 2.0.
         # This unit test should reflect that change beginning 2.0,
         # and check that the project configuration is immutable.
+        assert _CURRENT_VERSION < _VERSION_2
         with pytest.raises(ValueError):
             self.project.config["foo"] = "bar"
-
-    def test_workspace_directory_with_env_variable(self):
-        try:
-            with TemporaryDirectory() as tmp_dir:
-                os.environ["SIGNAC_ENV_DIR_TEST"] = os.path.join(tmp_dir, "work_here")
-                project = self.project_class.init_project(
-                    root=tmp_dir,
-                    workspace="${SIGNAC_ENV_DIR_TEST}",
-                )
-                assert project.workspace == os.environ["SIGNAC_ENV_DIR_TEST"]
-        finally:
-            if "SIGNAC_ENV_DIR_TEST" in os.environ:
-                del os.environ["SIGNAC_ENV_DIR_TEST"]
 
     def test_workspace_directory_exists(self):
         assert os.path.exists(self.project.workspace)
@@ -213,24 +207,6 @@ class TestProject(TestProjectBase):
         self.project.data = {"a": {"b": 45}}
         assert self.project.data == {"a": {"b": 45}}
 
-    def test_workspace_path_normalization(self):
-        def norm_path(p):
-            return os.path.abspath(os.path.expandvars(p))
-
-        assert self.project.workspace == norm_path(self._tmp_wd)
-
-        with TemporaryDirectory() as tmp_dir:
-            abs_path = os.path.join(tmp_dir, "path", "to", "workspace")
-            project = self.project_class.init_project(root=tmp_dir, workspace=abs_path)
-            assert project.workspace == norm_path(abs_path)
-
-        with TemporaryDirectory() as tmp_dir:
-            rel_path = norm_path(os.path.join("path", "to", "workspace"))
-            project = self.project_class.init_project(root=tmp_dir, workspace=rel_path)
-            assert project.workspace == norm_path(
-                os.path.join(project.root_directory(), rel_path)
-            )
-
     def test_no_workspace_warn_on_find(self, caplog):
         if os.path.exists(self.project.workspace):
             os.rmdir(self.project.workspace)
@@ -245,13 +221,11 @@ class TestProject(TestProjectBase):
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_workspace_broken_link_error_on_find(self):
         with TemporaryDirectory() as tmp_dir:
-            project = self.project_class.init_project(
-                root=tmp_dir, workspace="workspace-link"
-            )
-            os.rmdir(os.path.join(tmp_dir, "workspace-link"))
+            project = self.project_class.init_project(root=tmp_dir)
+            os.rmdir(project.workspace)
             os.symlink(
                 os.path.join(tmp_dir, "workspace~"),
-                os.path.join(tmp_dir, "workspace-link"),
+                project.workspace,
             )
             with pytest.raises(WorkspaceError):
                 list(project.find_jobs())
@@ -276,7 +250,6 @@ class TestProject(TestProjectBase):
         finally:
             logging.disable(logging.NOTSET)
 
-        assert not os.path.isdir(self._tmp_wd)
         assert not os.path.isdir(self.project.workspace)
 
     def test_find_jobs(self):
@@ -1033,11 +1006,6 @@ class TestProject(TestProjectBase):
         assert not os.path.isdir(tmp_root_dir)
 
 
-# Use the major version to fail tests expected to fail in 3.0.
-_MAJOR_VERSION = version.parse(signac.__version__)
-_VERSION_3 = version.parse("3.0.0")
-
-
 class TestProjectNameDeprecations:
     warning_context = pytest.warns(
         FutureWarning, match="Project names were removed in signac 2.0"
@@ -1048,7 +1016,7 @@ class TestProjectNameDeprecations:
         self._tmp_dir = TemporaryDirectory()
 
     def test_name_only_positional(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with self.warning_context:
             project = signac.init_project("name", root=self._tmp_dir.name)
 
@@ -1062,14 +1030,14 @@ class TestProjectNameDeprecations:
                 signac.init_project("new_name", root=self._tmp_dir.name)
 
     def test_name_with_other_args_positional(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with pytest.raises(
             TypeError, match="takes 0 positional arguments but 2 were given"
         ):
             signac.init_project("project", self._tmp_dir.name)
 
     def test_name_only_keyword(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         os.chdir(self._tmp_dir.name)
         with self.warning_context:
             project = signac.init_project(name="name")
@@ -1084,7 +1052,7 @@ class TestProjectNameDeprecations:
                 signac.init_project(name="new_name")
 
     def test_name_with_other_args_keyword(self):
-        assert _MAJOR_VERSION < _VERSION_3
+        assert _CURRENT_VERSION < _VERSION_3
         with pytest.raises(TypeError, match="got an unexpected keyword argument 'foo'"):
             signac.init_project(name="project", foo="bar")
 
@@ -2309,9 +2277,6 @@ class TestProjectInit:
         project = signac.Project.get_project(root=root)
         assert project.workspace == os.path.join(root, "workspace")
         assert project.root_directory() == root
-        # Deviating initialization parameters should result in errors.
-        with pytest.raises(RuntimeError):
-            signac.init_project(root=root, workspace="workspace2")
 
     def test_nested_project(self):
         def check_root(root=None):
@@ -2466,21 +2431,28 @@ class TestProjectSchema(TestProjectBase):
 
 class TestSchemaMigration:
     @pytest.mark.parametrize("implicit_version", [True, False])
-    def test_project_schema_version_migration(self, implicit_version):
+    @pytest.mark.parametrize("workspace_exists", [True, False])
+    def test_project_schema_version_migration(self, implicit_version, workspace_exists):
         from signac.contrib.migration import apply_migrations
 
         with TemporaryDirectory() as dirname:
             # Create v1 config file.
             cfg_fn = os.path.join(dirname, "signac.rc")
+            workspace_dir = "workspace_dir"
             with open(cfg_fn, "w") as f:
                 f.write(
                     textwrap.dedent(
-                        """\
+                        f"""\
                         project = project
-                        workspace_dir = workspace
+                        workspace_dir = {workspace_dir}
                         schema_version = 0"""
                     )
                 )
+
+            # Create a custom workspace
+            os.makedirs(os.path.join(dirname, workspace_dir))
+            if workspace_exists:
+                os.makedirs(os.path.join(dirname, "workspace"))
 
             # Create a shell history file.
             history_fn = os.path.join(dirname, ".signac_shell_history")
@@ -2504,6 +2476,12 @@ class TestSchemaMigration:
             else:
                 assert config["schema_version"] == "0"
             config.write()
+
+            # If the 'workspace' directory already exists the migration should fail.
+            if workspace_exists:
+                with pytest.raises(RuntimeError):
+                    apply_migrations(dirname)
+                return
 
             err = io.StringIO()
             with redirect_stderr(err):
@@ -2566,12 +2544,9 @@ class TestProjectStoreBase(test_h5store.TestH5StoreBase):
         self._tmp_dir = TemporaryDirectory(prefix="signac_")
         request.addfinalizer(self._tmp_dir.cleanup)
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
-        self._tmp_wd = os.path.join(self._tmp_dir.name, "wd")
         os.mkdir(self._tmp_pr)
         self.config = load_config()
-        self.project = self.project_class.init_project(
-            root=self._tmp_pr, workspace=self._tmp_wd
-        )
+        self.project = self.project_class.init_project(root=self._tmp_pr)
 
         self._fn_store = os.path.join(self._tmp_dir.name, "signac_data.h5")
         self._fn_store_other = os.path.join(self._tmp_dir.name, "other.h5")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -792,14 +792,9 @@ class TestBasicShell:
 
     def test_config_verify(self):
         # no config file
-        with pytest.raises(ExitCodeError):
-            self.call("python -m signac config --local verify".split(), error=True)
-        err = self.call(
-            "python -m signac config --local verify".split(),
-            error=True,
-            raise_error=False,
-        )
+        err = self.call("python -m signac config --local verify".split(), error=True)
         assert "Did not find a local configuration file" in err
+
         self.call("python -m signac init my_project".split())
         err = self.call("python -m signac config --local verify".split(), error=True)
         assert "Passed" in err

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -744,7 +744,7 @@ class TestBasicShell:
 
         self.call("python -m signac init".split())
         out = self.call("python -m signac config --local show".split()).strip()
-        cfg = config.read_config_file("signac.rc")
+        cfg = config.read_config_file(".signac/config")
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 
@@ -754,7 +754,7 @@ class TestBasicShell:
         assert out.split(os.linesep) == expected
 
         out = self.call("python -m signac config --global show".split()).strip()
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config.read_config_file(config.USER_CONFIG_FN)
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 
@@ -770,12 +770,12 @@ class TestBasicShell:
         assert "[x]" in cfg
         assert "y = z" in cfg
 
-        backup_config = os.path.exists(config.FN_CONFIG)
-        global_config_path_backup = config.FN_CONFIG + ".tmp"
+        backup_config = os.path.exists(config.USER_CONFIG_FN)
+        global_config_path_backup = config.USER_CONFIG_FN + ".tmp"
         try:
             # Make a backup of the global config if it exists
             if backup_config:
-                shutil.copy2(config.FN_CONFIG, global_config_path_backup)
+                shutil.copy2(config.USER_CONFIG_FN, global_config_path_backup)
 
             # Test the global config CLI
             self.call("python -m signac config --global set b c".split())
@@ -786,9 +786,9 @@ class TestBasicShell:
             # Revert the global config to its previous state (or remove it if
             # it did not exist)
             if backup_config:
-                shutil.move(global_config_path_backup, config.FN_CONFIG)
+                shutil.move(global_config_path_backup, config.USER_CONFIG_FN)
             else:
-                os.remove(config.FN_CONFIG)
+                os.remove(config.USER_CONFIG_FN)
 
     def test_config_verify(self):
         # no config file


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
**This PR should be merged using a merge commit, not squashed and rebased**
This pull request implements the migration from signac schema version 1 to schema version 2. The primary change is that all of signac's internal files are stored in a single common directory `.signac` in the project root instead of being stored directly in the project root. In particular, the signac config file `signac.rc` is now instead store in `.signac/config`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #197. See the constituent commits to see the other associated issues.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
