### PR TITLE
Stop filtering out warnings.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,25 +33,6 @@ source = signac
 omit = 
 	*/signac/common/configobj/*.py
 
-[tool:pytest]
-filterwarnings = 
-	error::FutureWarning:signac.*
-	error::DeprecationWarning:signac.*
-	ignore:Project names are deprecated:FutureWarning
-	ignore:Modifying the project configuration:FutureWarning
-	ignore:.+The indexing module is deprecated:FutureWarning
-	ignore:get_statepoint is deprecated:FutureWarning
-	ignore:Use of .+ as key is deprecated:FutureWarning
-	ignore:SimpleKeyring is deprecated:FutureWarning
-	ignore:The doc_filter argument was deprecated:FutureWarning
-	ignore:next is deprecated:FutureWarning
-	ignore:groupbydoc is deprecated:FutureWarning
-	ignore:The index argument is deprecated:FutureWarning
-	ignore:copytree is deprecated:FutureWarning
-	ignore:dumps is deprecated:FutureWarning
-	ignore:Version is deprecated:FutureWarning
-	ignore:parse_version is deprecated:FutureWarning
-
 [bumpversion:file:setup.py]
 
 [bumpversion:file:signac/version.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,10 @@ source = signac
 omit = 
 	*/signac/common/configobj/*.py
 
+[tool:pytest]
+filterwarnings =
+	error::FutureWarning:signac.*
+	error::DeprecationWarning:signac.*
 [bumpversion:file:setup.py]
 
 [bumpversion:file:signac/version.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,10 @@ omit =
 	*/signac/common/configobj/*.py
 
 [tool:pytest]
-filterwarnings =
+filterwarnings = 
 	error::FutureWarning:signac.*
 	error::DeprecationWarning:signac.*
+
 [bumpversion:file:setup.py]
 
 [bumpversion:file:signac/version.py]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Removes all filters of warnings during pytests.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These were hardcoded at various points during 1.x development due to ongoing deprecations and other related changes that could not be worked around. They are no longer necessary.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
