### PR TITLE
ci: No longer test latest packages on Python 3.8

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -21,8 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        config: [ {python: '3.8', dependencies: 'newest'},
-                  {python: '3.9', dependencies: 'newest'},
+        config: [ {python: '3.9', dependencies: 'newest'},
                   {python: '3.10', dependencies: 'newest'},
                   {python: '3.11', dependencies: 'newest'},
                   {python: '3.11', dependencies: 'minimal'},


### PR DESCRIPTION
## Description
Oldest tests still remains on Python 3.8. NumPy no longer supports Python3.8 in their latest packages.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
