### PR TITLE
Remove reference to signac.io

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,5 @@
 - [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
 - [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
 - [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
-- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
+- [ ] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://signac.readthedocs.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
 - [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.


### PR DESCRIPTION
## Description
This updates the PR template to use the ReadTheDocs URL for the documentation.

## Motivation and Context
The signac.io web domain is no longer active.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
