### PR TITLE
Use GitHub Actions.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.0
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
## Description
This PR overhauls our CI configurations to build and test signac with GitHub Actions. We've been planning to move to GitHub Actions for a long time and the breakage of our Windows builds (limited monthly minutes) and limited parallel runners are finally motivating a change here.

Before merging:
- [ ] Ensure we have builds for all supported platforms (Linux, macOS, Windows) and configurations (Python versions, oldest/newest dependencies). I'd like to see the following:
  - [ ] Linux, Python 3.10
  - [ ] Linux, Python 3.10 "minimal" (no optional dependencies)
  - [ ] Linux, Python 3.9
  - [ ] Linux, Python 3.8
  - [ ] Linux, Python 3.8 "oldest" (minimum versions of supported dependencies)
  - [ ] macOS, some supported Python version
  - [ ] Windows, some supported Python version
- [ ] Make an attempt at the "deploy to PyPI" logic that should release a source distribution (tarball) and a wheel tagged `py3-none-any` uploaded from one of those test configurations mentioned above. See https://github.com/pypa/gh-action-pypi-publish

## Motivation and Context
I don't think an issue exists for this but we've been discussing moving to GitHub Actions for a while. cibuildwheel is a convenient and well-tested / easily configurable way to do so.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
