### PR TITLE
Add more descriptive error if sp and id are not provided

### DIFF
--- a/signac/project.py
+++ b/signac/project.py
@@ -520,7 +520,7 @@ class Project:
             raise ValueError("Must provide statepoint or id.")
         elif statepoint is not None and id is not None:
             raise ValueError("Either statepoint or id must be provided, but not both.")
-        elif id is None:
+        elif statepoint is not None:
             # Second best case (Job will update self._sp_cache on init)
             return Job(project=self, statepoint=statepoint)
         try:

--- a/signac/project.py
+++ b/signac/project.py
@@ -516,9 +516,13 @@ class Project:
             than one match.
 
         """
-        if (statepoint is None) == (id is None):
+        statepoint_none = statepoint is None
+        id_none = id is None
+        if statepoint_none and id_none:
+            raise ValueError("Must provide statepoint or id.")
+        if statepoint_none == id_none:
             raise ValueError("Either statepoint or id must be provided, but not both.")
-        if id is None:
+        if id_none:
             # Second best case (Job will update self._sp_cache on init)
             return Job(project=self, statepoint=statepoint)
         try:

--- a/signac/project.py
+++ b/signac/project.py
@@ -516,13 +516,11 @@ class Project:
             than one match.
 
         """
-        statepoint_none = statepoint is None
-        id_none = id is None
-        if statepoint_none and id_none:
+        if statepoint is None and id is None:
             raise ValueError("Must provide statepoint or id.")
-        if statepoint_none == id_none:
+        elif statepoint is not None and id is not None:
             raise ValueError("Either statepoint or id must be provided, but not both.")
-        if id_none:
+        elif id is None:
             # Second best case (Job will update self._sp_cache on init)
             return Job(project=self, statepoint=statepoint)
         try:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Adds a better error messgae for calling `project.open_job()`.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Before, it would tell you something that implied you provided both statepoint and id: "Either statepoint or id must be provided, but not both."

I was working on something for dashboard and this more descriptive message would have saved me a little time.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
