### PR TITLE
Deprecate config module

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,7 +35,7 @@ Deprecated
  - ``JobSearchIndex`` class is deprecated (#600).
  - ``index`` argument is deprecated in ``Project`` methods (#602, #588).
  - ``signac.cite`` module is deprecated (#611, #592).
- - ``config.get_config`` method is deprecated (#675).
+ - The ``config`` module and all its methods are deprecated (#675, #753, #814).
  - Accessing ``Project.workspace`` as a method, it should be accessed as a property (#685).
  - ``Project.num_jobs`` (#685).
  - ``ProjectSchema.__call__``, ``ProjectSchema.detect`` (#685).

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -840,13 +840,13 @@ def main_config_show(args):
         for fn in config.CONFIG_FILENAMES:
             if os.path.isfile(fn):
                 if cfg is None:
-                    cfg = config.read_config_file(fn)
+                    cfg = config._read_config_file(fn)
                 else:
-                    cfg.merge(config.read_config_file(fn))
+                    cfg.merge(config._read_config_file(fn))
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config._read_config_file(config.FN_CONFIG)
     else:
-        cfg = config.load_config()
+        cfg = config._load_config()
     if cfg is None:
         if args.local and args.globalcfg:
             mode = " local or global "
@@ -879,13 +879,13 @@ def main_config_verify(args):
         for fn in config.CONFIG_FILENAMES:
             if os.path.isfile(fn):
                 if cfg is None:
-                    cfg = config.read_config_file(fn)
+                    cfg = config._read_config_file(fn)
                 else:
-                    cfg.merge(config.read_config_file(fn))
+                    cfg.merge(config._read_config_file(fn))
     elif args.globalcfg:
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config._read_config_file(config.FN_CONFIG)
     else:
-        cfg = config.load_config()
+        cfg = config._load_config()
     if cfg is None:
         if args.local and args.globalcfg:
             mode = " local or global "
@@ -920,7 +920,7 @@ def main_config_set(args):
             "to specify which configuration to modify."
         )
     try:
-        cfg = config.read_config_file(fn_config)
+        cfg = config._read_config_file(fn_config)
     except OSError:
         cfg = config._get_config(fn_config)
     keys = args.key.split(".")
@@ -971,7 +971,7 @@ def main_config_host(args):
             "to specify which configuration to modify."
         )
     try:
-        cfg = config.read_config_file(fn_config)
+        cfg = config._read_config_file(fn_config)
     except OSError:
         cfg = config._get_config(fn_config)
 

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -154,10 +154,12 @@ def _get_config(infile=None, configspec=None, *args, **kwargs):
     ),
 )
 def get_config(infile=None, configspec=None, *args, **kwargs):  # noqa: D103
+    """Get configuration from a file."""
     return _get_config(infile, configspec, *args, **kwargs)
 
 
 def _load_config(root=None, local=False):
+    """Load configuration, searching upward from a root path."""
     if root is None:
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))

--- a/signac/common/config.py
+++ b/signac/common/config.py
@@ -104,8 +104,7 @@ def check_and_fix_permissions(filename):
             logger.debug("Fixed permissions.")
 
 
-def read_config_file(filename):
-    """Read a configuration file."""
+def _read_config_file(filename):
     logger.debug(f"Reading config file '{filename}'.")
     try:
         config = Config(filename, configspec=cfg.split("\n"))
@@ -124,6 +123,20 @@ def read_config_file(filename):
     return config
 
 
+@deprecated(
+    deprecated_in="1.8",
+    removed_in="2.0",
+    current_version=__version__,
+    details=(
+        "The read_config_file method is deprecated. Configs should only be "
+        "accessed via a Project instance.",
+    ),
+)
+def read_config_file(filename):
+    """Read a configuration file."""
+    return _read_config_file(filename)
+
+
 def _get_config(infile=None, configspec=None, *args, **kwargs):
     """Get configuration from a file."""
     if configspec is None:
@@ -135,34 +148,50 @@ def _get_config(infile=None, configspec=None, *args, **kwargs):
     deprecated_in="1.8",
     removed_in="2.0",
     current_version=__version__,
-    details="The get_config method is deprecated. Use read_config_file instead.",
+    details=(
+        "The get_config method is deprecated. Configs should only be "
+        "accessed via a Project instance.",
+    ),
 )
 def get_config(infile=None, configspec=None, *args, **kwargs):  # noqa: D103
     return _get_config(infile, configspec, *args, **kwargs)
 
 
-def load_config(root=None, local=False):
-    """Load configuration, searching upward from a root path."""
+def _load_config(root=None, local=False):
     if root is None:
         root = os.getcwd()
     config = Config(configspec=cfg.split("\n"))
     if local:
         for fn in _search_local(root):
-            tmp = read_config_file(fn)
+            tmp = _read_config_file(fn)
             config.merge(tmp)
             if "project" in tmp:
                 config["project_dir"] = os.path.dirname(fn)
                 break
     else:
         for fn in _search_standard_dirs():
-            config.merge(read_config_file(fn))
+            config.merge(_read_config_file(fn))
         for fn in search_tree(root):
-            tmp = read_config_file(fn)
+            tmp = _read_config_file(fn)
             config.merge(tmp)
             if "project" in tmp:
                 config["project_dir"] = os.path.dirname(fn)
                 break
     return config
+
+
+@deprecated(
+    deprecated_in="1.8",
+    removed_in="2.0",
+    current_version=__version__,
+    details=(
+        "The load_config method is deprecated. Configs should only be "
+        "accessed via a Project instance.",
+    ),
+)
+def load_config(root=None, local=False):
+    """Load configuration, searching upward from a root path."""
+    return _load_config(root, local)
 
 
 class Config(ConfigObj):

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -24,7 +24,7 @@ from threading import RLock
 
 from packaging import version
 
-from ..common.config import Config, _get_config, load_config
+from ..common.config import Config, _get_config, _load_config
 from ..common.deprecation import deprecated
 from ..core.h5store import H5StoreManager
 from ..sync import sync_projects
@@ -269,7 +269,7 @@ class Project:
 
     def __init__(self, config=None):
         if config is None:
-            config = load_config()
+            config = _load_config()
         self._config = _ProjectConfig(
             config, _mutate_hook=partial(_invalidate_config_cache, self)
         )
@@ -2393,7 +2393,7 @@ class Project:
                 f"Unable to determine project id for nonexistent path '{os.path.abspath(root)}'."
             )
 
