### PR TITLE
Fix JSONAttrDict docstring

### DIFF
--- a/signac/_synced_collections/backends/collection_json.py
+++ b/signac/_synced_collections/backends/collection_json.py
@@ -538,7 +538,7 @@ right backend so that nested classes are created appropriately.
 class JSONAttrDict(JSONDict, AttrDict):
     r"""A dict-like data structure that synchronizes with a persistent JSON file.
 
-    Unlike :class:`JSONAttrDict`, this class also supports attribute-based access to
+    Unlike :class:`JSONDict`, this class also supports attribute-based access to
     dictionary contents, e.g. ``doc.foo == doc['foo']``.
 
     Examples


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
I think `JSONAttrDict` is supposed to be unlike `JSONDict` in docs. I simply updated the reference.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
