### PR TITLE
Add Python 3.12 and limit MacOS/Window's tests.

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -16,6 +16,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
+    name: test (${{ matrix.os }}, ${{ matrix.python }}, ${{ matrix.dependencies }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        default: 'true'
+        # unused key to force creation of new entries in the matrix
+        unused: 'true'
         include:
           # Defaults to newest dependencies
           - dependencies: 'newest'
@@ -47,7 +48,7 @@ jobs:
             python: '3.12'
             dependencies: 'newest'
           # Minimal dependencies tests
-          - default: 'false'
+          - unused: 'false'
             python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -36,6 +36,9 @@ jobs:
             python: '3.8'
             dependencies: 'oldest'
           # Newest version tests for non-Linux OS
+          - os: 'ubuntu-latest'
+            python: '3.12'
+            dependencies: 'newest'
           - os: 'macos-latest'
             python: '3.12'
             dependencies: 'newest'
@@ -43,8 +46,7 @@ jobs:
             python: '3.12'
             dependencies: 'newest'
           # Minimal dependencies tests
-          - os: 'ubuntu-latest'
-            python: '3.12'
+          - python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'
             python: '3.12'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -47,7 +47,7 @@ jobs:
             python: '3.12'
             dependencies: 'newest'
           # Minimal dependencies tests
-          - default: 'false' 
+          - default: 'false'
             python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        default: 'true'
         include:
           # Defaults to newest dependencies
           - dependencies: 'newest'
@@ -46,7 +47,8 @@ jobs:
             python: '3.12'
             dependencies: 'newest'
           # Minimal dependencies tests
-          - python: '3.12'
+          - default: 'false' 
+            python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'
             python: '3.12'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        # unused key to force creation of new entries in the matrix
-        unused: 'true'
+        # Unused key to force creation of new entries in the matrix
+        default: ['true']
         include:
           # Defaults to newest dependencies
           - dependencies: 'newest'
@@ -48,7 +48,7 @@ jobs:
             python: '3.12'
             dependencies: 'newest'
           # Minimal dependencies tests
-          - unused: 'false'
+          - default: 'false'
             python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -56,16 +56,16 @@ jobs:
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.config.python }}
+        python-version: ${{ matrix.python }}
     - name: Install newest dependencies
       run: |
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-test-optional.txt
-      if: ${{ matrix.config.dependencies == 'newest' }}
+      if: ${{ matrix.dependencies == 'newest' }}
     - name: Install minimal dependencies
       run: |
         pip install -r requirements/requirements-test.txt
-      if: ${{ matrix.config.dependencies == 'minimal' }}
+      if: ${{ matrix.dependencies == 'minimal' }}
     - name: Install oldest supported dependencies
       # To prevent Dependabot from updating the pinnings in this "oldest"
       # dependency list, we have to avoid the word "requirements" in the
@@ -73,7 +73,7 @@ jobs:
       # instead of "requirements."
       run: |
         pip install -r .github/workflows/ci-oldest-reqs.txt
-      if: ${{ matrix.config.dependencies == 'oldest' }}
+      if: ${{ matrix.dependencies == 'oldest' }}
     - name: Install the package
       run: |
         pip install -e .

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -20,12 +20,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        config: [ {python: '3.9', dependencies: 'newest'},
-                  {python: '3.10', dependencies: 'newest'},
-                  {python: '3.11', dependencies: 'newest'},
-                  {python: '3.11', dependencies: 'minimal'},
-                  {python: '3.8', dependencies: 'oldest'} ]
+        os: [ubuntu-latest]
+        python: ['3.9', '3.10', '3.11', '3.12']
+        include:
+          # Defaults to newest dependencies
+          - dependencies: 'newest'
+          # Oldest dependency tests
+          - python: '3.8'
+            dependencies: 'oldest'
+          - os: 'macos-latest'
+            python: '3.8'
+            dependencies: 'oldest'
+          - os: 'windows-latest'
+            python: '3.8'
+            dependencies: 'oldest'
+          # Newest version tests for non-Linux OS
+          - os: 'macos-latest'
+            python: '3.12'
+            dependencies: 'newest'
+          - os: 'windows-latest'
+            python: '3.12'
+            dependencies: 'newest'
+          # Minimal dependencies tests
+          - os: 'ubuntu-latest'
+            python: '3.12'
+            dependencies: 'minimal'
+          - os: 'macos-latest'
+            python: '3.12'
+            dependencies: 'minimal'
+          - os: 'windows-latest'
+            python: '3.12'
+            dependencies: 'minimal'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.config.python }}

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -49,6 +49,7 @@ jobs:
             dependencies: 'newest'
           # Minimal dependencies tests
           - default: 'false'
