### PR TITLE
[MNT] Remove upper bound on python_requires

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Fixed
 Removed
 +++++++
 
+ - Removed upper bound of Python 4 on ``python_requires`` (#781).
  - Dropped support for Python 3.6 and Python 3.7 (#715) following the recommended support schedules of `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
  - Dropped dependency on ``deprecation`` package (#687, #718).
 

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -114,4 +114,9 @@ contributors:
   -
     family-names: Tork
     given-names: Parisa
+  -
+    family-names: "Feickert"
+    given-names: "Matthew"
+    affiliation: "University of Wisconsin-Madison"
+    orcid: "https://orcid.org/0000-0003-4124-7862"
 ...

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=requirements,
     # Supported versions are determined according to NEP 29.
     # https://numpy.org/neps/nep-0029-deprecation_policy.html
-    python_requires=">=3.8, <4",
+    python_requires=">=3.8",
     extras_require={"db": ["pymongo>=3.0"], "mpi": ["mpi4py"], "h5": ["h5py"]},
     entry_points={"console_scripts": ["signac = signac.__main__:main"]},
 )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description

* Remove upper bound of Python 4 on `python_requires` as advocated for in Henry Schreiner's blog post "[Should You Use Upper Bound Version Constraints?](https://iscinumpy.dev/post/bound-version-constraints/)". 

<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

## Motivation and Context
This change follows best practices for libraries and frameworks as generally recommended by the PyPA.

Resolves #780
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
