### PR TITLE
Access project from job

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,8 +12,10 @@ Version 2
 
 Added
 +++++
+
  - ``H5Store`` related errors are now included in the public API (#775).
  - Users can now access the project which a job belongs to from the job object.
+
 Changed
 +++++++
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ Version 2
 Added
 +++++
  - ``H5Store`` related errors are now included in the public API (#775).
-
+ - Users can now access the project which a job belongs to from the job object.
 Changed
 +++++++
 

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -123,4 +123,8 @@ contributors:
     family-names: Takada
     given-names: Kody
     affiliation: "University of Michigan"
+  -
+    family-names: Kadar
+    given-names: Alain
+    affiliation: "University of Michigan"
 ...

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -90,6 +90,7 @@ The Job class
     Job.move
     Job.open
     Job.path
+    Job.project
     Job.remove
     Job.reset
     Job.sp

--- a/signac/contrib/job.py
+++ b/signac/contrib/job.py
@@ -605,6 +605,11 @@ class Job:
 
         """
         self.stores[self.KEY_DATA] = new_data
+    
+    @property
+    def project(self):
+        """Return the project that contains this job."""
+        return self._project
 
     def init(self, force=False):
         """Initialize the job's workspace directory.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -238,6 +238,11 @@ class TestJob(TestJobBase):
         copied_job.sp.a = 3
         assert copied_job in self.project
 
+    def test_project(self):
+        job = self.project.open_job({"a": 0})
+        assert isinstance(job.project, signac.Project)
+        assert job in job.project
+        assert job.project.path == self._tmp_pr
 
 class TestJobSpInterface(TestJobBase):
     def test_interface_read_only(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
Users can access the project which a job belongs to from the job object

## Motivation and Context
Resolves #423 

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
