### PR TITLE
Warn users to migrate when old schema is detected and enable migration CLI

### DIFF
--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -634,6 +634,7 @@ def main_update_cache(args):
         _print_err(f"Updated cache (size={n}).")
 
 
+# TODO: This can be uncommented now!
 # UNCOMMENT THE FOLLOWING BLOCK WHEN THE FIRST MIGRATION IS INTRODUCED.
 # def main_migrate(args):
 #     "Migrate the project's schema to the current schema version."

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -634,36 +634,36 @@ def main_update_cache(args):
         _print_err(f"Updated cache (size={n}).")
 
 
-# TODO: This can be uncommented now!
-# UNCOMMENT THE FOLLOWING BLOCK WHEN THE FIRST MIGRATION IS INTRODUCED.
-# def main_migrate(args):
-#     "Migrate the project's schema to the current schema version."
-#     from .contrib.migration import apply_migrations, _get_config_schema_version
-#     from packaging import version
-#     from .version import SCHEMA_VERSION
-#     project = get_project(_ignore_schema_version=True)
-#
-#     root = args.root_directory if args.root_directory else os.getcwd()
-#
-#     schema_version = version.parse(SCHEMA_VERSION)
-#     config_schema_version = _get_config_schema_version(root, schema_version)
-#
-#     if config_schema_version > schema_version:
-#         _print_err(
-#             "The schema version of the project ({}) is newer than the schema "
-#             "version supported by signac version {}: {}. Try updating signac.".format(
-#                 config_schema_version, __version__, schema_version))
-#     elif config_schema_version == schema_version:
-#         _print_err(
-#             "The schema version of the project ({}) is up to date. "
-#             "Nothing to do.".format(config_schema_version))
-#     elif args.yes or _query_yes_no(
-#         "Do you want to migrate this project's schema version from '{}' to '{}'? "
-#         "WARNING: THIS PROCESS IS IRREVERSIBLE!".format(
-#             config_schema_version, schema_version), 'no'):
-#         apply_migrations(root)
-#
-#
+def main_migrate(args):
+    """Migrate the project's schema to the current schema version."""
+    from .contrib.migration import _get_config_schema_version, apply_migrations
+    from .version import SCHEMA_VERSION
+
+    root = args.root_directory if args.root_directory else os.getcwd()
+
+    schema_version = int(SCHEMA_VERSION)
+    config_schema_version = _get_config_schema_version(root, schema_version)
+
+    if config_schema_version > schema_version:
+        _print_err(
+            f"The schema version of the project ({config_schema_version}) is "
+            "newer than the schema version supported by signac version "
+            f"{__version__}: {schema_version}. Try updating signac."
+        )
+    elif config_schema_version == schema_version:
+        _print_err(
+            f"The schema version of the project ({config_schema_version}) is "
+            "up to date. Nothing to do."
+        )
+    elif args.yes or _query_yes_no(
+        "Do you want to migrate this project's schema version from "
+        f"'{config_schema_version}' to '{schema_version}'? WARNING: THIS "
+        "PROCESS IS IRREVERSIBLE!",
+        "no",
+    ):
+        apply_migrations(root)
+
+
 def verify_config(cfg, preserve_errors=True):
     """Verify provided configuration."""
     verification = cfg.verify(preserve_errors=preserve_errors)
@@ -1574,19 +1574,25 @@ def main():
     parser_verify = config_subparsers.add_parser("verify")
     parser_verify.set_defaults(func=main_config_verify)
 
