### PR TITLE
Define build command in asv.conf.json to enable support for asv 0.6.2 and later

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -21,12 +21,11 @@
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
     //
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
+    // "install_command": ["in-dir={env_dir} python -m pip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -m pip uninstall -y {project}"],
+    "build_command": [
+        "python -m pip wheel --no-deps --no-build-isolation --no-index -w {build_cache_dir} {build_dir}"
+    ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,8 @@ Fixed
 
  - Support for Numpy 2.0 in tests (#997).
  - Use ``tool.setuptools`` key in ``pyproject.toml`` (#1020).
+ - Define build command in ``asv.conf.json`` to enable support for asv 0.6.2 and
+ later (#1021).
 
 [2.2.0] -- 2024-02-13
 ---------------------


### PR DESCRIPTION
## Description
`asv` 0.6.2 and later changed the default build command, breaking our benchmarks.

This PR defines a `build_command` that appears to work, which is closer to the pre-0.6.2 behavior of `asv`.

## Motivation and Context
See https://github.com/glotzerlab/signac/pull/1017#issuecomment-2634745588 and https://github.com/airspeed-velocity/asv/issues/1453#issuecomment-2645978145.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
