### PR TITLE
Remove --doc-filter option from CLI.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -53,6 +53,7 @@ Removed
  - The ``--workspace`` option for the command line ``job`` subcommand (#752).
  - The ability to call ``Project.workspace``, it is strictly a property now (#752).
  - ``ProjectSchema.__call__``, ``ProjectSchema.detect`` (#752).
+ - The ``--doc-filter`` option for several command line subcommands (#613, #795).
 
 Version 1
 =========

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -32,7 +32,7 @@ else:
 from . import get_project, init_project
 from .common import config
 from .common.configobj import Section, flatten_errors
-from .contrib.filterparse import _add_prefix, parse_filter_arg
+from .contrib.filterparse import parse_filter_arg
 from .contrib.import_export import _SchemaPathEvaluationError, export_jobs
 from .contrib.utility import _add_verbosity_argument, _print_err, _query_yes_no
 from .core.utility import _safe_relpath
@@ -135,7 +135,7 @@ def _open_job_by_id(project, job_id):
 
 def find_with_filter_or_none(args):
     """Return a filtered subset of jobs or None."""
-    if args.job_id or args.filter or args.doc_filter:
+    if args.job_id or args.filter:
         return find_with_filter(args)
     else:
         return None
@@ -144,15 +144,13 @@ def find_with_filter_or_none(args):
 def find_with_filter(args):
     """Return a filtered subset of jobs."""
     if getattr(args, "job_id", None):
-        if args.filter or args.doc_filter:
+        if args.filter:
             raise ValueError("Can't provide both 'job-id' and filter arguments!")
         else:
             return args.job_id
 
     project = get_project()
     filter_ = parse_filter_arg(args.filter) or {}
-    if args.doc_filter:
-        filter_.update(_add_prefix("doc.", parse_filter_arg(args.doc_filter)))
     if not filter_:
         filter_ = None
     return project._find_job_ids(filter=filter_)
@@ -993,14 +991,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Limit the diff to jobs matching this state point filter.",
-    )
-    parser_diff.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Show documents of jobs matching this document filter.",
+        help="Limit the diff to jobs matching the filter.",
     )
     parser_diff.set_defaults(func=main_diff)
 
@@ -1043,14 +1034,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Show documents of jobs matching this state point filter.",
-    )
-    parser_document.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Show documents of job matching this document filter.",
+        help="Show documents of jobs matching the filter.",
     )
     parser_document.set_defaults(func=main_document)
 
@@ -1121,10 +1105,7 @@ def main():
         "filter",
         type=str,
         nargs="*",
-        help="A JSON encoded state point filter (key-value pairs).",
-    )
-    parser_find.add_argument(
-        "-d", "--doc-filter", type=str, nargs="+", help="A document filter."
+        help="A JSON encoded filter (key-value pairs).",
     )
     parser_find.add_argument(
         "-s",
@@ -1207,14 +1188,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Limit the view to jobs matching this state point filter.",
-    )
-    selection_group.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Limit the view to jobs matching this document filter.",
+        help="Limit the view to jobs matching the filter.",
     )
     selection_group.add_argument(
         "-j",
@@ -1260,14 +1234,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Detect schema only for jobs that match the state point filter.",
-    )
-    selection_group.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Detect schema only for jobs that match the document filter.",
+        help="Detect schema only for jobs matching the filter.",
     )
     selection_group.add_argument(
         "-j",
@@ -1297,21 +1264,14 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Reduce selection to jobs that match the given filter.",
-    )
-    selection_group.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Reduce selection to jobs that match the given document filter.",
+        help="Reduce selection to jobs matching the filter.",
     )
     selection_group.add_argument(
         "-j",
         "--job-id",
         type=str,
         nargs="+",
-        help="Reduce selection to jobs that match the given job ids.",
+        help="Reduce selection to jobs matching the given job ids.",
     )
     parser_shell.set_defaults(func=main_shell)
 
@@ -1479,14 +1439,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Only synchronize jobs that match the state point filter.",
-    )
-    selection_group.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Only synchronize jobs that match the document filter.",
+        help="Only synchronize jobs matching the filter.",
     )
     selection_group.add_argument(
         "-j",
@@ -1562,14 +1515,7 @@ def main():
         "--filter",
         type=str,
         nargs="+",
-        help="Limit the jobs to export to those matching the state point filter.",
-    )
-    selection_group.add_argument(
-        "-d",
-        "--doc-filter",
-        type=str,
-        nargs="+",
-        help="Limit the jobs to export to those matching this document filter.",
+        help="Limit the jobs to export to those matching the filter.",
     )
     selection_group.add_argument(
         "-j",

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -166,7 +166,7 @@ def main_job(args):
     try:
         statepoint = json.loads(sp)
     except ValueError:
-        _print_err(f"Error while reading statepoint: '{sp}'")
+        _print_err(f"Error while reading state point: '{sp}'")
         raise
     job = project.open_job(statepoint)
     if args.create:
@@ -901,7 +901,7 @@ def main():
         nargs="?",
         default="-",
         type=str,
-        help="The job's statepoint in JSON format. Omit this argument to read from STDIN.",
+        help="The job's state point in JSON format. Omit this argument to read from STDIN.",
     )
     parser_job.add_argument(
         "-w",
@@ -925,7 +925,7 @@ def main():
 
     parser_statepoint = subparsers.add_parser(
         "statepoint",
-        description="Print the statepoint(s) corresponding to one or more job ids.",
+        description="Print the state point(s) corresponding to one or more job ids.",
     )
     parser_statepoint.add_argument(
         "job_id",
@@ -1105,7 +1105,7 @@ def main():
         "filter",
         type=str,
         nargs="*",
-        help="A JSON encoded filter (key-value pairs).",
+        help="Find jobs matching the filter.",
     )
     parser_find.add_argument(
         "-s",

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -219,7 +219,6 @@ class TestBasicShell:
         )
         assert "duplicate paths" in err
 
-    @pytest.mark.filterwarnings("ignore:The doc_filter argument is deprecated")
     def test_find(self):
         self.call("python -m signac init".split())
         project = signac.Project()
@@ -266,15 +265,6 @@ class TestBasicShell:
                 continue
             job.document["a"] = job.statepoint()["a"]
             job.document["b"] = job.statepoint()["a"] + 1
-
-        for i in range(3):
-            assert (
-                self.call(
-                    "python -m signac find --doc-filter".split()
-                    + ['{"a": ' + str(i) + "}"]
-                ).strip()
-                == next(iter(project.find_jobs({"a": i}))).id
-            )
 
         for i in range(3):
             assert (


### PR DESCRIPTION
## Description
This PR resolves #613 by removing the `--doc-filter` argument from the signac CLI. Users who wish to search by a document filter should replace syntax as shown below:

```bash
Before (simple syntax):
$ signac find --doc-filter a 0
After (simple syntax):
$ signac find doc.a 0

Before (JSON syntax):
$ signac find --doc-filter '{"a": 0}'
After (JSON syntax):
$ signac find '{"doc.a": 0}'
```

## Motivation and Context
The general feature of searching by document filters has been replaced by a generalized filter syntax that prefixes state point keys with `sp.` and document keys with `doc.`. This applies that change from #586 to the CLI.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
