### PR TITLE
Use main.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,9 @@
 ## Checklist:
 <!-- This checklist must be complete before merging the pull request. -->
 <!-- If you are unsure about any of these items, do not hesitate to ask! -->
-- [ ] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
-- [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
-- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
+- [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
+- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
 - [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
-- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
-- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
+- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
+- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -4,10 +4,10 @@ on:
   # trigger on pull requests
   pull_request:
 
-  # trigger on all commits to master
+  # trigger on all commits to main
   push:
     branches:
-      - 'master'
+      - 'main'
 
   # trigger on request
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ All contributors must agree to the Contributor Agreement ([ContributorAgreement.
 ### Guideline for Code Contributions
 
 * Use the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) model of development:
-  - Both new features and bug fixes should be developed in branches based on `master`.
+  - Both new features and bug fixes should be developed in branches based on `main`.
   - Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
-* Write code that is compatible with all supported versions of Python (listed in [pyproject.toml](https://github.com/glotzerlab/signac/blob/master/pyproject.toml)).
+* Write code that is compatible with all supported versions of Python (listed in [pyproject.toml](https://github.com/glotzerlab/signac/blob/main/pyproject.toml)).
 * Avoid introducing dependencies -- especially those that might be harder to install in high-performance computing environments.
 * Create [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [integration tests](https://en.wikipedia.org/wiki/Integration_testing) that cover the common cases and the corner cases of the code.
 * Preserve backwards-compatibility whenever possible, and make clear if something must change.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# <img src="https://raw.githubusercontent.com/glotzerlab/signac/master/doc/images/palette-header.png" width="75" height="58"> signac - simple data management
+# <img src="https://raw.githubusercontent.com/glotzerlab/signac/main/doc/images/palette-header.png" width="75" height="58"> signac - simple data management
 
 [![Affiliated with NumFOCUS](https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/sponsored-projects/affiliated-projects)
 [![PyPI](https://img.shields.io/pypi/v/signac.svg)](https://pypi.org/project/signac/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/signac.svg?style=flat)](https://anaconda.org/conda-forge/signac)
 [![GitHub Actions](https://github.com/glotzerlab/signac/actions/workflows/run-pytest.yml/badge.svg)](https://github.com/glotzerlab/signac/actions)
 [![RTD](https://img.shields.io/readthedocs/signac.svg?style=flat)](https://docs.signac.io)
-[![License](https://img.shields.io/github/license/glotzerlab/signac.svg)](https://github.com/glotzerlab/signac/blob/master/LICENSE.txt)
+[![License](https://img.shields.io/github/license/glotzerlab/signac.svg)](https://github.com/glotzerlab/signac/blob/main/LICENSE.txt)
 [![PyPI-downloads](https://img.shields.io/pypi/dm/signac.svg?style=flat)](https://pypistats.org/packages/signac)
 [![Slack](https://img.shields.io/badge/Slack-chat%20support-brightgreen.svg?style=flat&logo=slack)](https://signac.io/slack-invite/)
 [![Twitter](https://img.shields.io/twitter/follow/signacdata?style=social)](https://twitter.com/signacdata)

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -30,7 +30,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -17,8 +17,8 @@ This project is open-source.
 Users are highly encouraged to contribute directly by implementing new features and fixing issues.
 Development for packages as part of the **signac** framework should follow the general development guidelines outlined `here <https://docs.signac.io/en/latest/community.html#contributions>`__.
 
-A brief summary of contributing guidelines are outlined in the `CONTRIBUTING.md <https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md>`_ file as part of the repository.
-All contributors must agree to the `Contributor Agreement <https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md>`_ before their pull request can be merged.
+A brief summary of contributing guidelines are outlined in the `CONTRIBUTING.md <https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md>`_ file as part of the repository.
+All contributors must agree to the `Contributor Agreement <https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md>`_ before their pull request can be merged.
 
 Set up a development environment
 --------------------------------
@@ -107,7 +107,7 @@ To install the tool, execute:
 The ``asv`` tool will install signac into an isolated virtual environment that is used for benchmarking.
 Below is a quick reference with some helpful commands:
 
-  * ``$ asv run master..mybranch`` benchmarks every commit from ``master`` to ``mybranch``.
+  * ``$ asv run main..mybranch`` benchmarks every commit from ``main`` to ``mybranch``.
   * ``$ asv publish`` generates a static HTML site showing benchmark results.
   * ``$ asv preview`` hosts a local preview of the generated HTML site.
   * ``$ asv dev`` runs benchmarks that are in development.
@@ -140,7 +140,7 @@ Then you can build the documentation from within the ``doc/`` directory as part 
 Updating the changelog
 ----------------------
 
-To update the changelog, add a one-line description to the `changelog.txt <https://github.com/glotzerlab/signac/blob/master/changelog.txt>`_ file within the ``next`` section.
+To update the changelog, add a one-line description to the `changelog.txt <https://github.com/glotzerlab/signac/blob/main/changelog.txt>`_ file within the ``next`` section.
 For example:
 
 .. code-block:: bash


### PR DESCRIPTION
## Description
Renames `master` to `main` in branch references.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
