### PR TITLE
Always encode nested dicts.

### DIFF
--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -213,25 +213,6 @@ def _to_hashable(obj):
         return obj
 
 
-def _encode_tree(x):
-    """Encode if type of x is list.
-
-    Parameters
-    ----------
-    x :
-        type to encode.
-
-    Returns
-    -------
-    Hashable version of ``x``.
-
-    """
-    if type(x) is list:
-        return _to_hashable(x)
-    else:
-        return x
-
-
 def _nested_dicts_to_dotted_keys(d, key=None):
     """Generate tuples of key in dotted string format and value from nested dict.
 
@@ -250,7 +231,6 @@ def _nested_dicts_to_dotted_keys(d, key=None):
         Tuples of dotted key and values e.g. ('a.b', 'c')
 
     """
-    d = _encode_tree(d)
     if isinstance(d, Mapping):
         if d:
             for k in d:
@@ -259,4 +239,6 @@ def _nested_dicts_to_dotted_keys(d, key=None):
         elif key is not None:
             yield key, d
     else:
+        if type(d) is list:
+            d = _to_hashable(d)
         yield key, d

--- a/signac/contrib/utility.py
+++ b/signac/contrib/utility.py
@@ -232,15 +232,13 @@ def _encode_tree(x):
         return x
 
 
-def _nested_dicts_to_dotted_keys(t, encode=_encode_tree, key=None):
+def _nested_dicts_to_dotted_keys(d, key=None):
     """Generate tuples of key in dotted string format and value from nested dict.
 
     Parameters
     ----------
-    t : dict
+    d : dict
         A mapping instance with nested dicts, e.g. {'a': {'b': 'c'}}.
-    encode :
-        By default, values are encoded to be hashable. Use ``None`` to skip encoding.
     key : str
         Key of root at current point in the recursion, used to
         build up nested keys in the top-level dict through
@@ -252,14 +250,13 @@ def _nested_dicts_to_dotted_keys(t, encode=_encode_tree, key=None):
         Tuples of dotted key and values e.g. ('a.b', 'c')
 
     """
-    if encode is not None:
-        t = encode(t)
-    if isinstance(t, Mapping):
-        if t:
-            for k in t:
+    d = _encode_tree(d)
+    if isinstance(d, Mapping):
+        if d:
+            for k in d:
                 k_ = k if key is None else ".".join((key, k))
-                yield from _nested_dicts_to_dotted_keys(t[k], encode=encode, key=k_)
+                yield from _nested_dicts_to_dotted_keys(d[k], key=k_)
         elif key is not None:
-            yield key, t
+            yield key, d
     else:
-        yield key, t
+        yield key, d


### PR DESCRIPTION
## Description
This PR refactors a utility function `_nested_dicts_to_dotted_keys` to remove a default parameter that is never used by any callers. This simplifies the logic and removes unnecessary functionality. Because this is an internal change, no changelog entry is needed.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
