### PR TITLE
Improve H5Store docs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,10 @@ Version 2
 [2.0.0] -- 2021-xx-xx
 ---------------------
 
+Added
++++++
+ - ``H5Store`` related errors are now included in the public API (#775).
+
 Changed
 +++++++
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -109,7 +109,7 @@ The Job class
 The JSONDict
 ============
 
-This class implements the interface for the job's :attr:`~signac.contrib.job.Job.statepoint` and :attr:`~signac.contrib.job.Job.document` attributes, but can also be used stand-alone:
+This class implements the interface for the job's :attr:`~signac.contrib.job.Job.statepoint` and :attr:`~signac.contrib.job.Job.document` attributes, but can also be used on its own.
 
 .. autoclass:: JSONDict
     :members:
@@ -119,7 +119,7 @@ This class implements the interface for the job's :attr:`~signac.contrib.job.Job
 The H5Store
 ===========
 
-This class implements the interface to the job's :attr:`~signac.contrib.job.Job.data` attribute, but can also be used stand-alone:
+This class implements the interface to the job's :attr:`~signac.contrib.job.Job.data` attribute, but can also be used on its own.
 
 .. autoclass:: H5Store
     :members:
@@ -129,7 +129,7 @@ This class implements the interface to the job's :attr:`~signac.contrib.job.Job.
 The H5StoreManager
 ==================
 
-This class implements the interface to the job's :attr:`~signac.contrib.job.Job.stores` attribute, but can also be used stand-alone:
+This class implements the interface to the job's :attr:`~signac.contrib.job.Job.stores` attribute, but can also be used on its own.
 
 .. autoclass:: H5StoreManager
     :members:

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -354,10 +354,10 @@ class Project:
 
     @property
     def stores(self):
-        """Get HDF5-stores associated with this project.
+        """Get HDF5 stores associated with this project.
 
         Use this property to access an HDF5 file within the project
-        directory using the H5Store dict-like interface.
+        directory using the :py:class:`~.H5Store` dict-like interface.
 
         This is an example for accessing an HDF5 file called ``'my_data.h5'``
         within the project directory:
@@ -382,7 +382,7 @@ class Project:
         Returns
         -------
         :class:`~signac.H5StoreManager`
-            The HDF5-Store manager for this project.
+            The HDF5 store manager for this project.
 
         """
         with self._lock:

--- a/signac/core/errors.py
+++ b/signac/core/errors.py
@@ -11,7 +11,7 @@ class Error(Exception):
 
 
 class H5StoreClosedError(Error, RuntimeError):
-    """Raised when trying to access a closed store."""
+    """Raised when trying to access a closed HDF5 file."""
 
 
 class H5StoreAlreadyOpenError(Error, OSError):

--- a/signac/core/errors.py
+++ b/signac/core/errors.py
@@ -8,3 +8,11 @@ class Error(Exception):
     """Base class used for signac Errors."""
 
     pass
+
+
+class H5StoreClosedError(Error, RuntimeError):
+    """Raised when trying to access a closed store."""
+
+
+class H5StoreAlreadyOpenError(Error, OSError):
+    """Indicates that the underlying HDF5 file is already open."""

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Mapping, MutableMapping
 from threading import RLock
 
-from ..errors import InvalidKeyError
+from ..errors import H5StoreAlreadyOpenError, H5StoreClosedError, InvalidKeyError
 from .dict_manager import DictManager
 
 __all__ = [
@@ -61,14 +61,6 @@ def _requires_tables():
 
 
 logger = logging.getLogger(__name__)
-
-
-class H5StoreClosedError(RuntimeError):
-    """Raised when trying to access a closed store."""
-
-
-class H5StoreAlreadyOpenError(OSError):
-    """Indicates that the underlying HDF5 file is already open."""
 
 
 def _h5set(store, grp, key, value, path=None):

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -421,7 +421,7 @@ class H5Store(MutableMapping):
 
         Raises
         ------
-        :py:class:`~.H5StoreClosedError`
+        H5StoreClosedError
             If the store is closed.
         """
         if self._file is None:

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -406,7 +406,7 @@ class H5Store(MutableMapping):
     def file(self):
         """Access the underlying instance of :py:class:`h5py.File`.
 
-        This property exposes the underlying :py:class:`h5py.File` object enabling
+        This property exposes the underlying :py:class:`h5py.File` object, enabling
         use of functions such as :py:meth:`h5py.Group.create_dataset` or
         :py:meth:`h5py.Group.require_dataset`.
 

--- a/signac/core/h5store.py
+++ b/signac/core/h5store.py
@@ -68,7 +68,7 @@ class H5StoreClosedError(RuntimeError):
 
 
 class H5StoreAlreadyOpenError(OSError):
-    """Indicates that the underlying HDF5 file is already openend."""
+    """Indicates that the underlying HDF5 file is already open."""
 
 
 def _h5set(store, grp, key, value, path=None):
@@ -296,28 +296,25 @@ class H5Store(MutableMapping):
     ...     assert 'foo' in h5s
     ...     assert h5s.foo == 'bar'
     ...     assert h5s['foo'] == 'bar'
-    >>>
 
     The H5Store can be used as a context manager to ensure that the underlying
     file is opened, however most built-in types (excluding arrays) can be read
-    and stored without the need to _explicitly_ open the file. **To
+    and stored without the need to *explicitly* open the file. **To
     access arrays (reading or writing), the file must always be opened!**
 
     To open a file in read-only mode, use the :py:meth:`.open` method with ``mode='r'``:
 
     >>> with H5Store('file.h5').open(mode='r') as h5s:
     ...     pass
-    >>>
 
     Parameters
     ----------
     filename : str
         The filename of the underlying HDF5 file.
     \*\*kwargs
-        Additional keyword arguments to be forwarded to the ``h5py.File``
-        constructor. See the documentation for the `h5py.File constructor
-        <https://docs.h5py.org/en/latest/high/file.html#File>`_ for more
-        information.
+        Additional keyword arguments to be forwarded to the
+        :py:class:`h5py.File` constructor. See the :py:class:`h5py.File`
+        documentation for more information.
 
     """
     __slots__ = ["_filename", "_file", "_kwargs"]
@@ -383,9 +380,14 @@ class H5Store(MutableMapping):
     def open(self, mode=None):
         """Open the underlying HDF5 file.
 
-        :param mode:
+        Parameters
+        ----------
+        mode : str
             The file open mode to use. Defaults to 'a' (append).
-        :returns:
+
+        Returns
+        -------
+        H5Store
             This H5Store instance.
         """
         if mode is None:
@@ -410,21 +412,25 @@ class H5Store(MutableMapping):
 
     @property
     def file(self):
-        """Access the underlying instance of h5py.File.
+        """Access the underlying instance of :py:class:`h5py.File`.
 
-        This property exposes the underlying ``h5py.File`` object enabling
-        use of functions such as ``create_dataset()`` or ``requires_dataset()``.
+        This property exposes the underlying :py:class:`h5py.File` object enabling
+        use of functions such as :py:meth:`h5py.Group.create_dataset` or
+        :py:meth:`h5py.Group.require_dataset`.
 
         .. note::
 
             The store must be open to access this property!
 
-        :returns:
-            The ``h5py`` file-object that this store is operating on.
-        :rtype:
-            ``h5py.File``
-        :raises H5StoreClosedError:
-            When the store is closed at the time of accessing this property.
+        Returns
+        -------
+        h5py.File
+            The :py:class:`h5py.File` object that this store is operating on.
+
+        Raises
+        ------
+        :py:class:`~.H5StoreClosedError`
+            If the store is closed.
         """
         if self._file is None:
             raise H5StoreClosedError(self._filename)

--- a/signac/errors.py
+++ b/signac/errors.py
@@ -15,7 +15,7 @@ from .contrib.errors import (
     StatepointParsingError,
     WorkspaceError,
 )
-from .core.errors import Error
+from .core.errors import Error, H5StoreAlreadyOpenError, H5StoreClosedError
 from .synced_collections.errors import InvalidKeyError, KeyTypeError
 
 
@@ -64,6 +64,8 @@ __all__ = [
     "DocumentSyncConflict",
     "Error",
     "FileSyncConflict",
+    "H5StoreAlreadyOpenError",
+    "H5StoreClosedError",
     "IncompatibleSchemaVersion",
     "InvalidKeyError",
     "JobsCorruptedError",


### PR DESCRIPTION
## Description
This PR revises the documentation for the `H5Store` class. A few pieces of its docs were missed in the conversion to NumPy documentation style and/or were missing from the API docs.

## Motivation and Context
Clean up for signac 2.0.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
