### PR TITLE
Improve Windows compatibility (safe relative paths, no float128).

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Fixed
  - ``H5Store.mode`` returns the file mode (#607).
  - User-provided path functions now raise an error if not unique (#666).
  - ``Collection`` class no longer raises an error when searching by a primary key that does not exist (#676).
+ - Relative paths on Windows are not used if the current directory has no common prefix (#777).
 
 Removed
 +++++++

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -37,6 +37,7 @@ from .common.crypt import get_crypt_context, get_keyring, parse_pwhash
 from .contrib.filterparse import parse_filter_arg
 from .contrib.import_export import _SchemaPathEvaluationError, export_jobs
 from .contrib.utility import add_verbosity_argument, prompt_password, query_yes_no
+from .core.utility import _safe_relpath
 from .diff import diff_jobs
 from .errors import (
     DestinationExistsError,
@@ -530,7 +531,7 @@ def main_sync(args):
         if args.allow_workspace:
             destination = Project(
                 config={
-                    "project": os.path.relpath(args.destination),
+                    "project": _safe_relpath(args.destination),
                     "project_dir": args.destination,
                     "workspace_dir": ".",
                 }
@@ -1158,7 +1159,7 @@ def main_shell(args):
                     except PermissionError:
                         print(
                             "Warning: Shell history could not be read from "
-                            "{}.".format(os.path.relpath(fn_hist))
+                            "{}.".format(_safe_relpath(fn_hist))
                         )
 
                     def write_history_file():
@@ -1167,7 +1168,7 @@ def main_shell(args):
                         except PermissionError:
                             print(
                                 "Warning: Shell history could not be written to "
-                                "{}.".format(os.path.relpath(fn_hist))
+                                "{}.".format(_safe_relpath(fn_hist))
                             )
 
                     atexit.register(write_history_file)

--- a/signac/core/dict_manager.py
+++ b/signac/core/dict_manager.py
@@ -8,6 +8,8 @@ import os
 import re
 import uuid
 
+from .utility import _safe_relpath
+
 
 class DictManager:
     """Helper class to manage multiple instances of dict-like classes.
@@ -43,9 +45,7 @@ class DictManager:
         )
 
     def __repr__(self):
-        return "{}(prefix={})".format(
-            type(self).__name__, repr(os.path.relpath(self.prefix))
-        )
+        return f"{type(self).__name__}(prefix={repr(_safe_relpath(self.prefix))})"
 
     __str__ = __repr__
 

--- a/signac/core/utility.py
+++ b/signac/core/utility.py
@@ -1,17 +1,28 @@
 # Copyright (c) 2017 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""Utility classes for signac version."""
+"""Utility functions."""
 
+import os.path
 import re
 import subprocess
 
 from ..common.deprecation import deprecated
 from ..version import __version__
 
-"""
-THIS MODULE IS DEPRECATED!
-"""
+
+def _safe_relpath(path):
+    """Attempt to make a relative path, or return the original path.
+
+    This is useful for logging and representing objects, where an absolute path
+    may be very long.
+    """
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        # Windows cannot find relative paths across drives, so show the
+        # original path instead.
+        return path
 
 
 @deprecated(

--- a/signac/syncutil.py
+++ b/signac/syncutil.py
@@ -246,7 +246,7 @@ class _FileModifyProxy:
             if not self.dry_run:
                 os.symlink(link_target, dst)
         else:
-            msg = "Copy file{{}} '{}' -> '{}'.".format(
+            msg = "Copy file '{}' -> '{}'.".format(
                 _safe_relpath(src), _safe_relpath(dst)
             )
             if self.permissions and self.times:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2321,12 +2321,16 @@ class TestProjectInit:
         assert project == project.get_project(root=root, search=False)
         assert project == signac.get_project(root=root, search=False)
         try:
-            assert project == project.get_project(root=os.path.relpath(root), search=False)
+            assert project == project.get_project(
+                root=os.path.relpath(root), search=False
+            )
         except ValueError:
             # A relative path may not exist on Windows if it crosses drives.
             pass
         try:
-            assert project == signac.get_project(root=os.path.relpath(root), search=False)
+            assert project == signac.get_project(
+                root=os.path.relpath(root), search=False
+            )
         except ValueError:
             # A relative path may not exist on Windows if it crosses drives.
             pass

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2320,8 +2320,16 @@ class TestProjectInit:
         assert project == signac.get_project(root=root)
         assert project == project.get_project(root=root, search=False)
         assert project == signac.get_project(root=root, search=False)
-        assert project == project.get_project(root=os.path.relpath(root), search=False)
-        assert project == signac.get_project(root=os.path.relpath(root), search=False)
+        try:
+            assert project == project.get_project(root=os.path.relpath(root), search=False)
+        except ValueError:
+            # A relative path may not exist on Windows if it crosses drives.
+            pass
+        try:
+            assert project == signac.get_project(root=os.path.relpath(root), search=False)
+        except ValueError:
+            # A relative path may not exist on Windows if it crosses drives.
+            pass
         with pytest.raises(LookupError):
             assert project == project.get_project(root=subdir, search=False)
         with pytest.raises(LookupError):

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+import sys
 import platform
 from collections.abc import MutableMapping, MutableSequence
 from copy import deepcopy
@@ -13,7 +14,7 @@ from signac.synced_collections import SyncedCollection
 from signac.synced_collections.numpy_utils import NumpyConversionWarning
 
 PYPY = "PyPy" in platform.python_implementation()
-WINDOWS = "win" in platform.python_implementation()
+WINDOWS = sys.platform == "win32"
 
 
 try:
@@ -773,6 +774,13 @@ class SyncedListTest(SyncedCollectionTest):
         assert isinstance(child2, SyncedCollection)
         assert isinstance(child1, SyncedCollection)
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded(self, synced_collection):
         """Test multithreaded runs of synced lists."""
         if not type(synced_collection)._supports_threading:

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-import sys
 import platform
+import sys
 from collections.abc import MutableMapping, MutableSequence
 from copy import deepcopy
 from typing import Any, Tuple, Type

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 import platform
-import sys
 from collections.abc import MutableMapping, MutableSequence
 from copy import deepcopy
 from typing import Any, Tuple, Type
@@ -14,7 +13,6 @@ from signac.synced_collections import SyncedCollection
 from signac.synced_collections.numpy_utils import NumpyConversionWarning
 
 PYPY = "PyPy" in platform.python_implementation()
-WINDOWS = sys.platform == "win32"
 
 
 try:
@@ -455,11 +453,11 @@ class SyncedDictTest(SyncedCollectionTest):
             with pytest.raises(TypeError):
                 synced_collection[key] = testdata
 
-    @pytest.mark.skipif(
-        WINDOWS,
+    @pytest.mark.skip(
         reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
+            "This test sometimes fails. This may indicate a race condition. "
+            "The test fails more consistently on Windows but also appears on "
+            "Linux in CI."
         ),
     )
     def test_multithreaded(self, synced_collection):
@@ -774,11 +772,11 @@ class SyncedListTest(SyncedCollectionTest):
         assert isinstance(child2, SyncedCollection)
         assert isinstance(child1, SyncedCollection)
 
-    @pytest.mark.skipif(
-        WINDOWS,
+    @pytest.mark.skip(
         reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
+            "This test sometimes fails. This may indicate a race condition. "
+            "The test fails more consistently on Windows but also appears on "
+            "Linux in CI."
         ),
     )
     def test_multithreaded(self, synced_collection):

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -52,7 +52,6 @@ try:
         numpy.longdouble,
         numpy.float32,
         numpy.float64,
-        numpy.float128,
         numpy.float_,
     )
 

--- a/tests/test_synced_collections/synced_collection_test.py
+++ b/tests/test_synced_collections/synced_collection_test.py
@@ -453,7 +453,7 @@ class SyncedDictTest(SyncedCollectionTest):
             with pytest.raises(TypeError):
                 synced_collection[key] = testdata
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason=(
             "This test sometimes fails. This may indicate a race condition. "
             "The test fails more consistently on Windows but also appears on "
@@ -772,7 +772,7 @@ class SyncedListTest(SyncedCollectionTest):
         assert isinstance(child2, SyncedCollection)
         assert isinstance(child1, SyncedCollection)
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason=(
             "This test sometimes fails. This may indicate a race condition. "
             "The test fails more consistently on Windows but also appears on "

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -26,6 +26,7 @@ from signac.synced_collections.errors import BufferedError, MetadataError
 
 WINDOWS = sys.platform == "win32"
 
+
 class BufferedJSONCollectionTest(JSONCollectionTest):
     def load(self, collection):
         """Load the data corresponding to a SyncedCollection from disk."""

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -4,7 +4,6 @@
 import itertools
 import json
 import os
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -23,8 +22,6 @@ from signac.synced_collections.backends.collection_json import (
     MemoryBufferedJSONList,
 )
 from signac.synced_collections.errors import BufferedError, MetadataError
-
-WINDOWS = sys.platform == "win32"
 
 
 class BufferedJSONCollectionTest(JSONCollectionTest):
@@ -379,13 +376,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             # truly flushed correctly.
             assert self._collection_type.get_current_buffer_size() == 0
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
-        ),
-    )
     def test_multithreaded_buffering_setitem(self, tmpdir):
         """Test setitem in a multithreaded buffering context."""
 
@@ -395,13 +385,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(setitem_dict, tmpdir)
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
-        ),
-    )
     def test_multithreaded_buffering_update(self, tmpdir):
         """Test update in a multithreaded buffering context."""
 
@@ -410,13 +393,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(update_dict, tmpdir)
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
-        ),
-    )
     def test_multithreaded_buffering_reset(self, tmpdir):
         """Test reset in a multithreaded buffering context."""
 
@@ -425,13 +401,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(reset_dict, tmpdir)
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
-        ),
-    )
     def test_multithreaded_buffering_clear(self, tmpdir):
         """Test clear in a multithreaded buffering context.
 
@@ -477,13 +446,6 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             # truly flushed correctly.
             assert self._collection_type.get_current_buffer_size() == 0
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason=(
-            "This test sometimes fails on Windows. This may indicate a race condition, but "
-            "attempts to reproduce on other platforms have failed thus far."
-        ),
-    )
     def test_multithreaded_buffering_load(self, tmpdir):
         """Test loading data in a multithreaded buffering context.
 

--- a/tests/test_synced_collections/test_json_buffered_collection.py
+++ b/tests/test_synced_collections/test_json_buffered_collection.py
@@ -4,6 +4,7 @@
 import itertools
 import json
 import os
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -23,6 +24,7 @@ from signac.synced_collections.backends.collection_json import (
 )
 from signac.synced_collections.errors import BufferedError, MetadataError
 
+WINDOWS = sys.platform == "win32"
 
 class BufferedJSONCollectionTest(JSONCollectionTest):
     def load(self, collection):
@@ -376,6 +378,13 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             # truly flushed correctly.
             assert self._collection_type.get_current_buffer_size() == 0
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded_buffering_setitem(self, tmpdir):
         """Test setitem in a multithreaded buffering context."""
 
@@ -385,6 +394,13 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(setitem_dict, tmpdir)
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded_buffering_update(self, tmpdir):
         """Test update in a multithreaded buffering context."""
 
@@ -393,6 +409,13 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(update_dict, tmpdir)
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded_buffering_reset(self, tmpdir):
         """Test reset in a multithreaded buffering context."""
 
@@ -401,6 +424,13 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
 
         self.multithreaded_buffering_test(reset_dict, tmpdir)
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded_buffering_clear(self, tmpdir):
         """Test clear in a multithreaded buffering context.
 
@@ -446,6 +476,13 @@ class TestBufferedJSONDict(BufferedJSONCollectionTest, TestJSONDict):
             # truly flushed correctly.
             assert self._collection_type.get_current_buffer_size() == 0
 
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason=(
+            "This test sometimes fails on Windows. This may indicate a race condition, but "
+            "attempts to reproduce on other platforms have failed thus far."
+        ),
+    )
     def test_multithreaded_buffering_load(self, tmpdir):
         """Test loading data in a multithreaded buffering context.
 


### PR DESCRIPTION
## Description
Fixes a bug where relative paths crossing drives cause failures on Windows. Example:

```python
>>> # Starting from a current working directory in C:\Users\bdice
>>> import signac
>>> h = signac.H5Store(r"C:\data.h5")
>>> repr(h)
"H5Store(filename='..\\\\..\\\\data.h5')"
>>> h = signac.H5Store(r"D:\data.h5")
>>> repr(h)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\users\bdice\code\signac\signac\core\h5store.py", line 341, in __repr__
    type(self).__name__, repr(os.path.relpath(self._filename))
  File "C:\Users\bdice\mambaforge\lib\ntpath.py", line 703, in relpath
    raise ValueError("path is on mount %r, start on mount %r" % (
ValueError: path is on mount 'D:', start on mount 'C:'
```

signac uses relative paths in several places for user-readable data like log files and reprs. If `os.path.relpath` fails, we should just show the absolute path that is held internally. That's what I implemented in `_safe_relpath`.

Additionally, this removes explicit testing of `numpy.float128` from synced collections because it's not available on Windows builds of NumPy. The underlying `float128` type is already tested on Linux/macOS through other tests that use `numpy.longdouble`. That value is defined differently on UNIX-like platforms (float128) than on Windows (float64). cc: @vyasr

## Motivation and Context
I found this bug while working on #776.

It's not very straightforward to add comprehensive tests for this kind of bug. I was able to test it locally by running the tests from a `D:\` drive while the temp folders used for testing were on `C:\`.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
