### PR TITLE
Re-order active maintainers.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,14 +36,14 @@ authors:
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0001-7739-7796"
   -
-    family-names: Dodd
-    given-names: "Paul M."
-    affiliation: "University of Michigan"
-  -
     family-names: Kerr
     given-names: "Corwin B."
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0003-0776-2596"
+  -
+    family-names: Dodd
+    given-names: "Paul M."
+    affiliation: "University of Michigan"
   -
     family-names: Glotzer
     given-names: "Sharon C."


### PR DESCRIPTION
Small follow-up to #968. I re-ordered this so that active project maintainers are listed together. cc: @cbkerr for awareness.