### PR TITLE
Warn if old schema on init_project()

### DIFF
--- a/signac/_config.py
+++ b/signac/_config.py
@@ -44,8 +44,9 @@ def _raise_if_older_schema(root):
         schema_version = _get_config_schema_version(root, int(SCHEMA_VERSION))
         assert schema_version != int(SCHEMA_VERSION), (
             "Migration schema loader succeeded in loading a config file "
-            "where normal loader failed. This indicates an internal "
-            "error, please contact the signac developers."
+            "where normal loader failed. Do you have config files for multiple "
+            "schemas? Otherwise, this indicates an internal "
+            "error. Please contact the signac developers."
         )
         raise IncompatibleSchemaVersion(
             "The signac schema version used by this project is "

--- a/signac/_config.py
+++ b/signac/_config.py
@@ -49,7 +49,7 @@ def _raise_if_older_schema(root):
             "error. Please contact the signac developers."
         )
         raise IncompatibleSchemaVersion(
-            "The signac schema version used by this project is "
+            "Detected signac project using schema version "
             f"{schema_version}, but signac {__version__} requires "
             f"schema version {SCHEMA_VERSION}. Try running python -m "
             "signac migrate."

--- a/signac/_config.py
+++ b/signac/_config.py
@@ -40,10 +40,8 @@ def _raise_if_older_schema(root):
     from .migration import _get_config_schema_version
     from .version import SCHEMA_VERSION, __version__
 
-    schema_version = int(SCHEMA_VERSION)
-
     try:
-        schema_version = _get_config_schema_version(root, schema_version)
+        schema_version = _get_config_schema_version(root, int(SCHEMA_VERSION))
         assert schema_version != int(SCHEMA_VERSION), (
             "Migration schema loader succeeded in loading a config file "
             "where normal loader failed. This indicates an internal "

--- a/signac/project.py
+++ b/signac/project.py
@@ -1508,6 +1508,7 @@ class Project:
         try:
             project = cls.get_project(path=path, search=False)
         except LookupError:
+            _raise_if_older_schema(path)
             fn_config = _get_project_config_fn(path)
             _mkdir_p(os.path.dirname(fn_config))
             config = _read_config_file(fn_config)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2404,6 +2404,9 @@ class TestSchemaMigration:
                 signac.get_project(dirname)
 
             with pytest.raises(IncompatibleSchemaVersion):
+                signac.init_project(dirname)
+
+            with pytest.raises(IncompatibleSchemaVersion):
                 signac.Project(dirname)
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Adds test and fix for detecting an existing project with an old schema version when running `signac.init_project()`.

Tagging @vyasr as the main author of the migration code.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Since `signac.init_project()` is idempotent, lots of existing scripts probably use it. Till now, running `signac.init_project()` in the directory of a project using the old schema would create the new config files in `.signac` but leave the old `signac.rc` file.

While these are not conflicting configurations when run with signac 2.0, many users have different versions in different environments, so not cleaning up the old config files could result in unexpected and hard to debug behavior if an old version loads the old `signac.rc` file.

Thus, we should also detect if an existing old project exists even when initializing a new project and tell users about migrating schema versions. I use the existing code path for that.


## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
