### PR TITLE
Fix parsing of $not expression on command line

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,14 +36,14 @@ authors:
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0001-7739-7796"
   -
-    family-names: Dodd
-    given-names: "Paul M."
-    affiliation: "University of Michigan"
-  -
     family-names: Kerr
     given-names: "Corwin B."
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0003-0776-2596"
+  -
+    family-names: Dodd
+    given-names: "Paul M."
+    affiliation: "University of Michigan"
   -
     family-names: Glotzer
     given-names: "Sharon C."

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,11 @@ Changed
  - linked views now can contain spaces and other characters except directory separators (#926).
  - linked views now can be created on Windows, if 'Developer mode' is enabled (#430).
 
+Fixed
++++++
+
+ - Fixed parsing of ``$not`` query expressions on command line (#970).
+
 [2.1.0] -- 2023-07-12
 ---------------------
 

--- a/signac/filterparse.py
+++ b/signac/filterparse.py
@@ -195,6 +195,8 @@ def parse_filter_arg(args):
 
 def _add_prefix(filter):
     """Add prefix "sp." to a (possibly nested) filter."""
+
+    # Logical operators ($and, $or, $not) should not be prefixed, but their values should.
     for key, value in filter.items():
         if key in ("$and", "$or"):
             if isinstance(value, list) or isinstance(value, tuple):

--- a/signac/filterparse.py
+++ b/signac/filterparse.py
@@ -195,7 +195,6 @@ def parse_filter_arg(args):
 
 def _add_prefix(filter):
     """Add prefix "sp." to a (possibly nested) filter."""
-
     # Logical operators ($and, $or, $not) should not be prefixed, but their values should.
     for key, value in filter.items():
         if key in ("$and", "$or"):

--- a/signac/filterparse.py
+++ b/signac/filterparse.py
@@ -203,6 +203,8 @@ def _add_prefix(filter):
                 raise ValueError(
                     "The argument to a logical operator must be a list or a tuple!"
                 )
+        elif key == "$not":
+            yield key, dict(_add_prefix(value))
         elif "." in key and key.split(".", 1)[0] in ("sp", "doc"):
             yield key, value
         elif key in ("sp", "doc"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 def testdata():
     return str(uuid.uuid4())
 
+
 @pytest.fixture
 def find_filter():
     return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,33 @@ import pytest
 @pytest.fixture
 def testdata():
     return str(uuid.uuid4())
+
+@pytest.fixture
+def find_filter():
+    return [
+        {"a": 0},
+        {"a.b": 0},
+        {"a.b": {"$lt": 42}},
+        {"a.b.$lt": 42},
+        {"$or": [{"a.b": 41}, {"a.b.$lt": 42}]},
+        {"$or": [{"a.b": 42}, {"a.b.$lt": 42}]},
+        {"$and": [{"a.b": 42}, {"a.b.$lt": 42}]},
+        {"$and": [{"a.b": 0}, {"a.b.$lt": 42}]},
+        {"$and": [{"a.b.$gte": 0}, {"a.b.$lt": 42}]},
+        {"$not": {"a.b": 0}},
+        {"$and": [{"a.b.$gte": 0}, {"$not": {"a.b.$lt": 42}}]},
+        {"$not": {"$not": {"a.b": 0}}},
+        {"a.b": {"$in": [0, 1]}},
+        {"a.b": {"$nin": [0, 1]}},
+        {"$not": {"a.b": {"$in": [0, 1]}}},
+        {"a.b": {"$exists": True}},
+        {"a.b": {"$exists": False}},
+        {"a": {"$exists": True}},
+        {"a": {"$exists": False}},
+        {"c": {"$regex": r"^\d$"}},
+        {"c": {"$type": "str"}},
+        {"d": {"$type": "list"}},
+        {"a.b": {"$where": "lambda x: x < 10"}},
+        {"a.b": {"$where": "lambda x: isinstance(x, int)"}},
+        {"a": {"$regex": "[a][b][c]"}},
+    ]

--- a/tests/test_find_command_line_interface.py
+++ b/tests/test_find_command_line_interface.py
@@ -11,35 +11,6 @@ import pytest
 
 from signac.filterparse import parse_filter_arg, parse_simple
 
-# also used in test_shell
-FILTERS = [
-    {"a": 0},
-    {"a.b": 0},
-    {"a.b": {"$lt": 42}},
-    {"a.b.$lt": 42},
-    {"$or": [{"a.b": 41}, {"a.b.$lt": 42}]},
-    {"$or": [{"a.b": 42}, {"a.b.$lt": 42}]},
-    {"$and": [{"a.b": 42}, {"a.b.$lt": 42}]},
-    {"$and": [{"a.b": 0}, {"a.b.$lt": 42}]},
-    {"$and": [{"a.b.$gte": 0}, {"a.b.$lt": 42}]},
-    {"$not": {"a.b": 0}},
-    {"$and": [{"a.b.$gte": 0}, {"$not": {"a.b.$lt": 42}}]},
-    {"$not": {"$not": {"a.b": 0}}},
-    {"a.b": {"$in": [0, 1]}},
-    {"a.b": {"$nin": [0, 1]}},
-    {"$not": {"a.b": {"$in": [0, 1]}}},
-    {"a.b": {"$exists": True}},
-    {"a.b": {"$exists": False}},
-    {"a": {"$exists": True}},
-    {"a": {"$exists": False}},
-    {"c": {"$regex": r"^\d$"}},
-    {"c": {"$type": "str"}},
-    {"d": {"$type": "list"}},
-    {"a.b": {"$where": "lambda x: x < 10"}},
-    {"a.b": {"$where": "lambda x: isinstance(x, int)"}},
-    {"a": {"$regex": "[a][b][c]"}},
-]
-
 
 VALUES = {"1": 1, "1.0": 1.0, "abc": "abc", "true": True, "false": False, "null": None}
 
@@ -68,23 +39,25 @@ class TestFindCommandLineInterface:
     def _parse(args):
         with redirect_stderr(StringIO()):
             return parse_filter_arg(args)
-
-    def test_interpret_json(self):
+        
+    @pytest.mark.usefixtures("find_filter")
+    def test_interpret_json(self, find_filter):
         def _assert_equal(q):
             # TODO: full code path not tested with this test.
             # _assert_equal and _find_expression, are not tested
             assert q == self._parse([json.dumps(q)])
 
-        for f in FILTERS:
+        for f in find_filter:
             _assert_equal(f)
 
-    def test_interpret_simple(self):
+    @pytest.mark.usefixtures("find_filter")
+    def test_interpret_simple(self, find_filter):
         assert self._parse(["a"]) == {"a": {"$exists": True}}
         assert next(parse_simple(["a"])) == ("a", {"$exists": True})
 
         for s, v in VALUES.items():
             assert self._parse(["a", s]) == {"a": v}
-        for f in FILTERS:
+        for f in find_filter:
             f_ = f.copy()
             key, value = f.popitem()
             if key.startswith("$"):

--- a/tests/test_find_command_line_interface.py
+++ b/tests/test_find_command_line_interface.py
@@ -11,6 +11,7 @@ import pytest
 
 from signac.filterparse import parse_filter_arg, parse_simple
 
+# also used in test_shell
 FILTERS = [
     {"a": 0},
     {"a.b": 0},
@@ -70,6 +71,8 @@ class TestFindCommandLineInterface:
 
     def test_interpret_json(self):
         def _assert_equal(q):
+            # TODO: full code path not tested with this test.
+            # _assert_equal and _find_expression, are not tested
             assert q == self._parse([json.dumps(q)])
 
         for f in FILTERS:

--- a/tests/test_find_command_line_interface.py
+++ b/tests/test_find_command_line_interface.py
@@ -11,7 +11,6 @@ import pytest
 
 from signac.filterparse import parse_filter_arg, parse_simple
 
-
 VALUES = {"1": 1, "1.0": 1.0, "abc": "abc", "true": True, "false": False, "null": None}
 
 ARITHMETIC_EXPRESSIONS = [
@@ -39,7 +38,7 @@ class TestFindCommandLineInterface:
     def _parse(args):
         with redirect_stderr(StringIO()):
             return parse_filter_arg(args)
-        
+
     @pytest.mark.usefixtures("find_filter")
     def test_interpret_json(self, find_filter):
         def _assert_equal(q):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -9,6 +9,7 @@ import sys
 from tempfile import TemporaryDirectory
 
 import pytest
+from test_find_command_line_interface import FILTERS
 from test_project import WINDOWS, _initialize_v1_project, skip_windows_without_symlinks
 
 import signac
@@ -282,7 +283,6 @@ class TestBasicShell:
 
         # ensure that there are no errors due to adding sp and doc prefixes
         # by testing on all the example complex expressions
-        from test_find_command_line_interface import FILTERS
         for f in FILTERS:
             command = "python -m signac find ".split() + [json.dumps(f)]
             self.call(command).strip()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -9,7 +9,6 @@ import sys
 from tempfile import TemporaryDirectory
 
 import pytest
-from test_find_command_line_interface import FILTERS
 from test_project import WINDOWS, _initialize_v1_project, skip_windows_without_symlinks
 
 import signac
@@ -218,7 +217,8 @@ class TestBasicShell:
         )
         assert "duplicate paths" in err
 
-    def test_find(self):
+    @pytest.mark.usefixtures("find_filter")
+    def test_find(self, find_filter):
         self.call("python -m signac init".split())
         project = signac.Project()
         sps = [{"a": i} for i in range(3)]
@@ -283,7 +283,7 @@ class TestBasicShell:
 
         # ensure that there are no errors due to adding sp and doc prefixes
         # by testing on all the example complex expressions
-        for f in FILTERS:
+        for f in find_filter:
             command = "python -m signac find ".split() + [json.dumps(f)]
             self.call(command).strip()
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -280,6 +280,14 @@ class TestBasicShell:
                 == [job.id for job in project.find_jobs({"doc.b": i})][0]
             )
 
+        # ensure that there are no errors due to adding sp and doc prefixes
+        # by testing on all the example complex expressions
+        from test_find_command_line_interface import FILTERS
+        for f in FILTERS:
+            command = "python -m signac find ".split() + [json.dumps(f)]
+            self.call(command).strip()
+
+
     def test_diff(self):
         self.call("python -m signac init".split())
         project = signac.Project()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

- fixes bug
- adds test to `test_shell.py`
- I do not fix the testing code in `test_find_command_line_interface.py` that does not properly test the code path but I left a todo for now.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The `$not` expression was broken on the command line. I noticed this while working on https://github.com/glotzerlab/signac-docs/pull/199

signac was inserting `sp.` prefixes before the operator

```bash
$ signac find '{"$not": {"a": 1}}'
Error: "Invalid operator placement 'sp.$not.a'."
```

The function `filterparse._add_prefix` does the inserting, which later triggered an error in `_search_indexer._find_expression`. This code path wasn't tested.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