-        config = load_config(root=root, local=False)
+        config = _load_config(root=root, local=False)
         if "project" not in config or (
             not search
             and os.path.realpath(config["project_dir"]) != os.path.realpath(root)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -72,7 +72,7 @@ class TestJobBase:
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
         self._tmp_wd = os.path.join(self._tmp_dir.name, "wd")
         os.mkdir(self._tmp_pr)
-        self.config = signac.common.config.load_config()
+        self.config = signac.common.config._load_config()
         self.project = self.project_class.init_project(
             name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
         )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2604,7 +2604,7 @@ class TestProjectStoreBase(test_h5store.TestH5StoreBase):
         self._tmp_pr = os.path.join(self._tmp_dir.name, "pr")
         self._tmp_wd = os.path.join(self._tmp_dir.name, "wd")
         os.mkdir(self._tmp_pr)
-        self.config = signac.common.config.load_config()
+        self.config = signac.common.config._load_config()
         self.project = self.project_class.init_project(
             name="testing_test_project", root=self._tmp_pr, workspace=self._tmp_wd
         )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -790,17 +790,17 @@ class TestBasicShell:
 
         self.call("python -m signac init my_project".split())
         out = self.call("python -m signac config --local show".split()).strip()
-        cfg = config.read_config_file("signac.rc")
+        cfg = config._read_config_file("signac.rc")
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 
         out = self.call("python -m signac config show".split()).strip()
-        cfg = config.load_config()
+        cfg = config._load_config()
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 
         out = self.call("python -m signac config --global show".split()).strip()
-        cfg = config.read_config_file(config.FN_CONFIG)
+        cfg = config._read_config_file(config.FN_CONFIG)
         expected = config.Config(cfg).write()
         assert out.split(os.linesep) == expected
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
This PR deprecates the `read_config_file` and `load_config` APIs, the remaining public components of the config module. As of glotzerlab/signac-flow#649 we have confirmed that higher-level signac projects should be able to interface with configuration information solely via the `Project.config` attribute.

In the interest of simplicity I have not bothered to deprecate methods like `search_tree` and `check_and_fix_permissions` since we have no reason to expect external users to be touching them. I plan to remove them without deprecation in 2.0.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #753.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