+            os: 'ubuntu-latest'
             python: '3.12'
             dependencies: 'minimal'
           - os: 'macos-latest'

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           # Defaults to newest dependencies
           - dependencies: 'newest'
@@ -53,7 +53,7 @@ jobs:
             dependencies: 'minimal'
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.config.python }}
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config.python }}

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,11 @@ Version 2
 [2.2.0] -- 2023-xx-xx
 ---------------------
 
+Added
++++++
+
+ - Official support for Python 3.12 (#957).
+
 Changed
 +++++++
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Added
 Changed
 +++++++
 
+ - Restrict allowable tar file features in Python 3.12 (#957).
  - linked views now can contain spaces and other characters except directory separators (#926).
 
 [2.1.0] -- 2023-07-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ follow_imports = 'skip'
 
 [tool.pytest.ini_options]
 xfail_strict = true
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,8 @@ follow_imports = 'skip'
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:datetime"
+    "ignore::DeprecationWarning",
+    "error::DeprecationWarning:signac"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ follow_imports = 'skip'
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:datetime.datetime"
+    "ignore::DeprecationWarning:datetime"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ follow_imports = 'skip'
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:pandas.*",
+    "ignore::DeprecationWarning:dateutil.*",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,6 @@ follow_imports = 'skip'
 
 [tool.pytest.ini_options]
 xfail_strict = true
-filterwarnings = [
-    "error",
-    "ignore::DeprecationWarning",
-    "error::DeprecationWarning:signac"
-]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ follow_imports = 'skip'
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:datetime.*",
+    "ignore::DeprecationWarning:pandas.*",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ follow_imports = 'skip'
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning",
+    "ignore::DeprecationWarning:datetime.*",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,10 @@ follow_imports = 'skip'
 
 [tool.pytest.ini_options]
 xfail_strict = true
-filterwarnings = "error"
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning:datetime.datetime"
+]
 
 [tool.coverage.run]
 branch = true

--- a/requirements/requirements-test-optional.txt
+++ b/requirements/requirements-test-optional.txt
@@ -1,5 +1,5 @@
 h5py==3.10.0; implementation_name=='cpython'
 numpy==1.26.1
-pandas==2.1.2; implementation_name=='cpython'
+pandas==2.1.3; implementation_name=='cpython'
 ruamel.yaml==0.18.3
 tables==3.9.1; implementation_name=='cpython'

--- a/signac/import_export.py
+++ b/signac/import_export.py
@@ -1145,7 +1145,7 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
             "The jobs identified with the given schema function are not unique!"
         )
 
-    if sys.version_info[2] >= 12:
+    if sys.version_info[1] >= 12:  # minor version
         # the data filter should support all needed operations for users using signac's import
         # feature. Other filters assume Unix specific features.
         tarfile.extractall(path=tmpdir, filter="data")

--- a/signac/import_export.py
+++ b/signac/import_export.py
@@ -1145,7 +1145,7 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
             "The jobs identified with the given schema function are not unique!"
         )
 
-    if sys.version_info[1] >= 12:  # minor version
+    if sys.version_info[:2] >= (3, 12):
         # the data filter should support all needed operations for users using signac's import
         # feature. Other filters assume Unix specific features.
         tarfile.extractall(path=tmpdir, filter="data")

--- a/signac/import_export.py
+++ b/signac/import_export.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tarfile
 import zipfile
 from collections import Counter
@@ -1144,7 +1145,12 @@ def _analyze_tarfile_for_import(tarfile, project, schema, tmpdir):
             "The jobs identified with the given schema function are not unique!"
         )
 
-    tarfile.extractall(path=tmpdir)
+    if sys.version_info[2] >= 12:
+        # the data filter should support all needed operations for users using signac's import
+        # feature. Other filters assume Unix specific features.
+        tarfile.extractall(path=tmpdir, filter="data")
+    else:
+        tarfile.extractall(path=tmpdir)
     for path, job in mappings.items():
         if not os.path.isdir(tmpdir):
             raise RuntimeError(f"The provided tmpdir {tmpdir} is not a directory.")


### PR DESCRIPTION
## Description
Add Python 3.12 to CI testing and reduce non-Ubuntu runners to just oldest, minimal, and newest tests.

## Motivation and Context
- Add newest Python version to testing.
- Reduce organization runners required for limited non-Linux OSes.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
