### PR TITLE
Support `__getitem__` with `JobsCursor` objects

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -142,4 +142,9 @@ contributors:
     family-names: Anderson
     given-names: "Joshua A."
     affiliation: "University of Michigan"
+  -
+    family-names: Bradley
+    given-names: Jenna
+    affiliation: "University of Michigan"
+    orcid: "https://orcid.org/0009-0007-2443-2982"
 ...

--- a/signac/project.py
+++ b/signac/project.py
@@ -1810,6 +1810,26 @@ class JobsCursor:
         # Code duplication here for improved performance.
         return _JobsCursorIterator(self._project, self._ids)
 
+    def __getitem__(self, index):
+        """Get an item or slice of items from the `self._ids` list.
+
+        Parameters
+        ----------
+        index : int | slice
+            The jobs to get.
+
+        Returns
+        -------
+        :class:`~signac.job.Job` | :class:`~signac.project._JobsCursorIterator`
+            Single job or iterator of a slice of jobs.
+        """
+        ids_to_return = self._ids[index]
+
+        if isinstance(ids_to_return, list):
+            return _JobsCursorIterator(self._project, ids_to_return)
+
+        return Job(project=self._project, id_=ids_to_return, directory_known=True)
+
     def groupby(self, key=None, default=None):
         """Group jobs according to one or more state point or document parameters.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,7 +36,7 @@ from signac.errors import (
     StatepointParsingError,
     WorkspaceError,
 )
-from signac.job import calc_id
+from signac.job import Job, calc_id
 from signac.linked_view import _find_all_links
 from signac.project import JobsCursor, Project  # noqa: F401
 from signac.schema import ProjectSchema
@@ -615,6 +615,27 @@ class TestProject(TestProjectBase):
         assert job not in cursor
         job.init()
         assert job in cursor
+
+    def test_JobsCursor_getitem(self):
+        statepoints = [{"a": i, "b": i < 3} for i in range(5)]
+        for sp in statepoints:
+            self.project.open_job(sp).init()
+        cursor = self.project.find_jobs()
+        # Test single indexing
+        for i, job in enumerate(cursor):
+            assert job == cursor[i]
+            assert isinstance(cursor[i], Job)
+
+        # Test slice indexing
+        for start in range(0, len(cursor)):
+            for end in range(start, len(cursor)):
+                subset = cursor[slice(start, end)]
+
+                if start == end:
+                    assert len([*subset]) == 0
+
+                for i, job in enumerate(subset):
+                    assert job == cursor[start + i]
 
     def test_job_move(self):
         path = self._tmp_dir.name


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
Implemented `__getitem__` for JobsCursors, allow for indexing and slicing after calling `project.find_jobs()`

## Motivation and Context
`JobsCursors` are iterable through the `_JobsCursorIterator` API, but slicing and indexing was not supported. This is atypical for Python types and requires users to unpack the cursor to index it.

This implementation returns a single `Job` if an integer index is requested, or a `_JobsCursorIterator` if a slice is requested. New tests have been added to cover the new functionality.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
