### PR TITLE
Fix copytree docs and unify default parameter logic.

### DIFF
--- a/signac/contrib/import_export.py
+++ b/signac/contrib/import_export.py
@@ -474,10 +474,10 @@ def export_jobs(jobs, target, path=None, copytree=None):
         A path to a directory or archive file to export to.
     path : str or callable
         The path (function) used to structure the exported data space. (Default value = None)
-    copytree : callable
-        The function used for copying of directory tree
-        structures. Defaults to :func:`shutil.copytree`.
-        Can only be used when the target is a directory.
+    copytree : callable, optional
+        The function used for copying directory tree structures. Uses
+        :func:`shutil.copytree` if ``None`` (Default value = None). The function
+        requires that the target is a directory.
 
     Yields
     ------
@@ -786,8 +786,7 @@ def _copy_to_job_workspace(src, job, copytree):
     job : :class:`~signac.contrib.job.Job`
         An instance of :class:`~signac.contrib.job.Job`.
     copytree : callable
-        Function to use for the copytree operation. Defaults to
-        :func:`shutil.copytree`.
+        The function used for copying directory tree structures.
 
     Returns
     -------
@@ -1250,8 +1249,10 @@ def import_into_project(origin, project, schema=None, copytree=None):
         An optional schema function, which is either a string or a function that accepts a
         path as its first and only argument and returns the corresponding state point as dict
         (Default value = None).
-    copytree : callable
-        Function to use for the copytree operation. Defaults to :func:`shutil.copytree`.
+    copytree : callable, optional
+        The function used for copying directory tree structures. Uses
+        :func:`shutil.copytree` if ``None`` (Default value = None). The function
+        requires that the target is a directory.
 
     Yields
     ------

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -893,7 +893,7 @@ class Project:
 
         return create_linked_view(self, prefix, job_ids, path)
 
-    def clone(self, job, copytree=shutil.copytree):
+    def clone(self, job, copytree=None):
         """Clone job into this project.
 
         Create an identical copy of job within this project.
@@ -904,8 +904,10 @@ class Project:
         ----------
         job : :class:`~signac.contrib.job.Job`
             The job to copy into this project.
-        copytree :
-             (Default value = :func:`shutil.copytree`)
+        copytree : callable, optional
+            The function used for copying directory tree structures. Uses
+            :func:`shutil.copytree` if ``None`` (Default value = None). The function
+            requires that the target is a directory.
 
         Returns
         -------
@@ -919,6 +921,8 @@ class Project:
             initialized within this project.
 
         """
+        if copytree is None:
+            copytree = shutil.copytree
         dst = self.open_job(job.statepoint())
         try:
             copytree(job.path, dst.path)
@@ -952,15 +956,18 @@ class Project:
         ----------
         other : :class:`~signac.Project`
             The other project to synchronize this project with.
-        strategy :
-            A file synchronization strategy (Default value = None).
-        exclude :
-            Files with names matching the given pattern will be excluded
-            from the synchronization (Default value = None).
-        doc_sync :
-            The function applied for synchronizing documents (Default value = None).
-        selection :
-            Only sync the given jobs (Default value = None).
+        strategy : callable, optional
+            A synchronization strategy for file conflicts. If no strategy is provided, a
+            :class:`~signac.errors.SyncConflict` exception will be raised upon conflict
+            (Default value = None).
+        exclude : str, optional
+            A filename exclude pattern. All files matching this pattern will be
+            excluded from synchronization (Default value = None).
+        doc_sync : attribute or callable from :py:class:`~signac.sync.DocSync`, optional
+            A synchronization strategy for document keys. If this argument is None, by default
+            no keys will be synchronized upon conflict (Default value = None).
+        selection : sequence of :class:`~signac.contrib.job.Job` or job ids (str), optional
+            Only synchronize the given selection of jobs (Default value = None).
         \*\*kwargs :
             This method also accepts the same keyword arguments as the
             :meth:`~signac.sync.sync_projects` function.
@@ -1054,10 +1061,10 @@ class Project:
             of `job`, a string where fields are replaced using the job-state point dictionary,
             or `False`, which means that we just use the job-id as path.
             Defaults to the equivalent of ``{{auto}}``.
-        copytree :
-            The function used for the actual copying of directory tree
-            structures. Defaults to :func:`shutil.copytree`.
-            Can only be used when the target is a directory.
+        copytree : callable, optional
+            The function used for copying directory tree structures. Uses
+            :func:`shutil.copytree` if ``None`` (Default value = None). The function
+            requires that the target is a directory.
 
         Returns
         -------
@@ -1113,9 +1120,10 @@ class Project:
             If ``True``, the project will be synchronized with the imported data space. If a
             dict of keyword arguments is provided, the arguments will be used for
             :meth:`~signac.Project.sync` (Default value = None).
-        copytree :
-            Specify which exact function to use for the actual copytree operation.
-            Defaults to :func:`shutil.copytree`.
+        copytree : callable, optional
+            The function used for copying directory tree structures. Uses
+            :func:`shutil.copytree` if ``None`` (Default value = None). The function
+            requires that the target is a directory.
 
         Returns
         -------
@@ -1854,10 +1862,10 @@ class JobsCursor:
         path : str or callable
             The path (function) used to structure the exported data space
             (Default value = None).
-        copytree : callable
-            The function used for copying of directory tree structures.
-            Defaults to :func:`shutil.copytree`. Can only be used when the
-            target is a directory (Default value = None).
+        copytree : callable, optional
+            The function used for copying directory tree structures. Uses
+            :func:`shutil.copytree` if ``None`` (Default value = None). The function
+            requires that the target is a directory.
 
         Returns
         -------


### PR DESCRIPTION
## Description
While working on #763, I unified the `copytree` docs and default parameter behavior across the codebase. Now, the default parameter in public APIs should always be `None` and we should consistently document that `None` means that signac will use `shutil.copytree`.

I also updated a few docstrings related to synchronization.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
