### PR TITLE
Changed CLI View Prefix

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -114,4 +114,8 @@ contributors:
   -
     family-names: Tork
     given-names: Parisa
+  -
+    family-names: Takada
+    given-names: Kody
+    affiliation: "University of Michigan"
 ...

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -1184,7 +1184,7 @@ def main():
         "$ signac view $PREFIX $VIEW_PATH -f $FILTERS -d $DOC_FILTERS.",
     )
     parser_view.add_argument(
-        "prefix",
+        "--prefix",
         type=str,
         nargs="?",
         default="view",

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -1184,7 +1184,6 @@ def main():
         "$ signac view $PREFIX $VIEW_PATH -f $FILTERS -d $DOC_FILTERS.",
     )
     parser_view.add_argument(
-        "-p",
         "--prefix",
         type=str,
         nargs="?",

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -1184,6 +1184,7 @@ def main():
         "$ signac view $PREFIX $VIEW_PATH -f $FILTERS -d $DOC_FILTERS.",
     )
     parser_view.add_argument(
+        "-p",
         "--prefix",
         type=str,
         nargs="?",

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -186,6 +186,19 @@ class TestBasicShell:
             ) == os.path.realpath(project.open_job(sp).path)
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
+    def test_view_prefix(self):
+        self.call("python -m signac init my_project".split())
+        project = signac.Project()
+        sps = [{"a": i for i in range(3)}]
+        for sp in sps:
+            project.open_job(sp).init()
+        os.mkdir("view")
+        self.call("signac view --prefix test")
+        # for sp in sps:
+        #    assert os.path.isdir("view/test".format(sp["a"]))
+        # assert os.path.isdir("view/a/{}/job".format(sp["a"]))
+
+    @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_incomplete_path_spec(self):
         self.call("python -m signac init".split())
         project = signac.Project()
@@ -202,20 +215,6 @@ class TestBasicShell:
             raise_error=False,
         )
         assert "duplicate paths" in err
-
-        err2 = self.call(
-            "python -m signac view non_unique -p".split(),
-            error=True,
-            raise_error=False,
-        )
-        assert "duplicate paths" in err2
-
-        err3 = self.call(
-            "python -m signac view non_unique --prefix".split(),
-            error=True,
-            raise_error=False,
-        )
-        assert "duplicate paths" in err3
 
     @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find(self):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -189,14 +189,17 @@ class TestBasicShell:
     def test_view_prefix(self):
         self.call("python -m signac init my_project".split())
         project = signac.Project()
-        sps = [{"a": i for i in range(3)}]
+        sps = [{"a": i} for i in range(3)]
         for sp in sps:
             project.open_job(sp).init()
         os.mkdir("view")
-        self.call("signac view --prefix test")
-        # for sp in sps:
-        #    assert os.path.isdir("view/test".format(sp["a"]))
-        # assert os.path.isdir("view/a/{}/job".format(sp["a"]))
+        self.call("python -m signac view --prefix view/test_dir".split())
+        for sp in sps:
+            assert os.path.isdir("view/test_dir/a/{}".format(sp["a"]))
+            assert os.path.isdir("view/test_dir/a/{}/job".format(sp["a"]))
+            assert os.path.realpath(
+                "view/test_dir/a/{}/job".format(sp["a"])
+            ) == os.path.realpath(project.open_job(sp).path)
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_incomplete_path_spec(self):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -197,7 +197,7 @@ class TestBasicShell:
         # An error should be raised if the user-provided path function
         # doesn't make a 1-1 mapping.
         err = self.call(
-            "python -m signac view view non_unique".split(),
+            "python -m signac view non_unique".split(),
             error=True,
             raise_error=False,
         )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -185,6 +185,19 @@ class TestBasicShell:
                 "view/a/{}/job".format(sp["a"])
             ) == os.path.realpath(project.open_job(sp).path)
 
+    """@pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
+    def test_view_prefix(self):
+        self.call("python -m signac init my_project".split())
+        project = signac.Project()
+        sps = [{"a": i} for i in range(3)]
+        for sp in sps:
+            project.open_job(sp).init()
+        os.mkdir("view")
+        out = self.call("python -m signac view -p path".split())
+        assert os.path.isdir(out)
+        # Probably dictate a path and then see if view finds it?
+        # Figure out what view outputs and syntax for view"""
+
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_incomplete_path_spec(self):
         self.call("python -m signac init".split())

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -185,19 +185,6 @@ class TestBasicShell:
                 "view/a/{}/job".format(sp["a"])
             ) == os.path.realpath(project.open_job(sp).path)
 
-    """@pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
-    def test_view_prefix(self):
-        self.call("python -m signac init my_project".split())
-        project = signac.Project()
-        sps = [{"a": i} for i in range(3)]
-        for sp in sps:
-            project.open_job(sp).init()
-        os.mkdir("view")
-        out = self.call("python -m signac view -p path".split())
-        assert os.path.isdir(out)
-        # Probably dictate a path and then see if view finds it?
-        # Figure out what view outputs and syntax for view"""
-
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_incomplete_path_spec(self):
         self.call("python -m signac init".split())
@@ -215,6 +202,20 @@ class TestBasicShell:
             raise_error=False,
         )
         assert "duplicate paths" in err
+
+        err2 = self.call(
+            "python -m signac view non_unique -p".split(),
+            error=True,
+            raise_error=False,
+        )
+        assert "duplicate paths" in err2
+
+        err3 = self.call(
+            "python -m signac view non_unique --prefix".split(),
+            error=True,
+            raise_error=False,
+        )
+        assert "duplicate paths" in err3
 
     @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find(self):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -187,7 +187,7 @@ class TestBasicShell:
 
     @pytest.mark.skipif(WINDOWS, reason="Symbolic links are unsupported on Windows.")
     def test_view_prefix(self):
-        self.call("python -m signac init my_project".split())
+        self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
         for sp in sps:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
I changed the CLI `view` argument to establish a path to be a flag rather than a positional argument. Added a test to check this change and altered another test that had `signac view view path` and changed it to just `signac view path`.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes issue #653.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [X] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [X] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