-    # UNCOMMENT THE FOLLOWING BLOCK WHEN THE FIRST MIGRATION IS INTRODUCED.
-    # parser_migrate = subparsers.add_parser(
-    #     'migrate',
-    #     description="Irreversibly migrate this project's schema version to the "
-    #                 "supported version.")
-    # parser_migrate.add_argument(
-    #     "-r",
-    #     "--root-directory",
-    #     type=str,
-    #     default='',
-    #     help="The path to the project.",
-    # )
-    # parser_migrate.set_defaults(func=main_migrate)
+    parser_migrate = subparsers.add_parser(
+        "migrate",
+        description="Irreversibly migrate this project's schema version to the "
+        "supported version.",
+    )
+    parser_migrate.add_argument(
+        "-r",
+        "--root-directory",
+        type=str,
+        default="",
+        help="The path to the project.",
+    )
+    parser_migrate.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Do not ask for confirmation.",
+    )
+    parser_migrate.set_defaults(func=main_migrate)
 
     # This is a hack, as argparse itself does not
     # allow to parse only --version without any

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -647,8 +647,8 @@ def main_migrate(args):
     if config_schema_version > schema_version:
         _print_err(
             f"The schema version of the project ({config_schema_version}) is "
-            "newer than the schema version supported by signac version "
-            f"{__version__}: {schema_version}. Try updating signac."
+            "newer than the schema version {schema_version} supported by "
+            f"signac version {__version__}. Try updating signac."
         )
     elif config_schema_version == schema_version:
         _print_err(

--- a/signac/contrib/migration/v0_to_v1.py
+++ b/signac/contrib/migration/v0_to_v1.py
@@ -19,9 +19,12 @@ workspace_dir = string(default='workspace')
 
 
 def _load_config_v1(root_directory):
-    cfg = configobj.ConfigObj(
-        os.path.join(root_directory, "signac.rc"), configspec=_cfg.split("\n")
-    )
+    config_fn = os.path.join(root_directory, "signac.rc")
+    if not os.path.isfile(config_fn):
+        raise RuntimeError(
+            f"The directory {root_directory} does not contain a config file."
+        )
+    cfg = configobj.ConfigObj(config_fn, configspec=_cfg.split("\n"))
     validator = configobj.validate.Validator()
     if cfg.validate(validator) is not True:
         raise RuntimeError(

--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -29,9 +29,12 @@ schema_version = string(default='0')
 
 
 def _load_config_v2(root_directory):
-    cfg = configobj.ConfigObj(
-        os.path.join(root_directory, ".signac", "config"), configspec=_cfg.split("\n")
-    )
+    config_fn = os.path.join(root_directory, ".signac", "config")
+    if not os.path.isfile(config_fn):
+        raise RuntimeError(
+            f"The directory {root_directory} does not contain a config file."
+        )
+    cfg = configobj.ConfigObj(config_fn, configspec=_cfg.split("\n"))
     validator = configobj.validate.Validator()
     if cfg.validate(validator) is not True:
         raise RuntimeError(

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -25,6 +25,7 @@ from ..common.config import (
     _get_project_config_fn,
     _load_config,
     _locate_config_dir,
+    _raise_if_older_schema,
     _read_config_file,
 )
 from ..core.h5store import H5StoreManager
@@ -104,7 +105,7 @@ class Project:
         if path is None:
             path = os.getcwd()
         if not os.path.isfile(_get_project_config_fn(path)):
-            # TODO: Need to check whether we have an old config if not found.
+            _raise_if_older_schema(path)
             raise LookupError(
                 f"Unable to find project at path '{os.path.abspath(path)}'."
             )

--- a/signac/contrib/project.py
+++ b/signac/contrib/project.py
@@ -104,6 +104,7 @@ class Project:
         if path is None:
             path = os.getcwd()
         if not os.path.isfile(_get_project_config_fn(path)):
+            # TODO: Need to check whether we have an old config if not found.
             raise LookupError(
                 f"Unable to find project at path '{os.path.abspath(path)}'."
             )
@@ -1435,13 +1436,6 @@ class Project:
         -------
         :class:`~signac.Project`
             Initialized project, an instance of :class:`~signac.Project`.
-
-        Raises
-        ------
-        RuntimeError
-            If the project path already contains a conflicting project
-            configuration.
-
         """
         if path is None:
             path = os.getcwd()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2326,49 +2326,49 @@ class TestProjectSchema(TestProjectBase):
         assert len(migrations) == 0
 
 
-class TestSchemaMigration:
-    @staticmethod
-    def _initialize_v1_project(dirname, with_workspace=True):
-        # Create v1 config file.
-        cfg_fn = os.path.join(dirname, "signac.rc")
-        workspace_dir = "workspace_dir"
-        with open(cfg_fn, "w") as f:
-            f.write(
-                textwrap.dedent(
-                    f"""\
-                    project = project
-                    workspace_dir = {workspace_dir}
-                    schema_version = 0"""
-                )
+def _initialize_v1_project(dirname, with_workspace=True):
+    # Create v1 config file.
+    cfg_fn = os.path.join(dirname, "signac.rc")
+    workspace_dir = "workspace_dir"
+    with open(cfg_fn, "w") as f:
+        f.write(
+            textwrap.dedent(
+                f"""\
+                project = project
+                workspace_dir = {workspace_dir}
+                schema_version = 0"""
             )
+        )
 
-        # Create a custom workspace
-        os.makedirs(os.path.join(dirname, workspace_dir))
-        if with_workspace:
-            os.makedirs(os.path.join(dirname, "workspace"))
+    # Create a custom workspace
+    os.makedirs(os.path.join(dirname, workspace_dir))
+    if with_workspace:
+        os.makedirs(os.path.join(dirname, "workspace"))
 
-        # Create a shell history file.
-        history_fn = os.path.join(dirname, ".signac_shell_history")
-        with open(history_fn, "w") as f:
-            f.write("print(project)")
+    # Create a shell history file.
+    history_fn = os.path.join(dirname, ".signac_shell_history")
+    with open(history_fn, "w") as f:
+        f.write("print(project)")
 
-        # Create a statepoint cache. Note that this cache does not
-        # correspond to actual statepoints since we don't currently have
-        # any in this project, but that's fine for migration testing.
-        sp_cache = os.path.join(dirname, ".signac_sp_cache.json.gz")
-        sp = {"a": 1}
-        with gzip.open(sp_cache, "wb") as f:
-            f.write(json.dumps({calc_id(sp): sp}).encode())
+    # Create a statepoint cache. Note that this cache does not
+    # correspond to actual statepoints since we don't currently have
+    # any in this project, but that's fine for migration testing.
+    sp_cache = os.path.join(dirname, ".signac_sp_cache.json.gz")
+    sp = {"a": 1}
+    with gzip.open(sp_cache, "wb") as f:
+        f.write(json.dumps({calc_id(sp): sp}).encode())
 
-        return cfg_fn
+    return cfg_fn
 
+
+class TestSchemaMigration:
     @pytest.mark.parametrize("implicit_version", [True, False])
     @pytest.mark.parametrize("workspace_exists", [True, False])
     def test_project_schema_version_migration(self, implicit_version, workspace_exists):
         from signac.contrib.migration import apply_migrations
 
         with TemporaryDirectory() as dirname:
-            cfg_fn = self._initialize_v1_project(dirname, workspace_exists)
+            cfg_fn = _initialize_v1_project(dirname, workspace_exists)
 
             # If no schema version is present in the config it is equivalent to
             # version 0, so we test both explicit and implicit versions.
@@ -2402,7 +2402,7 @@ class TestSchemaMigration:
 
     def test_project_init_old_schema(self):
         with TemporaryDirectory() as dirname:
-            self._initialize_v1_project(dirname)
+            _initialize_v1_project(dirname)
 
             # Initializing a project should detect the incompatible schema.
             with pytest.raises(IncompatibleSchemaVersion):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2327,42 +2327,48 @@ class TestProjectSchema(TestProjectBase):
 
 
 class TestSchemaMigration:
+    @staticmethod
+    def _initialize_v1_project(dirname, with_workspace=True):
+        # Create v1 config file.
+        cfg_fn = os.path.join(dirname, "signac.rc")
+        workspace_dir = "workspace_dir"
+        with open(cfg_fn, "w") as f:
+            f.write(
+                textwrap.dedent(
+                    f"""\
+                    project = project
+                    workspace_dir = {workspace_dir}
+                    schema_version = 0"""
+                )
+            )
+
+        # Create a custom workspace
+        os.makedirs(os.path.join(dirname, workspace_dir))
+        if with_workspace:
+            os.makedirs(os.path.join(dirname, "workspace"))
+
+        # Create a shell history file.
+        history_fn = os.path.join(dirname, ".signac_shell_history")
+        with open(history_fn, "w") as f:
+            f.write("print(project)")
+
+        # Create a statepoint cache. Note that this cache does not
+        # correspond to actual statepoints since we don't currently have
+        # any in this project, but that's fine for migration testing.
+        sp_cache = os.path.join(dirname, ".signac_sp_cache.json.gz")
+        sp = {"a": 1}
+        with gzip.open(sp_cache, "wb") as f:
+            f.write(json.dumps({calc_id(sp): sp}).encode())
+
+        return cfg_fn
+
     @pytest.mark.parametrize("implicit_version", [True, False])
     @pytest.mark.parametrize("workspace_exists", [True, False])
     def test_project_schema_version_migration(self, implicit_version, workspace_exists):
         from signac.contrib.migration import apply_migrations
 
         with TemporaryDirectory() as dirname:
-            # Create v1 config file.
-            cfg_fn = os.path.join(dirname, "signac.rc")
-            workspace_dir = "workspace_dir"
-            with open(cfg_fn, "w") as f:
-                f.write(
-                    textwrap.dedent(
-                        f"""\
-                        project = project
-                        workspace_dir = {workspace_dir}
-                        schema_version = 0"""
-                    )
-                )
-
-            # Create a custom workspace
-            os.makedirs(os.path.join(dirname, workspace_dir))
-            if workspace_exists:
-                os.makedirs(os.path.join(dirname, "workspace"))
-
-            # Create a shell history file.
-            history_fn = os.path.join(dirname, ".signac_shell_history")
-            with open(history_fn, "w") as f:
-                f.write("print(project)")
-
-            # Create a statepoint cache. Note that this cache does not
-            # correspond to actual statepoints since we don't currently have
-            # any in this project, but that's fine for migration testing.
-            history_fn = os.path.join(dirname, ".signac_sp_cache.json.gz")
-            sp = {"a": 1}
-            with gzip.open(history_fn, "wb") as f:
-                f.write(json.dumps({calc_id(sp): sp}).encode())
+            cfg_fn = self._initialize_v1_project(dirname, workspace_exists)
 
             # If no schema version is present in the config it is equivalent to
             # version 0, so we test both explicit and implicit versions.
@@ -2393,6 +2399,17 @@ class TestSchemaMigration:
             assert os.path.isfile(project.fn(PROJECT_CONFIG_FN))
             assert os.path.isfile(project.fn(os.sep.join((".signac", "shell_history"))))
             assert os.path.isfile(project.fn(Project.FN_CACHE))
+
+    def test_project_init_old_schema(self):
+        with TemporaryDirectory() as dirname:
+            self._initialize_v1_project(dirname)
+
+            # Initializing a project should detect the incompatible schema.
+            with pytest.raises(IncompatibleSchemaVersion):
+                signac.get_project(dirname)
+
+            with pytest.raises(IncompatibleSchemaVersion):
+                signac.Project(dirname)
 
 
 class TestProjectPickling(TestProjectBase):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -9,6 +9,7 @@ import sys
 from tempfile import TemporaryDirectory
 
 import pytest
+from test_project import _initialize_v1_project
 
 import signac
 from signac.common import config
@@ -810,3 +811,12 @@ class TestBasicShell:
 
         err = self.call("python -m signac update-cache".split(), error=True)
         assert "Cache is up to date" in err
+
+    def test_migrate_v1_to_v2(self):
+        dirname = self.tmpdir.name
+        _initialize_v1_project(dirname, False)
+        self.call("python -m signac migrate --yes".split())
+        assert not os.path.isfile(os.path.join(dirname, "signac.rc"))
+        assert not os.path.isdir(os.path.join(dirname, "workspace_dir"))
+        assert os.path.isdir(os.path.join(dirname, ".signac"))
+        assert os.path.isdir(os.path.join(dirname, "workspace"))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
This PR adds a check in project initialization to ensure that projects with old schemas are detected when signac fails to find a project with the current schema. The resulting check provides the user a meaningful error about how to proceed with updating their schema using our migration code. This PR also exposes a CLI for migration to complement the Python interface, providing a simpler and friendlier approach to one-off migration that is recommended by the error.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Necessary to for projects how to migrate to v2.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
