### PR TITLE
Fix pyproject.toml tools -> tool.

### DIFF
--- a/signac/project.py
+++ b/signac/project.py
@@ -1810,6 +1810,26 @@ class JobsCursor:
         # Code duplication here for improved performance.
         return _JobsCursorIterator(self._project, self._ids)
 
+    def __getitem__(self, index):
+        """Get an item or slice of items from the `self._ids` list.
+
+        Parameters
+        ----------
+        index : int | slice
+            The jobs to get.
+
+        Returns
+        -------
+        :class:`~signac.job.Job` | :class:`~signac.project._JobsCursorIterator`
+            Single job or iterator of a slice of jobs.
+        """
+        ids_to_return = self._ids[index]
+
+        if isinstance(ids_to_return, list):
+            return _JobsCursorIterator(self._project, ids_to_return)
+
+        return Job(project=self._project, id_=ids_to_return, directory_known=True)
+
     def groupby(self, key=None, default=None):
         """Group jobs according to one or more state point or document parameters.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,7 +36,7 @@ from signac.errors import (
     StatepointParsingError,
     WorkspaceError,
 )
-from signac.job import calc_id
+from signac.job import Job, calc_id
 from signac.linked_view import _find_all_links
 from signac.project import JobsCursor, Project  # noqa: F401
 from signac.schema import ProjectSchema
@@ -615,6 +615,27 @@ class TestProject(TestProjectBase):
         assert job not in cursor
         job.init()
         assert job in cursor
+
+    def test_JobsCursor_getitem(self):
+        statepoints = [{"a": i, "b": i < 3} for i in range(5)]
+        for sp in statepoints:
+            self.project.open_job(sp).init()
+        cursor = self.project.find_jobs()
+        # Test single indexing
+        for i, job in enumerate(cursor):
+            assert job == cursor[i]
+            assert isinstance(cursor[i], Job)
+
+        # Test slice indexing
+        for start in range(0, len(cursor)):
+            for end in range(start, len(cursor)):
+                subset = cursor[slice(start, end)]
+
+                if start == end:
+                    assert len([*subset]) == 0
+
+                for i, job in enumerate(subset):
+                    assert job == cursor[start + i]
 
     def test_job_move(self):
         path = self._tmp_dir.name


### PR DESCRIPTION
## Description
There is a typo in `pyproject.toml`. It should be `[tool.setuptools...]` instead of `[tools.setuptools...]`.

A warning is issued when building (observed with Python 3.12 and pip 25.0):

```
/tmp/build-env-vzednt84/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py:72: _ToolsTypoInMetadata: Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?
```

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
