### PR TITLE
Remove inaccurate guidance about doc filters being removed in 3.0.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -147,7 +147,7 @@ Changed
 Deprecated
 ++++++++++
 
- - ``doc_filter`` arguments, which are replaced by namespaced filters. Due to their long history, ``doc_filter`` arguments will still be accepted in signac 2.0 and will only be removed in 3.0 (#516).
+ - ``doc_filter`` arguments, which are replaced by namespaced filters.
  - The modules ``signac.core.attrdict``, ``signac.core.json``, ``signac.core.jsondict``, and ``signac.core.synceddict.py`` are deprecated in favor of the new ``SyncedCollection`` classes and will be removed in signac 2.0 (#483).
 
 Fixed


### PR DESCRIPTION
## Description
Removes inaccurate guidance about doc filters being removed in 3.0. Doc filters were removed in 2.0 instead.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
