### PR TITLE
Miscellaneous TODO items

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ parallel = True
 source = signac
 omit = 
 	*/signac/common/configobj/*.py
+	*/signac/common/deprecation/*.py
 
 [tool:pytest]
 filterwarnings = 

--- a/signac/__main__.py
+++ b/signac/__main__.py
@@ -107,7 +107,7 @@ def _fmt_bytes(nbytes, suffix="B"):
         if abs(nbytes) < 1024.0:
             return f"{nbytes:3.1f} {unit}{suffix}"
         nbytes /= 1024.0
-    return "{:.1f} {}{}".format(nbytes, "Yi", suffix)
+    return f"{nbytes:.1f} Yi{suffix}"
 
 
 def _open_job_by_id(project, job_id):
@@ -346,10 +346,7 @@ def main_schema(args):
 
 def main_sync(args):
     """Handle sync subcommand."""
-    # TODO: This function appears to be untested.
-    #
     # Validate provided argument combinations
-    #
     if args.archive:
         args.recursive = True
         args.links = True
@@ -388,9 +385,7 @@ def main_sync(args):
 
         filecmp._sig = _sig
 
-    #
     # Setup synchronization process
-    #
 
     source = get_project(path=args.source)
     try:

--- a/tests/test_searchindexer.py
+++ b/tests/test_searchindexer.py
@@ -219,16 +219,16 @@ class TestSearchIndexer:
         assert list(self.c.find({"a": {"$type": "float"}})) == ["float"]
         assert list(self.c.find({"a": {"$type": "int"}})) == ["int"]
 
-    # TODO: Document that dots are not allowed in keys of the document. This is
-    # a condition for correctness but is not enforced.
     def test_docs_with_dots(self):
+        # Dots are not allowed in keys of the document. Here, we explicitly
+        # test to ensure that an error is raised if invalid keys are found.
         self.c["0"] = {"a.b": 0}
 
-        # These searches will not catch the error:
+        # These searches will not trigger an error:
         self.c.find()
         self.c.find({"a": 0})
 
-        # This one will:
+        # This search triggers an error:
         with pytest.raises(InvalidKeyError):
             self.c.find({"a.b": 0})
 


### PR DESCRIPTION
## Description
This PR fixes up a few miscellaneous TODO items.

- Ignore vendored `deprecation` in code coverage measurements.
- Remove TODO about `$ signac sync` being untested. This seems to be tested: https://github.com/glotzerlab/signac/blob/bd6575397f1d35527e02254bd5a8ea002108283d/tests/test_shell.py#L424

- Remove TODO about documenting the "no dots in keys" requirement for `_SearchIndexer`. This is already documented: https://github.com/glotzerlab/signac/blob/bd6575397f1d35527e02254bd5a8ea002108283d/signac/contrib/_searchindexer.py#L232

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
