### PR TITLE
Speed up schema by avoiding redundant iteration through jobs

### DIFF
--- a/signac/schema.py
+++ b/signac/schema.py
@@ -47,11 +47,14 @@ def _build_job_statepoint_index(exclude_const, index):
 
     """
     indexes = {}
+    dotted_keys = set()
     for _id in index.find():
         doc = index[_id]
         for key, _ in _nested_dicts_to_dotted_keys(doc):
-            if key.split(".")[0] == "sp":
-                indexes[key] = index.build_index(key)
+            dotted_keys.add(key)
+    for key in dotted_keys:
+        if key.split(".")[0] == "sp":
+            indexes[key] = index.build_index(key)
 
     for key in sorted(indexes, key=lambda key: (len(indexes[key]), key)):
         if (


### PR DESCRIPTION


As a benefit, using the cache now makes a noticeable difference, taking a project with 17,400 jobs from 9.4 s to 2.5 s to detect the schema.

(Before this change, I gave up benchmarking after several hours running)

<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Find all state point keys first, then iterate through jobs. This takes the speed from O(N**2) to O(N) in number of jobs.

Tested with existing unit tests.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Schema was extremely slow for large projects, which made signac dashboard's Navigator module unusable.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
