### PR TITLE
Catch warnings on creation of deprecated password cache.

### DIFF
--- a/signac/common/host.py
+++ b/signac/common/host.py
@@ -16,7 +16,10 @@ from .errors import AuthenticationError, ConfigError
 logger = logging.getLogger(__name__)
 
 
-SESSION_PASSWORD_HASH_CACHE = SimpleKeyring()
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    SESSION_PASSWORD_HASH_CACHE = SimpleKeyring()
+
 SESSION_USERNAME_CACHE = {}  # type: ignore
 
 """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
This PR prevents signac from emitting warnings when it creates a deprecated SimpleKeyring object on import because it is a module-level constant in the deprecated db module.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We shouldn't be surfacing warnings to the user that are expected consequences of normal signac usage. This issue will disappear when we actually remove the deprecated code in 2.0

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
