### PR TITLE
Remove numcodecs from docs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,5 +303,4 @@ intersphinx_mapping = {
     ),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "h5py": ("https://docs.h5py.org/en/stable/", None),
-    "numcodecs": ("https://numcodecs.readthedocs.io/en/stable/", None),
 }


### PR DESCRIPTION
## Description
Removed an unnecessary intersphinx reference that I missed in #924. No changelog needed.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
