### PR TITLE
Only try to move v1 schema files that exist.

### DIFF
--- a/signac/contrib/migration/v1_to_v2.py
+++ b/signac/contrib/migration/v1_to_v2.py
@@ -85,6 +85,6 @@ def _migrate_v1_to_v2(root_directory):
         ),
     }
     for src, dst in files_to_move.items():
-        os.replace(
-            os.sep.join((root_directory, src)), os.sep.join((root_directory, dst))
-        )
+        src = os.sep.join((root_directory, src))
+        if os.path.isfile(src):
+            os.replace(src, os.sep.join((root_directory, dst)))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Makes the final `os.replace` calls in the v1->v2 migration conditional on whether the files exist so that the script doesn't try to move nonexistent files.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Not every project will have a shell history or a state point cache.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
